### PR TITLE
feat(debug): enhance SQL debugging

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -1,9 +1,7 @@
 // @flow
-import debugFactory from "debug";
 
 import type { Plugin } from "graphile-build";
-
-const debugSql = debugFactory("graphile-build-pg:sql");
+import debugSql from "./debugSql";
 
 export default (async function PgAllRows(
   builder,

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -1,7 +1,6 @@
 // @flow
 import type { Plugin } from "graphile-build";
-import debugFactory from "debug";
-const debugSql = debugFactory("graphile-build-pg:sql");
+import debugSql from "./debugSql";
 
 export default (async function PgRowByUniqueConstraint(builder) {
   builder.hook("GraphQLObjectType:fields", (fields, build, context) => {

--- a/packages/graphile-build-pg/src/plugins/PgRowNode.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowNode.js
@@ -1,9 +1,8 @@
 // @flow
 import type { Plugin } from "graphile-build";
-import debugFactory from "debug";
+import debugSql from "./debugSql";
 
 const base64Decode = str => Buffer.from(String(str), "base64").toString("utf8");
-const debugSql = debugFactory("graphile-build-pg:sql");
 
 export default (async function PgRowNode(builder) {
   builder.hook("GraphQLObjectType", (object, build, context) => {

--- a/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgScalarFunctionConnectionPlugin.js
@@ -1,5 +1,6 @@
 // @flow
 import type { Plugin } from "graphile-build";
+
 const base64 = str => Buffer.from(String(str)).toString("base64");
 
 export default (function PgScalarFunctionConnectionPlugin(

--- a/packages/graphile-build-pg/src/plugins/debugSql.js
+++ b/packages/graphile-build-pg/src/plugins/debugSql.js
@@ -1,0 +1,74 @@
+import debugFactory from "debug";
+import chalk from "chalk";
+
+const rawDebugSql = debugFactory("graphile-build-pg:sql");
+
+function debugSql(sql) {
+  if (!rawDebugSql.enabled) {
+    return;
+  }
+  let colourIndex = 0;
+  let allowedColours = [
+    chalk.red,
+    chalk.green,
+    chalk.yellow,
+    chalk.blue,
+    chalk.magenta,
+    chalk.cyan,
+    chalk.white,
+    chalk.black,
+  ];
+  function nextColor() {
+    colourIndex = (colourIndex + 1) % allowedColours.length;
+    return allowedColours[colourIndex];
+  }
+  const colours = {};
+
+  /* Yep - that's `colour` from English and `ize` from American */
+  function colourize(str) {
+    if (!colours[str]) {
+      colours[str] = nextColor();
+    }
+    return colours[str].bold.call(null, str);
+  }
+
+  let indentLevel = 0;
+  function handleIndent(all, rawMatch) {
+    const match = rawMatch.replace(/ $/, "");
+    if (match === "(") {
+      indentLevel++;
+      return match + "\n" + "  ".repeat(indentLevel);
+    } else if (match === ")") {
+      indentLevel--;
+      return "\n" + "  ".repeat(indentLevel) + match;
+    } else if (match === "),") {
+      indentLevel--;
+      return (
+        "\n" +
+        "  ".repeat(indentLevel) +
+        match +
+        "\n" +
+        "  ".repeat(indentLevel)
+      );
+    } else if (match === ",") {
+      return match + "\n" + "  ".repeat(indentLevel);
+    } else {
+      return "\n" + "  ".repeat(indentLevel) + match.replace(/^\s+/, "");
+    }
+  }
+  const tidySql = sql
+    .replace(/\s+/g, " ")
+    .replace(/\s+(?=$|\n|\))/g, "")
+    .replace(/(\n|^|\()\s+/g, "$1")
+    .replace(
+      /(\(|\)|\), ?|, ?| (select|insert|update|delete|from|where|and|or|order|limit)(?= ))/g,
+      handleIndent
+    )
+    .replace(/\(\s*([A-Za-z0-9_."' =]{1,50})\s*\)/g, "($1)")
+    .replace(/\n\s*and \(TRUE\)/g, chalk.gray(" and (TRUE)"));
+  const colouredSql = tidySql.replace(/__local_[0-9]+__/g, colourize);
+  rawDebugSql("%s", "\n" + colouredSql);
+}
+Object.assign(debugSql, rawDebugSql);
+
+export default debugSql;

--- a/packages/graphile-build-pg/src/plugins/debugSql.js
+++ b/packages/graphile-build-pg/src/plugins/debugSql.js
@@ -65,6 +65,7 @@ function debugSql(sql) {
       handleIndent
     )
     .replace(/\(\s*([A-Za-z0-9_."' =]{1,50})\s*\)/g, "($1)")
+    .replace(/\(\s*(\([A-Za-z0-9_."' =]{1,50}\))\s*\)/g, "($1)")
     .replace(/\n\s*and \(TRUE\)/g, chalk.gray(" and (TRUE)"));
   const colouredSql = tidySql.replace(/__local_[0-9]+__/g, colourize);
   rawDebugSql("%s", "\n" + colouredSql);

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -1,11 +1,10 @@
 // @flow
-import debugFactory from "debug";
 
 import type { Build, FieldWithHooksFunction } from "graphile-build";
 import type { PgProc } from "./PgIntrospectionPlugin";
 import type { SQL } from "pg-sql2";
+import debugSql from "./debugSql";
 
-const debugSql = debugFactory("graphile-build-pg:sql");
 const firstValue = obj => {
   let firstKey;
   for (const k in obj) {

--- a/packages/graphile-build-pg/src/plugins/viaTemporaryTable.js
+++ b/packages/graphile-build-pg/src/plugins/viaTemporaryTable.js
@@ -1,11 +1,9 @@
 // @flow
 
 import * as sql from "pg-sql2";
-import debugFactory from "debug";
 import type { Client } from "pg";
 import type { SQL, SQLQuery } from "pg-sql2";
-
-const debugSql = debugFactory("graphile-build-pg:sql");
+import debugSql from "./debugSql";
 
 /*
  * Originally we tried this with a CTE, but:


### PR DESCRIPTION
When using `DEBUG="graphile-build-pg:sql"`, SQL will now be output formatted, with the the various `__local_#__` entries colour coded. We also no-longer prepend `graphile-build-pg:sql` to every line in the SQL statement. This makes debugging a lot easier!

Before:

![screenshot 2018-10-15 14 50 05](https://user-images.githubusercontent.com/129910/46954921-a01aad80-d089-11e8-8d5a-eadf63f419de.png)


After:

![screenshot 2018-10-15 14 54 19](https://user-images.githubusercontent.com/129910/46955224-57afbf80-d08a-11e8-9ce6-04c979b8327f.png)


<details>
<summary>GraphQL Query</summary>

```graphql
query {
  allPeople(first: 3, offset: 1) {
    nodes {
      nodeId
      id
      name
      email
      createdAt
      postsByAuthorId(orderBy:PRIMARY_KEY_DESC, first:1) {
        nodes {
          nodeId
          id
          headline
          body
          author: personByAuthorId {
            nodeId
            id
            name
          }
        }
      }
    }
  }
}
```
</details>
