### PR TITLE
chore(deps): upgrade lru-cache to version 5

### DIFF
--- a/packages/graphile-build/package.json
+++ b/packages/graphile-build/package.json
@@ -35,7 +35,7 @@
     "debug": ">=2 <3",
     "graphql-parse-resolve-info": "4.1.0",
     "lodash": ">=4 <5",
-    "lru-cache": ">=4 <5",
+    "lru-cache": "^5.0.0",
     "pluralize": "^7.0.0",
     "semver": "^5.6.0"
   },

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -48,7 +48,7 @@ const debug = debugFactory("graphile-build");
  * produce half a million hashes per second on my machine, the LRU only gives
  * us a 10x speedup!
  */
-const hashCache = LRUCache(100000);
+const hashCache = new LRUCache(100000);
 
 /*
  * This function must never return a string longer than 56 characters.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4838,6 +4838,13 @@ loud-rejection@^1.0.0:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"


### PR DESCRIPTION
This PR updates graphile-build's lru-cache dependency to version 5.