### PR TITLE
fix(nulls): fix null detection when requesting only nullable columns

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -117,7 +117,7 @@ export default (async function PgAllRows(
                         );
                       }
                       if (primaryKeys) {
-                        if (subscriptions && liveRecord) {
+                        if (subscriptions) {
                           queryBuilder.selectIdentifiers(table);
                         }
                         queryBuilder.beforeLock("orderBy", () => {

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -91,7 +91,7 @@ export default (async function PgAllRows(
                   : new GraphQLList(new GraphQLNonNull(TableType)),
                 args: {},
                 async resolve(parent, args, resolveContext, resolveInfo) {
-                  const { pgClient, liveRecord } = resolveContext;
+                  const { pgClient } = resolveContext;
                   const parsedResolveInfoFragment = parseResolveInfo(
                     resolveInfo
                   );

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -25,8 +25,8 @@ export default (function PgTablesPlugin(
 ) {
   const handleNullRow = pgForbidSetofFunctionsToReturnNull
     ? row => row
-    : row => {
-        if (hasNonNullKey(row)) {
+    : (row, identifiers) => {
+        if ((identifiers && hasNonNullKey(identifiers)) || hasNonNullKey(row)) {
           return row;
         } else {
           return null;
@@ -344,7 +344,10 @@ export default (function PgTablesPlugin(
                         const safeAlias = getSafeAliasFromResolveInfo(
                           resolveInfo
                         );
-                        const record = handleNullRow(data[safeAlias]);
+                        const record = handleNullRow(
+                          data[safeAlias],
+                          data.__identifiers
+                        );
                         if (
                           record &&
                           primaryKeys &&
@@ -411,7 +414,10 @@ export default (function PgTablesPlugin(
                           resolveInfo
                         );
                         return data.data.map(entry => {
-                          const record = handleNullRow(entry[safeAlias]);
+                          const record = handleNullRow(
+                            entry[safeAlias],
+                            entry.__identifiers
+                          );
                           if (
                             record &&
                             resolveContext.liveRecord &&

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -24,7 +24,7 @@ export default (function PgTablesPlugin(
   { pgForbidSetofFunctionsToReturnNull = false }
 ) {
   const handleNullRow = pgForbidSetofFunctionsToReturnNull
-    ? row => row
+    ? (row, _identifiers) => row
     : (row, identifiers) => {
         if ((identifiers && hasNonNullKey(identifiers)) || hasNonNullKey(row)) {
           return row;

--- a/packages/postgraphile-core/__tests__/fixtures/queries/connections.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/connections.graphql
@@ -41,6 +41,7 @@ query {
       }
     }
   }
+  nullTest1: allNullTestRecords { nodes { nullableText nullableInt } }
 }
 
 fragment personConnection on PeopleConnection {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -727,6 +727,30 @@ Object {
       },
       "totalCount": 6,
     },
+    "nullTest1": Object {
+      "nodes": Array [
+        Object {
+          "nullableInt": 99,
+          "nullableText": "Hello",
+        },
+        Object {
+          "nullableInt": 98,
+          "nullableText": null,
+        },
+        Object {
+          "nullableInt": null,
+          "nullableText": null,
+        },
+        Object {
+          "nullableInt": null,
+          "nullableText": "Hey",
+        },
+        Object {
+          "nullableInt": 95,
+          "nullableText": "Hey",
+        },
+      ],
+    },
     "o": Object {
       "nodes": Array [
         Object {
@@ -2629,6 +2653,11 @@ Object {
           "computed": "hello world",
           "notNullHasDefault": false,
           "wontCastEasy": -512,
+        },
+        Object {
+          "computed": "hello world",
+          "notNullHasDefault": false,
+          "wontCastEasy": null,
         },
       ],
     },

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -983,6 +983,41 @@ type CreateNoPrimaryKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Patch\` mutation.\\"\\"\\"
 input CreatePatchInput {
   \\"\\"\\"
@@ -1906,6 +1941,54 @@ type DeleteNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3631,6 +3714,14 @@ type Mutation {
     input: CreateNoPrimaryKeyInput!
   ): CreateNoPrimaryKeyPayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Patch\`.\\"\\"\\"
   createPatch(
     \\"\\"\\"
@@ -3846,6 +3937,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteNoPrimaryKeyByIdInput!
   ): DeleteNoPrimaryKeyPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Patch\` using its globally unique id.\\"\\"\\"
   deletePatch(
@@ -4394,6 +4501,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateNoPrimaryKeyByIdInput!
   ): UpdateNoPrimaryKeyPayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Patch\` using its globally unique id and a patch.\\"\\"\\"
   updatePatch(
@@ -5386,6 +5511,97 @@ enum NoPrimaryKeysOrderBy {
 scalar NotNullTimestamp
 
 scalar NotNullUrl
+
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
 
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
@@ -6469,6 +6685,35 @@ type Query implements Node {
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Patch\`.\\"\\"\\"
   allPatches(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -7105,6 +7350,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
   optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
   optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
@@ -8729,6 +8983,63 @@ type UpdateNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -10466,6 +10777,41 @@ type CreateNoPrimaryKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Patch\` mutation.\\"\\"\\"
 input CreatePatchInput {
   \\"\\"\\"
@@ -11389,6 +11735,54 @@ type DeleteNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -13114,6 +13508,14 @@ type Mutation {
     input: CreateNoPrimaryKeyInput!
   ): CreateNoPrimaryKeyPayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Patch\`.\\"\\"\\"
   createPatch(
     \\"\\"\\"
@@ -13329,6 +13731,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteNoPrimaryKeyByIdInput!
   ): DeleteNoPrimaryKeyPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Patch\` using its globally unique id.\\"\\"\\"
   deletePatch(
@@ -13877,6 +14295,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateNoPrimaryKeyByIdInput!
   ): UpdateNoPrimaryKeyPayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Patch\` using its globally unique id and a patch.\\"\\"\\"
   updatePatch(
@@ -14869,6 +15305,97 @@ enum NoPrimaryKeysOrderBy {
 scalar NotNullTimestamp
 
 scalar NotNullUrl
+
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
 
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
@@ -15952,6 +16479,35 @@ type Query implements Node {
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Patch\`.\\"\\"\\"
   allPatches(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -16588,6 +17144,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
   optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
   optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
@@ -18212,6 +18777,63 @@ type UpdateNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
@@ -350,6 +350,41 @@ type CreateMyTablePayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
 input CreatePersonInput {
   \\"\\"\\"
@@ -639,6 +674,54 @@ type DeleteMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1501,6 +1584,14 @@ type Mutation {
     input: CreateMyTableInput!
   ): CreateMyTablePayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
   createPerson(
     \\"\\"\\"
@@ -1588,6 +1679,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteMyTableByIdInput!
   ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
   deletePerson(
@@ -1881,6 +1988,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateMyTableByIdInput!
   ): UpdateMyTablePayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
   updatePerson(
@@ -2492,6 +2617,97 @@ scalar NotNullTimestamp
 
 scalar NotNullUrl
 
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord!
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
   \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
@@ -3041,6 +3257,35 @@ type Query implements Node {
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -3341,6 +3586,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
 
   \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
   person(
@@ -3736,6 +3990,63 @@ type UpdateMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
@@ -983,6 +983,41 @@ type CreateNoPrimaryKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Patch\` mutation.\\"\\"\\"
 input CreatePatchInput {
   \\"\\"\\"
@@ -1906,6 +1941,54 @@ type DeleteNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3631,6 +3714,14 @@ type Mutation {
     input: CreateNoPrimaryKeyInput!
   ): CreateNoPrimaryKeyPayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Patch\`.\\"\\"\\"
   createPatch(
     \\"\\"\\"
@@ -3846,6 +3937,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteNoPrimaryKeyByIdInput!
   ): DeleteNoPrimaryKeyPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Patch\` using its globally unique id.\\"\\"\\"
   deletePatch(
@@ -4394,6 +4501,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateNoPrimaryKeyByIdInput!
   ): UpdateNoPrimaryKeyPayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Patch\` using its globally unique id and a patch.\\"\\"\\"
   updatePatch(
@@ -5386,6 +5511,97 @@ enum NoPrimaryKeysOrderBy {
 scalar NotNullTimestamp
 
 scalar NotNullUrl
+
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
 
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
@@ -6469,6 +6685,35 @@ type Query implements Node {
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Patch\`.\\"\\"\\"
   allPatches(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -7105,6 +7350,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
   optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
   optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
@@ -8729,6 +8983,63 @@ type UpdateNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
@@ -1433,6 +1433,41 @@ type CreateNoPrimaryKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Patch\` mutation.\\"\\"\\"
 input CreatePatchInput {
   \\"\\"\\"
@@ -2348,6 +2383,54 @@ type DeleteNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -4010,6 +4093,14 @@ type Mutation {
     input: CreateNoPrimaryKeyInput!
   ): CreateNoPrimaryKeyPayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Patch\`.\\"\\"\\"
   createPatch(
     \\"\\"\\"
@@ -4225,6 +4316,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteNoPrimaryKeyByIdInput!
   ): DeleteNoPrimaryKeyPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Patch\` using its globally unique id.\\"\\"\\"
   deletePatch(
@@ -4773,6 +4880,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateNoPrimaryKeyByIdInput!
   ): UpdateNoPrimaryKeyPayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Patch\` using its globally unique id and a patch.\\"\\"\\"
   updatePatch(
@@ -5745,6 +5870,82 @@ scalar NotNullTimestamp
 
 scalar NotNullUrl
 
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
   \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
@@ -6694,6 +6895,35 @@ type Query implements Node {
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Patch\`.\\"\\"\\"
   allPatches(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -7320,6 +7550,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
   optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
   optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
@@ -8707,6 +8946,63 @@ type UpdateNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
@@ -988,6 +988,41 @@ type CreateNoPrimaryKeyPayload {
   query: Q
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Q
+}
+
 \\"\\"\\"All input for the create \`Patch\` mutation.\\"\\"\\"
 input CreatePatchInput {
   \\"\\"\\"
@@ -1911,6 +1946,54 @@ type DeleteNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Q
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3528,6 +3611,14 @@ type M {
     input: CreateNoPrimaryKeyInput!
   ): CreateNoPrimaryKeyPayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Patch\`.\\"\\"\\"
   createPatch(
     \\"\\"\\"
@@ -3743,6 +3834,22 @@ type M {
     \\"\\"\\"
     input: DeleteNoPrimaryKeyByIdInput!
   ): DeleteNoPrimaryKeyPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Patch\` using its globally unique id.\\"\\"\\"
   deletePatch(
@@ -4291,6 +4398,24 @@ type M {
     \\"\\"\\"
     input: UpdateNoPrimaryKeyByIdInput!
   ): UpdateNoPrimaryKeyPayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Patch\` using its globally unique id and a patch.\\"\\"\\"
   updatePatch(
@@ -5392,6 +5517,97 @@ scalar NotNullTimestamp
 
 scalar NotNullUrl
 
+type NullTestRecord implements N {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PI!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 type P {
   x: Float!
   y: Float!
@@ -6474,6 +6690,35 @@ type Q implements N {
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Patch\`.\\"\\"\\"
   allPatches(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -7110,6 +7355,15 @@ type Q implements N {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
   optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
   optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
@@ -8734,6 +8988,63 @@ type UpdateNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Q
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyFunctionsOnly.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyFunctionsOnly.test.js.snap
@@ -350,6 +350,41 @@ type CreateMyTablePayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
 input CreatePersonInput {
   \\"\\"\\"
@@ -639,6 +674,54 @@ type DeleteMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1358,6 +1441,14 @@ type Mutation {
     input: CreateMyTableInput!
   ): CreateMyTablePayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
   createPerson(
     \\"\\"\\"
@@ -1445,6 +1536,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteMyTableByIdInput!
   ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
   deletePerson(
@@ -1636,6 +1743,24 @@ type Mutation {
     input: UpdateMyTableByIdInput!
   ): UpdateMyTablePayload
 
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
+
   \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
   updatePerson(
     \\"\\"\\"
@@ -1786,6 +1911,97 @@ interface Node {
 scalar NotNullTimestamp
 
 scalar NotNullUrl
+
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
 
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
@@ -2330,6 +2546,35 @@ type Query implements Node {
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -2497,6 +2742,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
 
   \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
   person(
@@ -2889,6 +3143,63 @@ type UpdateMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
@@ -350,6 +350,41 @@ type CreateMyTablePayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
 input CreatePersonInput {
   \\"\\"\\"
@@ -639,6 +674,54 @@ type DeleteMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1501,6 +1584,14 @@ type Mutation {
     input: CreateMyTableInput!
   ): CreateMyTablePayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
   createPerson(
     \\"\\"\\"
@@ -1588,6 +1679,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteMyTableByIdInput!
   ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
   deletePerson(
@@ -1881,6 +1988,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateMyTableByIdInput!
   ): UpdateMyTablePayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
   updatePerson(
@@ -2492,6 +2617,97 @@ scalar NotNullTimestamp
 
 scalar NotNullUrl
 
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord!
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
   \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
@@ -3093,6 +3309,35 @@ type Query implements Node {
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -3393,6 +3638,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
 
   \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
   person(
@@ -3788,6 +4042,63 @@ type UpdateMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
@@ -1561,6 +1561,79 @@ scalar NotNullTimestamp
 
 scalar NotNullUrl
 
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord!
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
   \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
@@ -2087,6 +2160,35 @@ type Query implements Node {
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -2385,6 +2487,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
 
   \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
   person(

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -2298,6 +2298,41 @@ type CreateNoPrimaryKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Patch\` mutation.\\"\\"\\"
 input CreatePatchInput {
   \\"\\"\\"
@@ -3221,6 +3256,54 @@ type DeleteNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -4946,6 +5029,14 @@ type Mutation {
     input: CreateNoPrimaryKeyInput!
   ): CreateNoPrimaryKeyPayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Patch\`.\\"\\"\\"
   createPatch(
     \\"\\"\\"
@@ -5161,6 +5252,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteNoPrimaryKeyByIdInput!
   ): DeleteNoPrimaryKeyPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Patch\` using its globally unique id.\\"\\"\\"
   deletePatch(
@@ -5709,6 +5816,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateNoPrimaryKeyByIdInput!
   ): UpdateNoPrimaryKeyPayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Patch\` using its globally unique id and a patch.\\"\\"\\"
   updatePatch(
@@ -6701,6 +6826,97 @@ enum NoPrimaryKeysOrderBy {
 scalar NotNullTimestamp
 
 scalar NotNullUrl
+
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
 
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
@@ -7784,6 +8000,35 @@ type Query implements Node {
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Patch\`.\\"\\"\\"
   allPatches(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -8420,6 +8665,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
   optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
   optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
@@ -10044,6 +10298,63 @@ type UpdateNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
@@ -350,6 +350,41 @@ type CreateMyTablePayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
 input CreatePersonInput {
   \\"\\"\\"
@@ -639,6 +674,54 @@ type DeleteMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordByRowId\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByRowIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  rowId: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  id: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1507,6 +1590,14 @@ type Mutation {
     input: CreateMyTableInput!
   ): CreateMyTablePayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
   createPerson(
     \\"\\"\\"
@@ -1594,6 +1685,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteMyTableByRowIdInput!
   ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordByRowId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByRowIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
   deletePerson(
@@ -1882,6 +1989,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateMyTableByRowIdInput!
   ): UpdateMyTablePayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordByRowId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByRowIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
   updatePerson(
@@ -2492,6 +2617,96 @@ scalar NotNullTimestamp
 
 scalar NotNullUrl
 
+type NullTestRecord implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  id: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+  rowId: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`rowId\` field.\\"\\"\\"
+  rowId: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+  rowId: Int
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+  rowId: Int
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord!
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
   \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
@@ -3072,6 +3287,35 @@ type Query implements Node {
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -3370,6 +3614,15 @@ type Query implements Node {
     \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
     id: ID!
   ): Node
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    id: ID!
+  ): NullTestRecord
+  nullTestRecordByRowId(rowId: Int!): NullTestRecord
 
   \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
   person(
@@ -3770,6 +4023,63 @@ type UpdateMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordByRowId\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByRowIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+  rowId: Int!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  id: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -350,6 +350,41 @@ type CreateMyTablePayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
 input CreatePersonInput {
   \\"\\"\\"
@@ -639,6 +674,54 @@ type DeleteMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1509,6 +1592,14 @@ type Mutation {
     input: CreateMyTableInput!
   ): CreateMyTablePayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
   createPerson(
     \\"\\"\\"
@@ -1596,6 +1687,22 @@ type Mutation {
     \\"\\"\\"
     input: DeleteMyTableByIdInput!
   ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
   deletePerson(
@@ -1884,6 +1991,24 @@ type Mutation {
     \\"\\"\\"
     input: UpdateMyTableByIdInput!
   ): UpdateMyTablePayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
   updatePerson(
@@ -2494,6 +2619,97 @@ interface Node {
 scalar NotNullTimestamp
 
 scalar NotNullUrl
+
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord!
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
 
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
@@ -3206,6 +3422,52 @@ type Query implements Node {
     orderBy: [MyTablesOrderBy!]
   ): [MyTable!]
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
+  \\"\\"\\"Reads a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecordsList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!]
+  ): [NullTestRecord!]
+
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   allPeople(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -3615,6 +3877,15 @@ type Query implements Node {
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
   \\"\\"\\"
   nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
 
   \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
   person(
@@ -4032,6 +4303,63 @@ type UpdateMyTablePayload {
     \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
     orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
@@ -978,6 +978,41 @@ type CreateNoPrimaryKeyPayload {
   query: Query
 }
 
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
 \\"\\"\\"All input for the create \`Patch\` mutation.\\"\\"\\"
 input CreatePatchInput {
   \\"\\"\\"
@@ -1812,6 +1847,40 @@ type DeleteNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -3368,6 +3437,14 @@ type Mutation {
     input: CreateNoPrimaryKeyInput!
   ): CreateNoPrimaryKeyPayload
 
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
   \\"\\"\\"Creates a single \`Patch\`.\\"\\"\\"
   createPatch(
     \\"\\"\\"
@@ -3535,6 +3612,14 @@ type Mutation {
     \\"\\"\\"
     input: DeleteNoPrimaryKeyByIdInput!
   ): DeleteNoPrimaryKeyPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
 
   \\"\\"\\"Deletes a single \`Patch\` using a unique key.\\"\\"\\"
   deletePatchById(
@@ -3943,6 +4028,14 @@ type Mutation {
     \\"\\"\\"
     input: UpdateNoPrimaryKeyByIdInput!
   ): UpdateNoPrimaryKeyPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
 
   \\"\\"\\"Updates a single \`Patch\` using a unique key and a patch.\\"\\"\\"
   updatePatchById(
@@ -4822,6 +4915,92 @@ enum NoPrimaryKeysOrderBy {
 scalar NotNullTimestamp
 
 scalar NotNullUrl
+
+type NullTestRecord {
+  id: Int!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A connection to a list of \`NullTestRecord\` values.\\"\\"\\"
+type NullTestRecordsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`NullTestRecord\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [NullTestRecordsEdge!]!
+
+  \\"\\"\\"A list of \`NullTestRecord\` objects.\\"\\"\\"
+  nodes: [NullTestRecord]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"
+  The count of *all* \`NullTestRecord\` you could get from the connection.
+  \\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
 
 \\"\\"\\"Information about pagination in a connection.\\"\\"\\"
 type PageInfo {
@@ -5885,6 +6064,35 @@ type Query {
     orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
   ): NonUpdatableViewsConnection
 
+  \\"\\"\\"Reads and enables pagination through a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecords(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsConnection
+
   \\"\\"\\"Reads and enables pagination through a set of \`Patch\`.\\"\\"\\"
   allPatches(
     \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
@@ -6470,6 +6678,7 @@ type Query {
   myTableById(id: Int!): MyTable
   noArgsQuery: Int
   noPrimaryKeyById(id: Int!): NoPrimaryKey
+  nullTestRecordById(id: Int!): NullTestRecord
   optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
   optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
   optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
@@ -7872,6 +8081,44 @@ type UpdateNoPrimaryKeyPayload {
     \\"\\"\\"The method to use when ordering \`NoPrimaryKey\`.\\"\\"\\"
     orderBy: [NoPrimaryKeysOrderBy!] = [NATURAL]
   ): NoPrimaryKeysEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -98,7 +98,8 @@ insert into b.types values (
 insert into c.edge_case values
   (default, 20, 1),
   (true, null, 2),
-  (false, -512, 3);
+  (false, -512, 3),
+  (default, null, 4);
 
 insert into a.similar_table_1 (id, col1, col2, col3) values
   (1, null, 6, 3),
@@ -128,6 +129,13 @@ insert into c.my_table(id, json_data) values
   (3, '{"stringField":"notTest"}');
 
 alter sequence c.my_table_id_seq restart with 10;
+
+insert into c.null_test_record (id, nullable_text, nullable_int, non_null_text) values
+  (1, 'Hello', 99, 'World'),
+  (2, null, 98, 'Ninety eight'),
+  (3, null, null, 'Ninety seven'),
+  (4, 'Hey', null, 'Ninety six'),
+  (5, 'Hey', 95, 'Ninety five');
 
 -- Begin tests for smart comments
 

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -470,6 +470,14 @@ create table c.issue756 (
   id serial primary key,
   ts c.not_null_timestamp
 );
+
+create table c.null_test_record (
+  id serial primary key,
+  nullable_text text,
+  nullable_int int,
+  non_null_text text not null
+);
+
 create function c.issue756_mutation() returns c.issue756 as $$
 begin
   return null;


### PR DESCRIPTION
Fixes #404 

Requires `--subscriptions` to be enabled to force pulling down identifiers.

V5 will mandate that primary keys are selectable.