### PR TITLE
chore: cleanup function deprecation and nullsFirst features

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.d.ts
+++ b/packages/graphile-build-pg/src/QueryBuilder.d.ts
@@ -25,7 +25,7 @@ export default class QueryBuilder {
   public where(exprGen: SQLGen): void;
   public whereBound(exprGen: SQLGen, isLower: boolean): void;
   public setOrderIsUnique(): void;
-  public orderBy(exprGen: SQLGen, ascending: boolean, nullsFirst: boolean): void;
+  public orderBy(exprGen: SQLGen, ascending: boolean, nullsFirst: boolean | null): void;
   public limit(limitGen: NumberGen): void;
   public offset(offsetGen: NumberGen): void;
   public first(first: number): void;
@@ -45,7 +45,7 @@ export default class QueryBuilder {
   };
   public getFinalOffset(): number;
   public getFinalLimit(): number;
-  public getOrderByExpressionsAndDirections(): Array<[SQL, boolean, boolean]>;
+  public getOrderByExpressionsAndDirections(): Array<[SQL, boolean, boolean | null]>;
   public getSelectFieldsCount(): number;
   public buildSelectFields(): SQL;
   public buildSelectJson({ addNullCase }: { addNullCase?: boolean }): SQL;

--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -66,7 +66,7 @@ class QueryBuilder {
       lower: Array<SQLGen>,
       upper: Array<SQLGen>,
     },
-    orderBy: Array<[SQLGen, boolean, boolean]>,
+    orderBy: Array<[SQLGen, boolean, boolean | null]>,
     orderIsUnique: boolean,
     limit: ?NumberGen,
     offset: ?NumberGen,
@@ -88,7 +88,7 @@ class QueryBuilder {
       lower: Array<SQL>,
       upper: Array<SQL>,
     },
-    orderBy: Array<[SQL, boolean, boolean]>,
+    orderBy: Array<[SQL, boolean, boolean | null]>,
     orderIsUnique: boolean,
     limit: ?number,
     offset: ?number,
@@ -236,7 +236,11 @@ class QueryBuilder {
   setOrderIsUnique() {
     this.data.orderIsUnique = true;
   }
-  orderBy(exprGen: SQLGen, ascending: boolean = true, nullsFirst: boolean) {
+  orderBy(
+    exprGen: SQLGen,
+    ascending: boolean = true,
+    nullsFirst: boolean | null
+  ) {
     this.checkLock("orderBy");
     this.data.orderBy.push([exprGen, ascending, nullsFirst]);
   }

--- a/packages/graphile-build-pg/src/plugins/PgColumnDeprecationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnDeprecationPlugin.js
@@ -13,10 +13,11 @@ export default (function PgColumnDeprecationPlugin(builder) {
     ) {
       return field;
     }
-    return Object.assign({}, field, {
+    return {
+      ...field,
       deprecationReason: Array.isArray(pgFieldIntrospection.tags.deprecated)
         ? pgFieldIntrospection.tags.deprecated.join("\n")
         : pgFieldIntrospection.tags.deprecated,
-    });
+    };
   });
 }: Plugin);

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -1077,13 +1077,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -2064,7 +2064,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3653,7 +3653,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Creates a single \`Post\`.\\"\\"\\"
   createPost(
@@ -3893,7 +3893,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
   deletePersonSecretByPersonId(
@@ -3901,7 +3901,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`Post\` using its globally unique id.\\"\\"\\"
   deletePost(
@@ -4251,7 +4251,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: PostWithSuffixInput!
-  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated (comment on function a.post_with_suffix).\\")
   returnVoidMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -4443,7 +4443,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
   updatePersonSecretByPersonId(
@@ -4451,7 +4451,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretByPersonIdInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`Post\` using its globally unique id and a patch.\\"\\"\\"
   updatePost(
@@ -5590,7 +5590,7 @@ type Person implements Node {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -5689,7 +5689,7 @@ type Person implements Node {
   nodeId: ID!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -5718,7 +5718,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -6546,7 +6546,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   allPosts(
@@ -6857,7 +6857,7 @@ type Query implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -7124,7 +7124,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     nodeId: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"Reads a single \`Post\` using its globally unique \`ID\`.\\"\\"\\"
@@ -8895,7 +8895,7 @@ type UpdatePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
@@ -2631,7 +2631,7 @@ type Person implements Node {
   createdAt: Datetime
   email: Email!
 
-  \\"\\"\\"@deprecated This is deprecated.\\"\\"\\"
+  \\"\\"\\"@deprecated This is deprecated (comment on function c.person_exists).\\"\\"\\"
   exists(email: Email): Boolean
   firstName: String
   firstPost: Post
@@ -2786,7 +2786,7 @@ input PersonPatch {
 }
 
 \\"\\"\\"
-@deprecated This is deprecated.
+@deprecated This is deprecated (comment on table c.person_secret).
 Tracks the person's secret
 \\"\\"\\"
 type PersonSecret implements Node {
@@ -3093,7 +3093,9 @@ type Query implements Node {
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonSecretsConnection
 
-  \\"\\"\\"@deprecated This is deprecated.\\"\\"\\"
+  \\"\\"\\"
+  @deprecated This is deprecated (comment on function c.badly_behaved_function).
+  \\"\\"\\"
   badlyBehavedFunction(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
     after: Cursor

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
@@ -1077,13 +1077,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -2064,7 +2064,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3653,7 +3653,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Creates a single \`Post\`.\\"\\"\\"
   createPost(
@@ -3893,7 +3893,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
   deletePersonSecretByPersonId(
@@ -3901,7 +3901,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`Post\` using its globally unique id.\\"\\"\\"
   deletePost(
@@ -4251,7 +4251,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: PostWithSuffixInput!
-  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated (comment on function a.post_with_suffix).\\")
   returnVoidMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -4443,7 +4443,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
   updatePersonSecretByPersonId(
@@ -4451,7 +4451,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretByPersonIdInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`Post\` using its globally unique id and a patch.\\"\\"\\"
   updatePost(
@@ -5590,7 +5590,7 @@ type Person implements Node {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -5689,7 +5689,7 @@ type Person implements Node {
   nodeId: ID!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -5718,7 +5718,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -6546,7 +6546,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   allPosts(
@@ -6857,7 +6857,7 @@ type Query implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -7124,7 +7124,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     nodeId: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"Reads a single \`Post\` using its globally unique \`ID\`.\\"\\"\\"
@@ -8895,7 +8895,7 @@ type UpdatePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
@@ -1026,13 +1026,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -2005,7 +2005,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3531,7 +3531,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Creates a single \`Post\`.\\"\\"\\"
   createPost(
@@ -3771,7 +3771,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
   deletePersonSecretByPersonId(
@@ -3779,7 +3779,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`Post\` using its globally unique id.\\"\\"\\"
   deletePost(
@@ -4129,7 +4129,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: PostWithSuffixInput!
-  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated (comment on function a.post_with_suffix).\\")
   returnVoidMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -4321,7 +4321,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
   updatePersonSecretByPersonId(
@@ -4329,7 +4329,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretByPersonIdInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`Post\` using its globally unique id and a patch.\\"\\"\\"
   updatePost(
@@ -5404,7 +5404,7 @@ type Person implements Node {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -5474,7 +5474,7 @@ type Person implements Node {
   nodeId: ID!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -5503,7 +5503,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -6270,7 +6270,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   allPosts(
@@ -6571,7 +6571,7 @@ type Query implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -6838,7 +6838,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     nodeId: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"Reads a single \`Post\` using its globally unique \`ID\`.\\"\\"\\"
@@ -8377,7 +8377,7 @@ type UpdatePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyFunctionsOnly.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyFunctionsOnly.test.js.snap
@@ -409,13 +409,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -749,7 +749,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1372,7 +1372,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`CompoundKey\` using its globally unique id.\\"\\"\\"
   deleteCompoundKey(
@@ -1476,7 +1476,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
   deletePersonSecretByPersonId(
@@ -1484,7 +1484,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   intSetMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -1668,7 +1668,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
   updatePersonSecretByPersonId(
@@ -1676,7 +1676,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretByPersonIdInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 }
 
 type MyTable implements Node {
@@ -1918,7 +1918,7 @@ type Person implements Node {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -1988,7 +1988,7 @@ type Person implements Node {
   nodeId: ID!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -2017,7 +2017,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
 
@@ -2383,7 +2383,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   badlyBehavedFunction(
@@ -2404,7 +2404,7 @@ type Query implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -2509,7 +2509,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     nodeId: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"
@@ -3011,7 +3011,7 @@ type UpdatePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
@@ -2631,7 +2631,7 @@ type Person implements Node {
   createdAt: Datetime
   email: Email!
 
-  \\"\\"\\"@deprecated This is deprecated.\\"\\"\\"
+  \\"\\"\\"@deprecated This is deprecated (comment on function c.person_exists).\\"\\"\\"
   exists(email: Email): Boolean
   firstName: String
   firstPost: Post
@@ -2838,7 +2838,7 @@ input PersonPatch {
 }
 
 \\"\\"\\"
-@deprecated This is deprecated.
+@deprecated This is deprecated (comment on table c.person_secret).
 Tracks the person's secret
 \\"\\"\\"
 type PersonSecret implements Node {
@@ -3145,7 +3145,9 @@ type Query implements Node {
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonSecretsConnection
 
-  \\"\\"\\"@deprecated This is deprecated.\\"\\"\\"
+  \\"\\"\\"
+  @deprecated This is deprecated (comment on function c.badly_behaved_function).
+  \\"\\"\\"
   badlyBehavedFunction(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
     after: Cursor

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
@@ -1699,7 +1699,7 @@ type Person implements Node {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -1769,7 +1769,7 @@ type Person implements Node {
   nodeId: ID!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -1798,7 +1798,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
 
@@ -2135,7 +2135,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   badlyBehavedFunction(
@@ -2156,7 +2156,7 @@ type Query implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -2392,7 +2392,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     nodeId: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pgColumnFilter.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pgColumnFilter.test.js.snap
@@ -1803,7 +1803,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: PostWithSuffixInput!
-  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated (comment on function a.post_with_suffix).\\")
   returnVoidMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -115,13 +115,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -302,7 +302,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -474,7 +474,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`LeftArm\` using its globally unique id.\\"\\"\\"
   deleteLeftArm(
@@ -530,7 +530,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
   deletePersonSecretByPersonId(
@@ -538,7 +538,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   leftArmIdentity(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -724,7 +724,7 @@ type Person implements Node {
   nodeId: ID!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -753,7 +753,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -1072,7 +1072,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   allPosts(
@@ -1137,7 +1137,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     nodeId: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"Reads a single \`Post\` using its globally unique \`ID\`.\\"\\"\\"
@@ -2392,13 +2392,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3379,7 +3379,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -4968,7 +4968,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Creates a single \`Post\`.\\"\\"\\"
   createPost(
@@ -5208,7 +5208,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
   deletePersonSecretByPersonId(
@@ -5216,7 +5216,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`Post\` using its globally unique id.\\"\\"\\"
   deletePost(
@@ -5566,7 +5566,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: PostWithSuffixInput!
-  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated (comment on function a.post_with_suffix).\\")
   returnVoidMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -5758,7 +5758,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
   updatePersonSecretByPersonId(
@@ -5766,7 +5766,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretByPersonIdInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`Post\` using its globally unique id and a patch.\\"\\"\\"
   updatePost(
@@ -6905,7 +6905,7 @@ type Person implements Node {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -7004,7 +7004,7 @@ type Person implements Node {
   nodeId: ID!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -7033,7 +7033,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -7861,7 +7861,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   allPosts(
@@ -8172,7 +8172,7 @@ type Query implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -8439,7 +8439,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     nodeId: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"Reads a single \`Post\` using its globally unique \`ID\`.\\"\\"\\"
@@ -10210,7 +10210,7 @@ type UpdatePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
@@ -409,13 +409,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -749,7 +749,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1521,7 +1521,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`CompoundKey\` using its globally unique id.\\"\\"\\"
   deleteCompoundKey(
@@ -1625,7 +1625,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
   deletePersonSecretByPersonId(
@@ -1633,7 +1633,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   intSetMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -1915,7 +1915,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
   updatePersonSecretByPersonId(
@@ -1923,7 +1923,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretByPersonIdInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 }
 
 \\"\\"\\"All input for the \`mutationInInout\` mutation.\\"\\"\\"
@@ -2630,7 +2630,7 @@ type Person implements Node {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -2697,7 +2697,7 @@ type Person implements Node {
   name: String!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -2726,7 +2726,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
   rowId: Int!
@@ -3120,7 +3120,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   badlyBehavedFunction(
@@ -3141,7 +3141,7 @@ type Query implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -3377,7 +3377,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     id: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"
@@ -3887,7 +3887,7 @@ type UpdatePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -409,13 +409,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -749,7 +749,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1523,7 +1523,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`CompoundKey\` using its globally unique id.\\"\\"\\"
   deleteCompoundKey(
@@ -1627,7 +1627,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
   deletePersonSecretByPersonId(
@@ -1635,7 +1635,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   intSetMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -1917,7 +1917,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
   updatePersonSecretByPersonId(
@@ -1925,7 +1925,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretByPersonIdInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 }
 
 \\"\\"\\"All input for the \`mutationInInout\` mutation.\\"\\"\\"
@@ -2667,7 +2667,7 @@ type Person implements Node {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -2746,7 +2746,7 @@ type Person implements Node {
   nodeId: ID!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -2775,7 +2775,7 @@ type Person implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
 }
 
@@ -3268,7 +3268,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads a set of \`PersonSecret\`.\\"\\"\\"
   allPersonSecretsList(
@@ -3285,7 +3285,7 @@ type Query implements Node {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!]
-  ): [PersonSecret!] @deprecated(reason: \\"This is deprecated.\\")
+  ): [PersonSecret!] @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   badlyBehavedFunction(
@@ -3306,7 +3306,7 @@ type Query implements Node {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   badlyBehavedFunctionList(
@@ -3315,7 +3315,7 @@ type Query implements Node {
 
     \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
     offset: Int
-  ): [Person] @deprecated(reason: \\"This is deprecated.\\")
+  ): [Person] @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
 
   \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
   compoundKey(
@@ -3619,7 +3619,7 @@ type Query implements Node {
     The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
     \\"\\"\\"
     nodeId: ID!
-  ): PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
   personSecretByPersonId(personId: Int!): PersonSecret
 
   \\"\\"\\"
@@ -4138,7 +4138,7 @@ type UpdatePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
@@ -1072,13 +1072,13 @@ type CreatePersonSecretPayload {
   personByPersonId: Person
 
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
-  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1928,7 +1928,7 @@ type DeletePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3390,7 +3390,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: CreatePersonSecretInput!
-  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Creates a single \`Post\`.\\"\\"\\"
   createPost(
@@ -3566,7 +3566,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: DeletePersonSecretByPersonIdInput!
-  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Deletes a single \`Post\` using a unique key.\\"\\"\\"
   deletePostById(
@@ -3852,7 +3852,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: PostWithSuffixInput!
-  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): PostWithSuffixPayload @deprecated(reason: \\"This is deprecated (comment on function a.post_with_suffix).\\")
   returnVoidMutation(
     \\"\\"\\"
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -3974,7 +3974,7 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     \\"\\"\\"
     input: UpdatePersonSecretByPersonIdInput!
-  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated.\\")
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Updates a single \`Post\` using a unique key and a patch.\\"\\"\\"
   updatePostById(
@@ -5021,7 +5021,7 @@ type Person {
   config: KeyValueHash
   createdAt: Datetime
   email: Email!
-  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated.\\")
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
   firstName: String
   firstPost: Post
 
@@ -5115,7 +5115,7 @@ type Person {
   name: String!
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
-  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated.\\")
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
   personSecretsByPersonId(
@@ -5144,7 +5144,7 @@ type Person {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection! @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   postsByAuthorId(
@@ -5962,7 +5962,7 @@ type Query {
 
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsConnection @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"Reads and enables pagination through a set of \`Post\`.\\"\\"\\"
   allPosts(
@@ -6273,7 +6273,7 @@ type Query {
     based pagination. May not be used with \`last\`.
     \\"\\"\\"
     offset: Int
-  ): PeopleConnection! @deprecated(reason: \\"This is deprecated.\\")
+  ): PeopleConnection! @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
@@ -7981,7 +7981,7 @@ type UpdatePersonSecretPayload {
   personSecretEdge(
     \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
     orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated.\\")
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -54,7 +54,7 @@ create table c.person_secret (
 comment on column c.person_secret.sekrit is E'@name secret\nA secret held by the associated Person';
 comment on constraint person_secret_person_id_fkey on c.person_secret is E'@forwardDescription The `Person` this `PersonSecret` belongs to.\n@backwardDescription This `Person`''s `PersonSecret`.';
 
-comment on table c.person_secret is E'@deprecated This is deprecated.\nTracks the person''s secret';
+comment on table c.person_secret is E'@deprecated This is deprecated (comment on table c.person_secret).\nTracks the person''s secret';
 
 -- This is to test that "one-to-one" relationships also work on unique keys
 create table c.left_arm (
@@ -78,7 +78,7 @@ create function c.person_exists(person c.person, email b.email) returns boolean 
 select exists(select 1 from c.person where person.email = person_exists.email);
 $$ language sql stable;
 
-comment on function c.person_exists(person c.person, email b.email) is '@deprecated This is deprecated.';
+comment on function c.person_exists(person c.person, email b.email) is '@deprecated This is deprecated (comment on function c.person_exists).';
 
 create type a.an_enum as enum('awaiting',
   'rejected',
@@ -398,7 +398,7 @@ create function a.post_with_suffix(post a.post,suffix text) returns a.post as $$
   returning *; 
 $$ language sql volatile;
 
-comment on function a.post_with_suffix(post a.post,suffix text) is '@deprecated This is deprecated.';
+comment on function a.post_with_suffix(post a.post,suffix text) is '@deprecated This is deprecated (comment on function a.post_with_suffix).';
 
 create function a.static_big_integer() returns setof int8 as $$
   -- See https://github.com/graphile/postgraphile/issues/678#issuecomment-363659705
@@ -437,7 +437,7 @@ begin
 end;
 $$ language plpgsql stable;
 
-comment on function c.badly_behaved_function() is '@deprecated This is deprecated.';
+comment on function c.badly_behaved_function() is '@deprecated This is deprecated (comment on function c.badly_behaved_function).';
 
 create table c.my_table (
   id serial primary key,


### PR DESCRIPTION
This is some minor cleanup following PRs https://github.com/graphile/graphile-engine/pull/332 and https://github.com/graphile/graphile-engine/pull/340