### PR TITLE
Add a fallback value for server_version_num in Redshift

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -227,20 +227,21 @@ export default (async function PgIntrospectionPlugin(
           let serverVersionNum;
           let versionResult;
           try {
-            versionResult = await pgClient.query(
-              "show server_version_num;"
-            );
+            versionResult = await pgClient.query("show server_version_num;");
             serverVersionNum = parseInt(
               versionResult.rows[0].server_version_num,
               10
             );
           } catch (error) {
             // If Redshift, `show server_version_num` will not be available
-            versionResult = await pgClient.query(
-              "select version();"
-            );
+            versionResult = await pgClient.query("select version();");
             serverVersionNum = parseInt(
-              versionResult.split(" ")[1].split(".").map(s => s.padStart(2, "0")).join("").padEnd(6, "0"),
+              versionResult
+                .split(" ")[1]
+                .split(".")
+                .map(s => s.padStart(2, "0"))
+                .join("")
+                .padEnd(6, "0"),
               10
             );
           }

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -236,7 +236,7 @@ export default (async function PgIntrospectionPlugin(
           } catch (error) {
             // If Redshift, `show server_version_num` will not be available
             // Fall back to version 90600
-            console.warn(`⚠️ WARNING ⚠️ Failed to check server_version_num, returned error: ${error}, falling back to 90600.`); // eslint-disable-line no-console
+            console.warn(`⚠️ WARNING ⚠️ Failed to check server_version_num, falling back to 90600.`); // eslint-disable-line no-console
             serverVersionNum = 90600;
           }
           const introspectionQuery = makeIntrospectionQuery(serverVersionNum, {

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -223,20 +223,21 @@ export default (async function PgIntrospectionPlugin(
     };
     const introspectionResultsByKind = cloneResults(
       await persistentMemoizeWithKey(cacheKey, () =>
-        withPgClient(pgConfig, async pgClient => {          
+        withPgClient(pgConfig, async pgClient => {
+          let serverVersionNum;
           try {
             const versionResult = await pgClient.query(
               "show server_version_num;"
             );
-            const serverVersionNum = parseInt(
+            serverVersionNum = parseInt(
               versionResult.rows[0].server_version_num,
               10
             );
           } catch (error) {
             // If Redshift, `show server_version_num` will not be available
             // Fall back to version 90600
-            console.warn(`⚠️ WARNING ⚠️ Failed to check server_version_num, returned error: ${error}, falling back to 90600.`); 
-            const serverVersionNum = 90600;
+            console.warn(`⚠️ WARNING ⚠️ Failed to check server_version_num, returned error: ${error}, falling back to 90600.`); // eslint-disable-line no-console
+            serverVersionNum = 90600;
           }
           const introspectionQuery = makeIntrospectionQuery(serverVersionNum, {
             pgLegacyFunctionsOnly,

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -236,7 +236,7 @@ export default (async function PgIntrospectionPlugin(
           } catch (error) {
             // If Redshift, `show server_version_num` will not be available
             // Fall back to version 90600
-            console.warn(`⚠️ WARNING ⚠️ Failed to check server_version_num, falling back to 90600.`); // eslint-disable-line no-console
+            console.warn('⚠️ WARNING ⚠️ Failed to check server_version_num, falling back to 90600.'); // eslint-disable-line no-console
             serverVersionNum = 90600;
           }
           const introspectionQuery = makeIntrospectionQuery(serverVersionNum, {


### PR DESCRIPTION
Related to https://github.com/graphile/postgraphile/issues/913

Redshift doesn't seem to allow getting server_version_num via the `show server_version_num` query, so here I add a fallback value as suggested in the issue above.
What would be a good way to test it? I'm not really familiar with Lerna, and not super familiar with code structure in Typescript projects. I 