### PR TITLE
feat(pg): Recognise unique multi-key relations

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -115,16 +115,12 @@ export default (function PgBackwardRelationPlugin(
         if (foreignKeys.some(key => omit(key, "read"))) {
           return memo;
         }
-        const singleKey = keys.length === 1 ? keys[0] : null;
-        const isUnique = !!(
-          singleKey &&
-          introspectionResultsByKind.constraint.find(
-            c =>
-              c.classId === singleKey.classId &&
-              c.keyAttributeNums.length === 1 &&
-              c.keyAttributeNums[0] === singleKey.num &&
-              (c.type === "p" || c.type === "u")
-          )
+        const isUnique = !!introspectionResultsByKind.constraint.find(
+          c =>
+            c.classId === table.id &&
+            (c.type === "p" || c.type === "u") &&
+            c.keyAttributeNums.length === keys.length &&
+            c.keyAttributeNums.every((n, i) => keys[i].num === n)
         );
 
         const isDeprecated = isUnique && legacyRelationMode === DEPRECATED;

--- a/packages/postgraphile-core/__tests__/fixtures/queries/unique-foreign-keys.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/unique-foreign-keys.graphql
@@ -1,0 +1,20 @@
+{
+  allCompoundKeys {
+    nodes {
+      personId1
+      personId2
+      uniqueForeignKeyByCompoundKey1AndCompoundKey2 {
+        compoundKey1
+        compoundKey2
+        compoundKeyByCompoundKey1AndCompoundKey2 {
+          personId1
+          personId2
+          uniqueForeignKeyByCompoundKey1AndCompoundKey2 {
+            compoundKey1
+            compoundKey2
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -7004,6 +7004,80 @@ Object {
 }
 `;
 
+exports[`unique-foreign-keys.graphql 1`] = `
+Object {
+  "data": Object {
+    "allCompoundKeys": Object {
+      "nodes": Array [
+        Object {
+          "personId1": 1,
+          "personId2": 2,
+          "uniqueForeignKeyByCompoundKey1AndCompoundKey2": null,
+        },
+        Object {
+          "personId1": 2,
+          "personId2": 1,
+          "uniqueForeignKeyByCompoundKey1AndCompoundKey2": Object {
+            "compoundKey1": 2,
+            "compoundKey2": 1,
+            "compoundKeyByCompoundKey1AndCompoundKey2": Object {
+              "personId1": 2,
+              "personId2": 1,
+              "uniqueForeignKeyByCompoundKey1AndCompoundKey2": Object {
+                "compoundKey1": 2,
+                "compoundKey2": 1,
+              },
+            },
+          },
+        },
+        Object {
+          "personId1": 2,
+          "personId2": 3,
+          "uniqueForeignKeyByCompoundKey1AndCompoundKey2": null,
+        },
+        Object {
+          "personId1": 2,
+          "personId2": 5,
+          "uniqueForeignKeyByCompoundKey1AndCompoundKey2": Object {
+            "compoundKey1": 2,
+            "compoundKey2": 5,
+            "compoundKeyByCompoundKey1AndCompoundKey2": Object {
+              "personId1": 2,
+              "personId2": 5,
+              "uniqueForeignKeyByCompoundKey1AndCompoundKey2": Object {
+                "compoundKey1": 2,
+                "compoundKey2": 5,
+              },
+            },
+          },
+        },
+        Object {
+          "personId1": 4,
+          "personId2": 3,
+          "uniqueForeignKeyByCompoundKey1AndCompoundKey2": null,
+        },
+        Object {
+          "personId1": 4,
+          "personId2": 4,
+          "uniqueForeignKeyByCompoundKey1AndCompoundKey2": Object {
+            "compoundKey1": 4,
+            "compoundKey2": 4,
+            "compoundKeyByCompoundKey1AndCompoundKey2": Object {
+              "personId1": 4,
+              "personId2": 4,
+              "uniqueForeignKeyByCompoundKey1AndCompoundKey2": Object {
+                "compoundKey1": 4,
+                "compoundKey2": 4,
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`view.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -419,6 +419,11 @@ type CompoundKey implements Node {
   personId1: Int!
   personId2: Int!
 
+  \\"\\"\\"
+  Reads a single \`UniqueForeignKey\` that is related to this \`CompoundKey\`.
+  \\"\\"\\"
+  uniqueForeignKeyByCompoundKey1AndCompoundKey2: UniqueForeignKey
+
   \\"\\"\\"Reads and enables pagination through a set of \`UniqueForeignKey\`.\\"\\"\\"
   uniqueForeignKeysByCompoundKey1AndCompoundKey2(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -438,7 +443,7 @@ type CompoundKey implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): UniqueForeignKeysConnection!
+  ): UniqueForeignKeysConnection! @deprecated(reason: \\"Please use uniqueForeignKeyByCompoundKey1AndCompoundKey2 instead\\")
 }
 
 \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -418,6 +418,27 @@ type CompoundKey implements Node {
   personByPersonId2: Person
   personId1: Int!
   personId2: Int!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`UniqueForeignKey\`.\\"\\"\\"
+  uniqueForeignKeysByCompoundKey1AndCompoundKey2(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): UniqueForeignKeysConnection!
 }
 
 \\"\\"\\"
@@ -6357,6 +6378,7 @@ type Query implements Node {
   ): Type
   typeById(id: Int!): Type
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+  uniqueForeignKeyByCompoundKey1AndCompoundKey2(compoundKey1: Int!, compoundKey2: Int!): UniqueForeignKey
 
   \\"\\"\\"Reads a single \`ViewTable\` using its globally unique \`ID\`.\\"\\"\\"
   viewTable(
@@ -7284,6 +7306,44 @@ enum TypesOrderBy {
   TIMETZ_DESC
   VARCHAR_ASC
   VARCHAR_DESC
+}
+
+type UniqueForeignKey {
+  compoundKey1: Int
+  compoundKey2: Int
+
+  \\"\\"\\"
+  Reads a single \`CompoundKey\` that is related to this \`UniqueForeignKey\`.
+  \\"\\"\\"
+  compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
+}
+
+\\"\\"\\"A connection to a list of \`UniqueForeignKey\` values.\\"\\"\\"
+type UniqueForeignKeysConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`UniqueForeignKey\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [UniqueForeignKeysEdge!]!
+
+  \\"\\"\\"A list of \`UniqueForeignKey\` objects.\\"\\"\\"
+  nodes: [UniqueForeignKey]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`UniqueForeignKey\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`UniqueForeignKey\` edge in the connection.\\"\\"\\"
+type UniqueForeignKeysEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`UniqueForeignKey\` at the end of the edge.\\"\\"\\"
+  node: UniqueForeignKey
 }
 
 \\"\\"\\"YOYOYO!!\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pgColumnFilter.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pgColumnFilter.test.js.snap
@@ -3055,6 +3055,7 @@ type Query implements Node {
     \\"\\"\\"
     offset: Int
   ): StaticBigIntegerConnection!
+  uniqueForeignKeyByCompoundKey1AndCompoundKey2(compoundKey1: Int!, compoundKey2: Int!): UniqueForeignKey
 
   \\"\\"\\"Reads a single \`ViewTable\` using its globally unique \`ID\`.\\"\\"\\"
   viewTable(
@@ -3575,6 +3576,11 @@ enum TestviewsOrderBy {
   NATURAL
   TESTVIEWID_ASC
   TESTVIEWID_DESC
+}
+
+type UniqueForeignKey {
+  compoundKey1: Int
+  compoundKey2: Int
 }
 
 \\"\\"\\"All input for the \`updateDefaultValueById\` mutation.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -1734,6 +1734,11 @@ type CompoundKey implements Node {
   personId1: Int!
   personId2: Int!
 
+  \\"\\"\\"
+  Reads a single \`UniqueForeignKey\` that is related to this \`CompoundKey\`.
+  \\"\\"\\"
+  uniqueForeignKeyByCompoundKey1AndCompoundKey2: UniqueForeignKey
+
   \\"\\"\\"Reads and enables pagination through a set of \`UniqueForeignKey\`.\\"\\"\\"
   uniqueForeignKeysByCompoundKey1AndCompoundKey2(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -1753,7 +1758,7 @@ type CompoundKey implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): UniqueForeignKeysConnection!
+  ): UniqueForeignKeysConnection! @deprecated(reason: \\"Please use uniqueForeignKeyByCompoundKey1AndCompoundKey2 instead\\")
 }
 
 \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -1733,6 +1733,27 @@ type CompoundKey implements Node {
   personByPersonId2: Person
   personId1: Int!
   personId2: Int!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`UniqueForeignKey\`.\\"\\"\\"
+  uniqueForeignKeysByCompoundKey1AndCompoundKey2(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+  ): UniqueForeignKeysConnection!
 }
 
 \\"\\"\\"
@@ -7672,6 +7693,7 @@ type Query implements Node {
   ): Type
   typeById(id: Int!): Type
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+  uniqueForeignKeyByCompoundKey1AndCompoundKey2(compoundKey1: Int!, compoundKey2: Int!): UniqueForeignKey
 
   \\"\\"\\"Reads a single \`ViewTable\` using its globally unique \`ID\`.\\"\\"\\"
   viewTable(
@@ -8599,6 +8621,44 @@ enum TypesOrderBy {
   TIMETZ_DESC
   VARCHAR_ASC
   VARCHAR_DESC
+}
+
+type UniqueForeignKey {
+  compoundKey1: Int
+  compoundKey2: Int
+
+  \\"\\"\\"
+  Reads a single \`CompoundKey\` that is related to this \`UniqueForeignKey\`.
+  \\"\\"\\"
+  compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
+}
+
+\\"\\"\\"A connection to a list of \`UniqueForeignKey\` values.\\"\\"\\"
+type UniqueForeignKeysConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`UniqueForeignKey\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [UniqueForeignKeysEdge!]!
+
+  \\"\\"\\"A list of \`UniqueForeignKey\` objects.\\"\\"\\"
+  nodes: [UniqueForeignKey]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`UniqueForeignKey\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`UniqueForeignKey\` edge in the connection.\\"\\"\\"
+type UniqueForeignKeysEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`UniqueForeignKey\` at the end of the edge.\\"\\"\\"
+  node: UniqueForeignKey
 }
 
 \\"\\"\\"YOYOYO!!\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -55,6 +55,11 @@ insert into a.foreign_key (person_id, compound_key_1, compound_key_2) values
   (null, 4, 4),
   (null, 2, 1);
 
+insert into a.unique_foreign_key (compound_key_1, compound_key_2) values
+  (2, 1),
+  (4, 4),
+  (2, 5);
+
 insert into b.types values (
   12,
   50,

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -181,6 +181,19 @@ create table a.foreign_key (
 alter table a.foreign_key add constraint second_fkey
   foreign key (compound_key_1, compound_key_2) references c.compound_key(person_id_1, person_id_2) on delete cascade;
 
+create table a.unique_foreign_key (
+  compound_key_1 int,
+  compound_key_2 int,
+  foreign key (compound_key_1, compound_key_2) references c.compound_key(person_id_1, person_id_2) on delete cascade,
+  unique(compound_key_1, compound_key_2)
+);
+
+alter table a.unique_foreign_key add constraint second_fkey
+  foreign key (compound_key_1, compound_key_2) references c.compound_key(person_id_1, person_id_2) on delete cascade;
+
+-- We're just testing the relations work as expected, we don't need everything else.
+comment on table a.unique_foreign_key is E'@omit create,update,delete,all,order,filter';
+
 create table c.edge_case (
   not_null_has_default boolean not null default false,
   wont_cast_easy smallint,


### PR DESCRIPTION
We already recognise unique single-key relations and use a single relation (rather than a connection) for these. This PR extends that to multi-key relations that are unique (caveat: the unique constraint and the foreign key constraint must specify the columns in the same order).

This is not a breaking change (unless you have multi-key unique relations and use `--legacy-relations omit`, in which case I'm sure I would have heard about this earlier) because the old connection is still generated, it's just marked as deprecated.

Thanks to @charlescrain for bringing this to my attention on Gitter:

https://gitter.im/graphile/postgraphile?at=5b99af58d655361f76ef76ca