### PR TITLE
fix(sql): queryFromResolveData call withBuilder before resolveData.pgQuery

### DIFF
--- a/packages/graphile-build-pg/src/queryFromResolveData.js
+++ b/packages/graphile-build-pg/src/queryFromResolveData.js
@@ -42,11 +42,11 @@ export default (
   const queryBuilder = new QueryBuilder();
   queryBuilder.from(from, fromAlias ? fromAlias : undefined);
 
-  for (const fn of pgQuery || []) {
-    fn(queryBuilder, resolveData);
-  }
   if (withBuilder) {
     withBuilder(queryBuilder);
+  }
+  for (const fn of pgQuery || []) {
+    fn(queryBuilder, resolveData);
   }
 
   function generateNextPrevPageSql(

--- a/packages/graphile-utils/src/index.ts
+++ b/packages/graphile-utils/src/index.ts
@@ -1,5 +1,12 @@
 import { embed, gql } from "./gql";
 import makeAddInflectorsPlugin from "./makeAddInflectorsPlugin";
 import makeExtendSchemaPlugin from "./makeExtendSchemaPlugin";
+import makePluginByCombiningPlugins from "./makePluginByCombiningPlugins";
 
-export { embed, gql, makeAddInflectorsPlugin, makeExtendSchemaPlugin };
+export {
+  embed,
+  gql,
+  makeAddInflectorsPlugin,
+  makeExtendSchemaPlugin,
+  makePluginByCombiningPlugins,
+};

--- a/packages/graphile-utils/src/makePluginByCombiningPlugins.ts
+++ b/packages/graphile-utils/src/makePluginByCombiningPlugins.ts
@@ -1,0 +1,11 @@
+import { Plugin } from "graphile-build";
+
+export default function makePluginByCombiningPlugins(
+  ...plugins: Array<Plugin>
+): Plugin {
+  return async (builder, options) => {
+    for (const plugin of plugins) {
+      await plugin(builder, options);
+    }
+  };
+}


### PR DESCRIPTION
`withBuilder` is used to set up some context, e.g. `innerQueryBuilder.parentQueryBuilder = queryBuilder`; but if you don't do this before calling the callbacks in `resolveData.pgQuery` then there's little point doing it.