### PR TITLE
feat(utils): enable wrapping resolvers matching a filter

### DIFF
--- a/packages/graphile-utils/README.md
+++ b/packages/graphile-utils/README.md
@@ -11,7 +11,7 @@ utilising Graphile Engine, such as the one produced by
 [PostGraphile](https://graphile.org/postgraphile).
 
 Documentation is currently available
-[here](https://graphile.org/postgraphile/extending/#the-easy-way-graphile-utils).
+[here](https://graphile.org/postgraphile/extending/).
 
 PRs to improve documentation are always welcome!
 
@@ -29,6 +29,8 @@ Used to wrap a value to be included in a `gql` AST, e.g. for use in GraphQL
 directives.
 
 ### `makeExtendSchemaPlugin`
+
+Docs: https://www.graphile.org/postgraphile/make-extend-schema-plugin/
 
 Enables you to add additonal types or extend existing types within your
 Graphile Engine GraphQL schema.
@@ -83,25 +85,29 @@ makeExtendSchemaPlugin(build => ({
 
 ### `makeAddInflectorsPlugin`
 
+Docs: https://www.graphile.org/postgraphile/make-add-inflectors-plugin/
+
 If you don't like the default naming conventions that come with a Graphile
 Engine GraphQL schema then it's easy for you to override them using the
 inflector.
 
-For example, if you want '\*Patch' types to instead be called '\*ChangeSet'
-you could make a plugin such as this one:
+### `makeChangeNullabilityPlugin`
 
-```js
-const { makeAddInflectorsPlugin } = require("graphile-utils");
+Docs: https://www.graphile.org/postgraphile/make-change-nullability-plugin/
 
-module.exports = makeAddInflectorsPlugin({
-  patchType(typeName: string) {
-    return this.upperCamelCase(`${typeName}-change-set`);
-  },
-});
-```
+Use this plugin to override the nullability of fields in your GraphQL schema.
 
-The default Graphile Engine inflectors (`pluralize`, `singularize`,
-`upperCamelCase`, `camelCase` and `constantCase`) can be found
-[here](https://github.com/graphile/graphile-engine/blob/6b0cb9e4e91050c98f1a9c62b73e3613a6c78f09/packages/graphile-build/src/makeNewBuild.js#L811-L815).
+### `makeProcessSchemaPlugin`
 
-The additional inflectors used in PostGraphile can be found [here](https://github.com/graphile/graphile-engine/blob/6b0cb9e4e91050c98f1a9c62b73e3613a6c78f09/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js#L296-L699).
+Docs: https://www.graphile.org/postgraphile/make-process-schema-plugin/
+
+Enables you to process the schema after it's built, e.g. print it to a file,
+augment it with a third party library (e.g. graphql-shield), etc.
+
+### `makeWrapResolversPlugin`
+
+Docs: https://www.graphile.org/postgraphile/make-wrap-resolvers-plugin/
+
+Enables you to wrap the field resolvers in the generated GraphQL API,
+allowing you to take an action before or after the resolver, or even modify
+the resolver result.

--- a/packages/graphile-utils/__tests__/makeWrapResolversPlugin.test.js
+++ b/packages/graphile-utils/__tests__/makeWrapResolversPlugin.test.js
@@ -285,7 +285,7 @@ describe("wrapping named resolvers", () => {
 describe("wrapping resolvers matching a filter", () => {
   it("filters correctly", async () => {
     const filter = context => {
-      if (context.scope.isRootMutation) {
+      if (context.scope.isRootMutation && context.scope.fieldName !== "c") {
         return { scope: context.scope };
       }
       return null;
@@ -313,12 +313,14 @@ describe("wrapping resolvers matching a filter", () => {
           extend type Mutation {
             a(arg1: Int = 1, arg2: Int = 2): Int
             b(arg1: String = "1", arg2: String = "2"): String
+            c(arg1: String = "1", arg2: String = "2"): String
           }
         `,
         resolvers: {
           Mutation: {
             a: (_, { arg1, arg2 }) => arg1 + arg2,
             b: (_, { arg1, arg2 }) => arg1 + arg2,
+            c: (_, { arg1, arg2 }) => arg1 + arg2,
           },
         },
       }),
@@ -331,6 +333,7 @@ describe("wrapping resolvers matching a filter", () => {
         mutation {
           a(arg2: 7)
           b(arg2: "ARG2")
+          c(arg2: "NOWRAP")
         }
       `,
       rootValue,
@@ -339,6 +342,7 @@ describe("wrapping resolvers matching a filter", () => {
     expect(result.errors).toBeFalsy();
     expect(result.data.a).toBe(8);
     expect(result.data.b).toBe("1ARG2");
+    expect(result.data.c).toBe("1NOWRAP");
     expect(before.length).toEqual(2);
     expect(after.length).toEqual(2);
     expect(before).toMatchInlineSnapshot(`

--- a/packages/graphile-utils/__tests__/makeWrapResolversPlugin.test.js
+++ b/packages/graphile-utils/__tests__/makeWrapResolversPlugin.test.js
@@ -47,17 +47,57 @@ const makeEchoSpy = fn =>
       })
   );
 
-it("passes args by default", async () => {
-  const wrappers = [
-    resolve => resolve(),
-    (resolve, parent) => resolve(parent),
-    (resolve, parent, args) => resolve(parent, args),
-    (resolve, parent, args, context) => resolve(parent, args, context),
-    (resolve, parent, args, context, resolveInfo) =>
-      resolve(parent, args, context, resolveInfo),
-  ];
+describe("wrapping named resolvers", () => {
+  it("passes args by default", async () => {
+    const wrappers = [
+      resolve => resolve(),
+      (resolve, parent) => resolve(parent),
+      (resolve, parent, args) => resolve(parent, args),
+      (resolve, parent, args, context) => resolve(parent, args, context),
+      (resolve, parent, args, context, resolveInfo) =>
+        resolve(parent, args, context, resolveInfo),
+    ];
 
-  for (const wrapper of wrappers) {
+    for (const wrapper of wrappers) {
+      const spy = makeEchoSpy();
+      const schema = await makeSchemaWithSpyAndPlugins(spy, [
+        makeWrapResolversPlugin({
+          Query: {
+            echo: wrapper,
+          },
+        }),
+      ]);
+      const rootValue = { root: true };
+      const result = await graphql(
+        schema,
+        `
+          {
+            echo(message: "Hello")
+          }
+        `,
+        rootValue,
+        { test: true }
+      );
+      expect(result.errors).toBeFalsy();
+      expect(result.data.echo).toEqual("Hello");
+      expect(spy).toHaveBeenCalledTimes(1);
+      const spyArgs = spy.mock.calls[0];
+      const [parent, args, context, resolveInfo] = spyArgs;
+      expect(parent).toBe(rootValue);
+      expect(args).toEqual({ message: "Hello" });
+      expect(context).toEqual({ test: true });
+      expect(resolveInfo).toBeTruthy();
+    }
+  });
+
+  it("can override args", async () => {
+    const wrapper = (resolve, parent, args, context) =>
+      resolve(
+        { ...parent, rideover: true },
+        { message: args.message.toUpperCase() },
+        { ...context, override: true }
+      );
+
     const spy = makeEchoSpy();
     const schema = await makeSchemaWithSpyAndPlugins(spy, [
       makeWrapResolversPlugin({
@@ -78,7 +118,117 @@ it("passes args by default", async () => {
       { test: true }
     );
     expect(result.errors).toBeFalsy();
-    expect(result.data.echo).toEqual("Hello");
+    expect(result.data.echo).toEqual("HELLO");
+    expect(spy).toHaveBeenCalledTimes(1);
+    const spyArgs = spy.mock.calls[0];
+    const [parent, args, context, resolveInfo] = spyArgs;
+    expect(parent).toEqual({ ...rootValue, rideover: true });
+    expect(args).toEqual({ message: "HELLO" });
+    expect(context).toEqual({ test: true, override: true });
+    expect(resolveInfo).toBeTruthy();
+  });
+
+  it("can asynchronously abort resolver before", async () => {
+    const wrapper = async () => {
+      await delay(10);
+      throw new Error("Abort");
+    };
+    let called = false;
+    const spy = makeEchoSpy(() => {
+      called = true;
+    });
+    const schema = await makeSchemaWithSpyAndPlugins(spy, [
+      makeWrapResolversPlugin({
+        Query: {
+          echo: wrapper,
+        },
+      }),
+    ]);
+    const rootValue = { root: true };
+    const result = await graphql(
+      schema,
+      `
+        {
+          echo(message: "Hello")
+        }
+      `,
+      rootValue,
+      { test: true }
+    );
+    expect(result.errors).toBeTruthy();
+    expect(result.data.echo).toBe(null);
+    expect(spy).not.toHaveBeenCalled();
+    expect(result.errors).toHaveLength(1);
+    expect(called).toBe(false);
+    expect(result.errors[0]).toMatchInlineSnapshot(`[GraphQLError: Abort]`);
+  });
+
+  it("can asynchronously abort resolver after", async () => {
+    const wrapper = async resolve => {
+      const result = await resolve();
+      // eslint-disable-next-line no-constant-condition
+      if (true) {
+        await delay(10);
+        throw new Error("Abort");
+      }
+      return result;
+    };
+    let called = false;
+    const spy = makeEchoSpy(() => {
+      called = true;
+    });
+    const schema = await makeSchemaWithSpyAndPlugins(spy, [
+      makeWrapResolversPlugin({
+        Query: {
+          echo: wrapper,
+        },
+      }),
+    ]);
+    const rootValue = { root: true };
+    const result = await graphql(
+      schema,
+      `
+        {
+          echo(message: "Hello")
+        }
+      `,
+      rootValue,
+      { test: true }
+    );
+    expect(result.errors).toBeTruthy();
+    expect(result.data.echo).toBe(null);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result.errors).toHaveLength(1);
+    expect(called).toBe(true);
+    expect(result.errors[0]).toMatchInlineSnapshot(`[GraphQLError: Abort]`);
+  });
+
+  it("can modify result of resolver", async () => {
+    const wrapper = async resolve => {
+      const result = await resolve();
+      return result.toLowerCase();
+    };
+    const spy = makeEchoSpy();
+    const schema = await makeSchemaWithSpyAndPlugins(spy, [
+      makeWrapResolversPlugin({
+        Query: {
+          echo: wrapper,
+        },
+      }),
+    ]);
+    const rootValue = { root: true };
+    const result = await graphql(
+      schema,
+      `
+        {
+          echo(message: "Hello")
+        }
+      `,
+      rootValue,
+      { test: true }
+    );
+    expect(result.errors).toBeFalsy();
+    expect(result.data.echo).toBe("hello");
     expect(spy).toHaveBeenCalledTimes(1);
     const spyArgs = spy.mock.calls[0];
     const [parent, args, context, resolveInfo] = spyArgs;
@@ -86,196 +236,48 @@ it("passes args by default", async () => {
     expect(args).toEqual({ message: "Hello" });
     expect(context).toEqual({ test: true });
     expect(resolveInfo).toBeTruthy();
-  }
-});
-
-it("can override args", async () => {
-  const wrapper = (resolve, parent, args, context) =>
-    resolve(
-      { ...parent, rideover: true },
-      { message: args.message.toUpperCase() },
-      { ...context, override: true }
-    );
-
-  const spy = makeEchoSpy();
-  const schema = await makeSchemaWithSpyAndPlugins(spy, [
-    makeWrapResolversPlugin({
-      Query: {
-        echo: wrapper,
-      },
-    }),
-  ]);
-  const rootValue = { root: true };
-  const result = await graphql(
-    schema,
-    `
-      {
-        echo(message: "Hello")
-      }
-    `,
-    rootValue,
-    { test: true }
-  );
-  expect(result.errors).toBeFalsy();
-  expect(result.data.echo).toEqual("HELLO");
-  expect(spy).toHaveBeenCalledTimes(1);
-  const spyArgs = spy.mock.calls[0];
-  const [parent, args, context, resolveInfo] = spyArgs;
-  expect(parent).toEqual({ ...rootValue, rideover: true });
-  expect(args).toEqual({ message: "HELLO" });
-  expect(context).toEqual({ test: true, override: true });
-  expect(resolveInfo).toBeTruthy();
-});
-
-it("can asynchronously abort resolver before", async () => {
-  const wrapper = async () => {
-    await delay(10);
-    throw new Error("Abort");
-  };
-  let called = false;
-  const spy = makeEchoSpy(() => {
-    called = true;
   });
-  const schema = await makeSchemaWithSpyAndPlugins(spy, [
-    makeWrapResolversPlugin({
-      Query: {
-        echo: wrapper,
-      },
-    }),
-  ]);
-  const rootValue = { root: true };
-  const result = await graphql(
-    schema,
-    `
-      {
-        echo(message: "Hello")
-      }
-    `,
-    rootValue,
-    { test: true }
-  );
-  expect(result.errors).toBeTruthy();
-  expect(result.data.echo).toBe(null);
-  expect(spy).not.toHaveBeenCalled();
-  expect(result.errors).toHaveLength(1);
-  expect(called).toBe(false);
-  expect(result.errors[0]).toMatchInlineSnapshot(`[GraphQLError: Abort]`);
-});
 
-it("can asynchronously abort resolver after", async () => {
-  const wrapper = async resolve => {
-    const result = await resolve();
-    // eslint-disable-next-line no-constant-condition
-    if (true) {
-      await delay(10);
-      throw new Error("Abort");
-    }
-    return result;
-  };
-  let called = false;
-  const spy = makeEchoSpy(() => {
-    called = true;
-  });
-  const schema = await makeSchemaWithSpyAndPlugins(spy, [
-    makeWrapResolversPlugin({
-      Query: {
-        echo: wrapper,
-      },
-    }),
-  ]);
-  const rootValue = { root: true };
-  const result = await graphql(
-    schema,
-    `
-      {
-        echo(message: "Hello")
-      }
-    `,
-    rootValue,
-    { test: true }
-  );
-  expect(result.errors).toBeTruthy();
-  expect(result.data.echo).toBe(null);
-  expect(spy).toHaveBeenCalledTimes(1);
-  expect(result.errors).toHaveLength(1);
-  expect(called).toBe(true);
-  expect(result.errors[0]).toMatchInlineSnapshot(`[GraphQLError: Abort]`);
-});
-
-it("can modify result of resolver", async () => {
-  const wrapper = async resolve => {
-    const result = await resolve();
-    return result.toLowerCase();
-  };
-  const spy = makeEchoSpy();
-  const schema = await makeSchemaWithSpyAndPlugins(spy, [
-    makeWrapResolversPlugin({
-      Query: {
-        echo: wrapper,
-      },
-    }),
-  ]);
-  const rootValue = { root: true };
-  const result = await graphql(
-    schema,
-    `
-      {
-        echo(message: "Hello")
-      }
-    `,
-    rootValue,
-    { test: true }
-  );
-  expect(result.errors).toBeFalsy();
-  expect(result.data.echo).toBe("hello");
-  expect(spy).toHaveBeenCalledTimes(1);
-  const spyArgs = spy.mock.calls[0];
-  const [parent, args, context, resolveInfo] = spyArgs;
-  expect(parent).toBe(rootValue);
-  expect(args).toEqual({ message: "Hello" });
-  expect(context).toEqual({ test: true });
-  expect(resolveInfo).toBeTruthy();
-});
-
-it("can supports options modify result of resolver", async () => {
-  const wrapper = async resolve => {
-    const result = await resolve();
-    return result.toLowerCase();
-  };
-  const spy = makeEchoSpy();
-  let options;
-  const schema = await makeSchemaWithSpyAndPlugins(spy, [
-    makeWrapResolversPlugin(_options => {
-      options = _options;
-      return {
-        Query: {
-          echo: {
-            resolve: wrapper,
+  it("can supports options modify result of resolver", async () => {
+    const wrapper = async resolve => {
+      const result = await resolve();
+      return result.toLowerCase();
+    };
+    const spy = makeEchoSpy();
+    let options;
+    const schema = await makeSchemaWithSpyAndPlugins(spy, [
+      makeWrapResolversPlugin(_options => {
+        options = _options;
+        return {
+          Query: {
+            echo: {
+              resolve: wrapper,
+            },
           },
-        },
-      };
-    }),
-  ]);
-  const rootValue = { root: true };
-  const result = await graphql(
-    schema,
-    `
-      {
-        echo(message: "Hello")
-      }
-    `,
-    rootValue,
-    { test: true }
-  );
-  expect(options).toBeTruthy();
-  expect(options.optionKey).toEqual("optionValue");
-  expect(result.errors).toBeFalsy();
-  expect(result.data.echo).toBe("hello");
-  expect(spy).toHaveBeenCalledTimes(1);
-  const spyArgs = spy.mock.calls[0];
-  const [parent, args, context, resolveInfo] = spyArgs;
-  expect(parent).toBe(rootValue);
-  expect(args).toEqual({ message: "Hello" });
-  expect(context).toEqual({ test: true });
-  expect(resolveInfo).toBeTruthy();
+        };
+      }),
+    ]);
+    const rootValue = { root: true };
+    const result = await graphql(
+      schema,
+      `
+        {
+          echo(message: "Hello")
+        }
+      `,
+      rootValue,
+      { test: true }
+    );
+    expect(options).toBeTruthy();
+    expect(options.optionKey).toEqual("optionValue");
+    expect(result.errors).toBeFalsy();
+    expect(result.data.echo).toBe("hello");
+    expect(spy).toHaveBeenCalledTimes(1);
+    const spyArgs = spy.mock.calls[0];
+    const [parent, args, context, resolveInfo] = spyArgs;
+    expect(parent).toBe(rootValue);
+    expect(args).toEqual({ message: "Hello" });
+    expect(context).toEqual({ test: true });
+    expect(resolveInfo).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Enables you to wrap a class of resolvers rather than only ones that have a particular name.


```js
// Example: log before and after each mutation runs
module.exports = makeWrapResolversPlugin(
  context => {
    if (context.scope.isRootMutation) {
      return { scope: context.scope };
    }
    return null;
  },
  ({ scope }) => async (resolver, user, args, context, _resolveInfo) => {
    console.log(`Mutation '${scope.fieldName}' starting with arguments:`, args);
    const result = await resolver();
    console.log(`Mutation '${scope.fieldName}' result:`, result);
    return result;
  }
);
```