### PR TITLE
fix(sql): tsrange, tstzrange, int8range and numrange now properly formatted

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -1,6 +1,5 @@
 // @flow
 import type { Plugin } from "graphile-build";
-import { types as pgTypes } from "pg";
 
 import makeGraphQLJSONTypes from "../GraphQLJSON";
 
@@ -25,44 +24,6 @@ function parseInterval(str) {
   }
   return result;
 }
-
-const pgRangeParser = {
-  parse(str) {
-    const parts = str.split(",");
-    if (parts.length !== 2) {
-      throw new Error("Invalid daterange");
-    }
-
-    return {
-      start:
-        parts[0].length > 1
-          ? {
-              inclusive: parts[0][0] === "[",
-              value: parts[0].slice(1),
-            }
-          : null,
-      end:
-        parts[1].length > 1
-          ? {
-              inclusive: parts[1][parts[1].length - 1] === "]",
-              value: parts[1].slice(0, -1),
-            }
-          : null,
-    };
-  },
-
-  serialize({ start, end }) {
-    const inclusivity = {
-      true: "[]",
-      false: "()",
-    };
-
-    return [
-      start ? inclusivity[start.inclusive][0] + start.value : "[",
-      end ? end.value + inclusivity[end.inclusive][1] : "]",
-    ].join(",");
-  },
-};
 
 export default (function PgTypesPlugin(
   builder,
@@ -660,32 +621,24 @@ export default (function PgTypesPlugin(
         }
         gqlTypeByTypeIdAndModifier[type.id][typeModifierKey] = Range;
         gqlInputTypeByTypeIdAndModifier[type.id][typeModifierKey] = RangeInput;
+        if (pgTweaksByTypeIdAndModifer[type.id] === undefined) {
+          pgTweaksByTypeIdAndModifer[type.id] = {};
+        }
+        pgTweaksByTypeIdAndModifer[type.id][
+          typeModifierKey
+        ] = fragment => sql.fragment`case
+          when (${fragment}) is null then null else json_build_object(
+            'start', case
+              when lower(${fragment}) is null then null
+              else json_build_object('value', lower(${fragment}), 'inclusive', lower_inc(${fragment}))
+            end,
+            'end', case
+              when upper(${fragment}) is null then null
+              else json_build_object('value', upper(${fragment}), 'inclusive', upper_inc(${fragment}))
+            end
+        ) end`;
         pg2GqlMapper[type.id] = {
-          map: pgRange => {
-            const parsed = pgRangeParser.parse(pgRange);
-            // Since the value we will get from `parsed.(start|end).value` is a
-            // string but our code will expect it to be the value after `pg`
-            // parsed it, we pass through to `pg-types` for parsing.
-            const pgParse =
-              rawTypes.indexOf(parseInt(subtype.id, 10)) >= 0
-                ? identity
-                : pgTypes.getTypeParser(subtype.id);
-            const { start, end } = parsed;
-            return {
-              start: start
-                ? {
-                    value: pg2gql(pgParse(start.value), subtype),
-                    inclusive: start.inclusive,
-                  }
-                : null,
-              end: end
-                ? {
-                    value: pg2gql(pgParse(end.value), subtype),
-                    inclusive: end.inclusive,
-                  }
-                : null,
-            };
-          },
+          map: identity,
           unmap: ({ start, end }) => {
             // Ref: https://www.postgresql.org/docs/9.6/static/rangetypes.html#RANGETYPES-CONSTRUCT
             const lower =

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -630,11 +630,21 @@ export default (function PgTypesPlugin(
           when (${fragment}) is null then null else json_build_object(
             'start', case
               when lower(${fragment}) is null then null
-              else json_build_object('value', lower(${fragment}), 'inclusive', lower_inc(${fragment}))
+              else json_build_object('value', ${pgTweakFragmentForTypeAndModifier(
+                sql.fragment`lower(${fragment})`,
+                subtype,
+                typeModifier,
+                {}
+              )}, 'inclusive', lower_inc(${fragment}))
             end,
             'end', case
               when upper(${fragment}) is null then null
-              else json_build_object('value', upper(${fragment}), 'inclusive', upper_inc(${fragment}))
+              else json_build_object('value', ${pgTweakFragmentForTypeAndModifier(
+                sql.fragment`upper(${fragment})`,
+                subtype,
+                typeModifier,
+                {}
+              )}, 'inclusive', upper_inc(${fragment}))
             end
         ) end`;
         pg2GqlMapper[type.id] = {

--- a/packages/postgraphile-core/__tests__/integration/queries-ranges.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries-ranges.test.js
@@ -46,12 +46,12 @@ test("bigint range", () =>
     const {
       rows: [row],
     } = await pgClient.query(
-      "insert into ranges.range_test (num) values (numrange($1, $2)) returning *",
+      "insert into ranges.range_test (int8) values (int8range($1, $2)) returning *",
       ["-98765432109876543", "22222222222222222"]
     );
     const result = await graphql(
       schema,
-      "query ($id: Int!) {rangeTestById(id:$id) {num{start {value inclusive} end { value inclusive } }}}",
+      "query ($id: Int!) {rangeTestById(id:$id) {int8{start {value inclusive} end { value inclusive } }}}",
       null,
       {
         pgClient: pgClient,
@@ -59,7 +59,7 @@ test("bigint range", () =>
       { id: row.id }
     );
     expect(result.errors).toBeFalsy();
-    expect(result.data.rangeTestById.num).toEqual({
+    expect(result.data.rangeTestById.int8).toEqual({
       start: {
         value: "-98765432109876543",
         inclusive: true,
@@ -67,6 +67,58 @@ test("bigint range", () =>
       end: {
         value: "22222222222222222",
         inclusive: false,
+      },
+    });
+  }));
+
+test("ts range", () =>
+  withPgClient(async pgClient => {
+    const {
+      rows: [row],
+    } = await pgClient.query(
+      "insert into ranges.range_test (ts) values (tsrange($1::timestamp, null)) returning *",
+      ["2019-01-10 21:45:56.356022"]
+    );
+    const result = await graphql(
+      schema,
+      "query ($id: Int!) {rangeTestById(id:$id) {ts{start {value inclusive} }}}",
+      null,
+      {
+        pgClient: pgClient,
+      },
+      { id: row.id }
+    );
+    expect(result.errors).toBeFalsy();
+    expect(result.data.rangeTestById.ts).toEqual({
+      start: {
+        value: "2019-01-10T21:45:56.356022",
+        inclusive: true,
+      },
+    });
+  }));
+
+test("tstz range", () =>
+  withPgClient(async pgClient => {
+    const {
+      rows: [row],
+    } = await pgClient.query(
+      "insert into ranges.range_test (tstz) values (tstzrange($1::timestamptz, null)) returning *",
+      ["2019-01-10 21:45:56.356022+00"]
+    );
+    const result = await graphql(
+      schema,
+      "query ($id: Int!) {rangeTestById(id:$id) {tstz{start {value inclusive} }}}",
+      null,
+      {
+        pgClient: pgClient,
+      },
+      { id: row.id }
+    );
+    expect(result.errors).toBeFalsy();
+    expect(result.data.rangeTestById.tstz).toEqual({
+      start: {
+        value: "2019-01-10T17:45:56.356022-04:00",
+        inclusive: true,
       },
     });
   }));

--- a/packages/postgraphile-core/__tests__/integration/queries-ranges.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries-ranges.test.js
@@ -1,16 +1,6 @@
 const { graphql } = require("graphql");
 const { withPgClient } = require("../helpers");
 const { createPostGraphileSchema } = require("../..");
-const { readFile: rawReadFile } = require("fs");
-
-function readFile(filename, encoding) {
-  return new Promise((resolve, reject) => {
-    rawReadFile(filename, encoding, (err, res) => {
-      if (err) reject(err);
-      else resolve(res);
-    });
-  });
-}
 
 let schema;
 

--- a/packages/postgraphile-core/__tests__/integration/queries-ranges.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries-ranges.test.js
@@ -1,0 +1,53 @@
+const { graphql } = require("graphql");
+const { withPgClient } = require("../helpers");
+const { createPostGraphileSchema } = require("../..");
+const { readFile: rawReadFile } = require("fs");
+
+function readFile(filename, encoding) {
+  return new Promise((resolve, reject) => {
+    rawReadFile(filename, encoding, (err, res) => {
+      if (err) reject(err);
+      else resolve(res);
+    });
+  });
+}
+
+let schema;
+
+beforeAll(async () => {
+  // Get a few GraphQL schema instance that we can query.
+  schema = await withPgClient(async pgClient =>
+    createPostGraphileSchema(pgClient, ["ranges"])
+  );
+});
+
+test("numeric range", () =>
+  withPgClient(async pgClient => {
+    const {
+      rows: [row],
+    } = await pgClient.query(
+      "insert into ranges.range_test (num) values (numrange($1, $2)) returning *",
+      ["-1234567890123456789.123456789012", "1111111111111111111.111111111111"]
+    );
+    const result = await graphql(
+      schema,
+      "query ($id: Int!) {rangeTestById(id:$id) {num{start {value inclusive} end { value inclusive } }}}",
+      null,
+      {
+        pgClient: pgClient,
+      },
+      { id: row.id }
+    );
+    expect(result.errors).toBeFalsy();
+    expect(result.data.rangeTestById.num).toEqual({
+      start: {
+        value: "-1234567890123456789.123456789012",
+        inclusive: true,
+      },
+      end: {
+        value: "1111111111111111111.111111111111",
+        inclusive: false,
+      },
+    });
+  }));
+//int8range(-98765432109876543, 22222222222222222)

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -1,5 +1,5 @@
 -- WARNING: this database is shared with graphile-utils, don't run the tests in parallel!
-drop schema if exists a, b, c, d, inheritence, smart_comment_relations cascade;
+drop schema if exists a, b, c, d, inheritence, smart_comment_relations, ranges cascade;
 drop extension if exists tablefunc;
 drop extension if exists intarray;
 drop extension if exists hstore;
@@ -952,3 +952,10 @@ create view smart_comment_relations.offer_view as
 comment on view smart_comment_relations.offer_view is E'@name offers
 @primaryKey id
 @foreignKey (post_id) references post_view (id)';
+
+create schema ranges;
+create table ranges.range_test (
+  id serial primary key,
+  num numrange default null,
+  int8 int8range default null
+);

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -411,7 +411,7 @@ create view a.testview as
 create function a.post_with_suffix(post a.post,suffix text) returns a.post as $$
   insert into a.post(id,headline,body,author_id,enums,comptypes) values
   (post.id,post.headline || suffix,post.body,post.author_id,post.enums,post.comptypes)
-  returning *; 
+  returning *;
 $$ language sql volatile;
 
 comment on function a.post_with_suffix(post a.post,suffix text) is '@deprecated This is deprecated (comment on function a.post_with_suffix).';
@@ -899,7 +899,7 @@ comment on table smart_comment_relations.buildings is E'@foreignKey (name) refer
 create unique index on smart_comment_relations.buildings (property_id) where is_primary is true;
 
 create view smart_comment_relations.houses as (
-  select 
+  select
     buildings.name as building_name,
     properties.name_or_number as property_name_or_number,
     streets.name as street_name,
@@ -937,7 +937,7 @@ comment on table smart_comment_relations.offer is E'@name offer_table
 @omit';
 
 create view smart_comment_relations.post_view as
-  SELECT 
+  SELECT
     post.id
     FROM smart_comment_relations.post post;
 comment on view smart_comment_relations.post_view is E'@name posts
@@ -957,5 +957,7 @@ create schema ranges;
 create table ranges.range_test (
   id serial primary key,
   num numrange default null,
-  int8 int8range default null
+  int8 int8range default null,
+  ts tsrange default null,
+  tstz tstzrange default null
 );


### PR DESCRIPTION
I've tried this by patching manually PgTypesPlugin.js in my node_modules and it seems to work fine

I tried to do this as a plugin as suggested but this was easier than rebuilding the whole Ranges types

I have not looked into the tests for this yet