### PR TITLE
feat(utils): makeProcessSchemaPlugin

### DIFF
--- a/packages/graphile-build/src/SchemaBuilder.d.ts
+++ b/packages/graphile-build/src/SchemaBuilder.d.ts
@@ -100,6 +100,7 @@ export default class SchemaBuilder extends EventEmitter {
     hookName: "GraphQLEnumType:values:value",
     fn: Hook<GraphQLEnumValueConfig>
   ): void;
+  hook(hookName: "finalize", fn: Hook<GraphQLSchema>): void;
 
   /*
   applyHooks(

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -162,6 +162,11 @@ class SchemaBuilder extends EventEmitter {
       // if you need to set up any global types you can do so here.
       init: [],
 
+      // 'finalize' phase is called once the schema is built; typically you
+      // shouldn't use this, but it's useful for interfacing with external
+      // libraries that mutate an already constructed schema.
+      finalize: [],
+
       // Add 'query', 'mutation' or 'subscription' types in this hook:
       GraphQLSchema: [],
 
@@ -324,13 +329,20 @@ class SchemaBuilder extends EventEmitter {
   buildSchema(): GraphQLSchema {
     if (!this._generatedSchema) {
       const build = this.createBuild();
-      this._generatedSchema = build.newWithHooks(
+      const schema = build.newWithHooks(
         GraphQLSchema,
         {},
         {
           __origin: `GraphQL built-in`,
           isSchema: true,
         }
+      );
+      this._generatedSchema = this.applyHooks(
+        build,
+        "finalize",
+        schema,
+        {},
+        "Finalising GraphQL schema"
       );
     }
     if (!this._generatedSchema) {

--- a/packages/graphile-utils/__tests__/makeProcessSchemaPlugin.test.js
+++ b/packages/graphile-utils/__tests__/makeProcessSchemaPlugin.test.js
@@ -1,0 +1,91 @@
+import { makeProcessSchemaPlugin } from "../";
+import {
+  buildSchema,
+  // defaultPlugins,
+  StandardTypesPlugin,
+  QueryPlugin,
+  MutationPlugin,
+  SubscriptionPlugin,
+  MutationPayloadQueryPlugin,
+} from "graphile-build";
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+  printSchema,
+} from "graphql";
+
+const makeSchemaWithSpy = spy =>
+  buildSchema(
+    [
+      StandardTypesPlugin,
+      QueryPlugin,
+      MutationPlugin,
+      SubscriptionPlugin,
+      MutationPayloadQueryPlugin,
+      makeProcessSchemaPlugin(spy),
+    ],
+    {
+      optionKey: "optionValue",
+    }
+  );
+
+const makeSpy = fn => jest.fn(fn || (schema => schema));
+
+it("Gets passed the final schema", async () => {
+  let spySchema;
+  const spy = makeSpy(_schema => {
+    spySchema = _schema;
+    return _schema;
+  });
+  const schema = await makeSchemaWithSpy(spy);
+  expect(spySchema).toBeTruthy();
+  expect(spySchema).toEqual(schema);
+});
+
+const simpleSchema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: "Query",
+    fields: {
+      hello: {
+        type: GraphQLString,
+        resolve: () => "world",
+      },
+    },
+  }),
+});
+
+it("Can replace the schema", async () => {
+  let spySchema;
+  const spy = makeSpy(_schema => {
+    spySchema = _schema;
+    return simpleSchema;
+  });
+  const schema = await makeSchemaWithSpy(spy);
+  expect(spySchema).toBeTruthy();
+  expect(spySchema).not.toEqual(schema);
+  expect(schema).toEqual(simpleSchema);
+});
+
+it("Can tweak the schema", async () => {
+  let spySchema;
+  const spy = makeSpy(_schema => {
+    _schema.getQueryType().description = "MODIFIED DESCRIPTION";
+    spySchema = _schema;
+    return _schema;
+  });
+  const schema = await makeSchemaWithSpy(spy);
+  expect(spySchema).toBeTruthy();
+  expect(spySchema).toEqual(schema);
+  expect(printSchema(schema)).toMatchInlineSnapshot(`
+"\\"\\"\\"MODIFIED DESCRIPTION\\"\\"\\"
+type Query {
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+}
+"
+`);
+});

--- a/packages/graphile-utils/src/index.ts
+++ b/packages/graphile-utils/src/index.ts
@@ -4,6 +4,7 @@ import makeExtendSchemaPlugin from "./makeExtendSchemaPlugin";
 import makePluginByCombiningPlugins from "./makePluginByCombiningPlugins";
 import makeWrapResolversPlugin from "./makeWrapResolversPlugin";
 import makeChangeNullabilityPlugin from "./makeChangeNullabilityPlugin";
+import makeProcessSchemaPlugin from "./makeProcessSchemaPlugin";
 
 export {
   embed,
@@ -13,4 +14,5 @@ export {
   makePluginByCombiningPlugins,
   makeWrapResolversPlugin,
   makeChangeNullabilityPlugin,
+  makeProcessSchemaPlugin,
 };

--- a/packages/graphile-utils/src/makeProcessSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeProcessSchemaPlugin.ts
@@ -1,0 +1,11 @@
+import { GraphQLSchema } from "graphql";
+import { SchemaBuilder } from "graphile-build";
+
+type ProcessSchemaFunction = (schema: GraphQLSchema) => GraphQLSchema;
+export default function makeProcessSchemaPlugin(
+  schemaCallback: ProcessSchemaFunction
+) {
+  return (builder: SchemaBuilder) => {
+    builder.hook("finalize", schemaCallback);
+  };
+}


### PR DESCRIPTION
Fixes #353

Enables a way of processing the schema after it's built. Use cases:

- Printing the schema SDL to a file
- Uploading the schema SDL to a network service
- Checking the schema against your persisted queries
- Validating the schema against your custom logic
- Replacing the schema with a mocked version or a derivative version (e.g. stitching it with another schema)
- Integrating with third-party libraries such as graphql-middleware / graphql-shield which mutate the GraphQLSchema after it has been constructed