### PR TITLE
refactor: more startup performance improvements

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -238,22 +238,19 @@ export default (async function PgIntrospectionPlugin(
             pgIncludeExtensionResources,
           ]);
 
-          const result = rows.reduce(
-            (memo, { object }) => {
-              memo[object.kind].push(object);
-              return memo;
-            },
-            {
-              namespace: [],
-              class: [],
-              attribute: [],
-              type: [],
-              constraint: [],
-              procedure: [],
-              extension: [],
-              index: [],
-            }
-          );
+          const result = {
+            namespace: [],
+            class: [],
+            attribute: [],
+            type: [],
+            constraint: [],
+            procedure: [],
+            extension: [],
+            index: [],
+          };
+          for (const { object } of rows) {
+            result[object.kind].push(object);
+          }
 
           // Parse tags from comments
           [
@@ -289,7 +286,7 @@ export default (async function PgIntrospectionPlugin(
           });
 
           for (const k in result) {
-            result[k].map(Object.freeze);
+            result[k].forEach(Object.freeze);
           }
           return Object.freeze(result);
         })

--- a/packages/graphile-build/src/extend.js
+++ b/packages/graphile-build/src/extend.js
@@ -1,8 +1,8 @@
 // @flow
 import chalk from "chalk";
 
-const aExtendedB = new WeakMap();
 const INDENT = "  ";
+const $$hints = Symbol("hints");
 
 export function indent(text: string) {
   return (
@@ -15,24 +15,16 @@ export default function extend<Obj1: *, Obj2: *>(
   extra: Obj2,
   hint?: string
 ): Obj1 & Obj2 {
-  const keysA = Object.keys(base);
-  const keysB = Object.keys(extra);
-  const hints = Object.create(null);
-  for (const key of keysA) {
-    const hintKey = `_source__${key}`;
-    if (base[hintKey]) {
-      hints[hintKey] = base[hintKey];
-    }
-  }
+  const hints = base[$$hints] || {};
 
+  const keysB = Object.keys(extra);
+  const extraHints = extra[$$hints] || {};
   for (const key of keysB) {
     const newValue = extra[key];
-    const oldValue = base[key];
-    const hintKey = `_source__${key}`;
-    const hintB = extra[hintKey] || hint;
-    if (aExtendedB.get(newValue) !== oldValue && keysA.indexOf(key) >= 0) {
+    const hintB = extraHints[key] || hint;
+    if (key in base && base[key] !== newValue) {
       // $FlowFixMe
-      const hintA: ?string = base[hintKey];
+      const hintA: ?string = hints[key];
       const firstEntityDetails = !hintA
         ? "We don't have any information about the first entity."
         : `The first entity was:\n\n${indent(chalk.magenta(hintA))}`;
@@ -45,19 +37,11 @@ export default function extend<Obj1: *, Obj2: *>(
         )}'.\n\n${indent(firstEntityDetails)}\n\n${indent(secondEntityDetails)}`
       );
     }
-    hints[hintKey] = hints[hintKey] || hintB || base[hintKey];
-  }
-  const obj = Object.assign({}, base, extra);
-  aExtendedB.set(obj, base);
-  for (const hintKey in hints) {
-    if (hints[hintKey]) {
-      Object.defineProperty(obj, hintKey, {
-        configurable: false,
-        enumerable: false,
-        value: hints[hintKey],
-        writable: false,
-      });
+    if (hintB) {
+      hints[key] = hintB;
     }
   }
-  return obj;
+  return Object.assign(base, extra, {
+    [$$hints]: hints,
+  });
 }

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -562,7 +562,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
                   },
                   scope: extend(
                     extend(
-                      scope,
+                      { ...scope },
                       {
                         fieldName,
                       },
@@ -667,7 +667,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
                   Self,
                   scope: extend(
                     extend(
-                      scope,
+                      { ...scope },
                       {
                         fieldName,
                       },


### PR DESCRIPTION
Two changes:

- One trivial reduce -> for loop in PgIntrospectionPlugin
- One MAJOR CHANGE: `extend` now lives up to its name, and actually extends the object rather than creating a new one.

The latter of these is the big change since it reduces the load on the Garbage Collector during startup / watch.