### PR TITLE
Update introspection query URL in introspectionQuery.js

### DIFF
--- a/packages/graphile-build-pg/src/plugins/introspectionQuery.js
+++ b/packages/graphile-build-pg/src/plugins/introspectionQuery.js
@@ -14,7 +14,7 @@ function makeIntrospectionQuery(
   const { pgLegacyFunctionsOnly } = options;
   return `\
 -- @see https://www.postgresql.org/docs/9.5/static/catalogs.html
--- @see https://github.com/graphile/postgraphile/blob/master/resources/introspection-query.sql
+-- @see https://github.com/graphile/graphile-engine/blob/master/packages/graphile-build-pg/src/plugins/introspectionQuery.js
 --
 -- ## Parameters
 -- - \`$1\`: An array of strings that represent the namespaces we are introspecting.


### PR DESCRIPTION
This simple PR updates the introspection query URL in introspectionQuery.js

The file was at some point inlined from explicitly loaded `introspection-query.sql` to `introspectionQuery.js` but the URL was never changed: the URL shows up when errors happen during introspections making it a bit confusing for the end users.