### PR TITLE
fix: Improve error message for invalid pg configurations

### DIFF
--- a/packages/graphile-build-pg/src/withPgClient.js
+++ b/packages/graphile-build-pg/src/withPgClient.js
@@ -1,6 +1,7 @@
 // @flow
 import pg from "pg";
 import debugFactory from "debug";
+
 const debug = debugFactory("graphile-build-pg");
 
 function constructorName(obj) {
@@ -72,7 +73,9 @@ const withPgClient = async (
         pgClient.connect(err => (err ? reject(err) : resolve()))
       );
     } else {
-      throw new Error("You must provide a valid PG client configuration");
+      throw new Error(
+        "You must provide either a pg.Pool or pg.Client instance or a PostgreSQL connection string."
+      );
     }
     result = await fn(pgClient);
   } finally {


### PR DESCRIPTION
As seen in the [docs](https://node-postgres.com/api/client), `pg` also accepts an object as the configuration:

```js
type pgConfigObject = {
  user?: string, // default process.env.PGUSER || process.env.USER
  password?: string, //default process.env.PGPASSWORD
  database?: string, // default process.env.PGDATABASE || process.env.USER
  port?: number, // default process.env.PGPORT
  connectionString?: string, // e.g. postgres://user:password@host:5432/database
  ssl?: any, // passed directly to node.TLSSocket
  types?: any, // custom type parsers
  statement_timeout?: number, // number of milliseconds before a query will time out default is no timeout
}
```

All the fields are entirely optional, would be filled with the env variables if available:

> Every field of the config object is entirely optional. A Client instance will use environment variables for all missing values.

This PR adds the option to pass in an object as the `pgConfig`.

(`ssl` and `types` are commented due to `no-weak-types` rule. The `ssl` config for example is quite complex and most likely not very relevant).

Not very familar of `graphile-engine` yet so let me know if there's any changes necessary. 

edit: Weird, build failed. It passed on my branch though https://travis-ci.com/petetnt/graphile-engine
