### PR TITLE
fix(deps): add chalk as explicit dependency of graphile-build

### DIFF
--- a/packages/graphile-build/package.json
+++ b/packages/graphile-build/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://graphile.org/graphile-build/",
   "dependencies": {
     "@types/graphql": "^0.13.4",
+    "chalk": "^2.1.0",
     "debug": ">=2 <3",
     "graphql-parse-resolve-info": "4.0.0",
     "lodash": ">=4 <5",


### PR DESCRIPTION
Fixes #321 