### PR TITLE
 fix(simple): don't add edges to mutation payloads when simpleCollections only

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -2,7 +2,14 @@
 import type { Plugin } from "graphile-build";
 import isString from "lodash/isString";
 
-export default (function PgMutationPayloadEdgePlugin(builder) {
+export default (function PgMutationPayloadEdgePlugin(
+  builder,
+  { pgSimpleCollections, disableIssue397Fix }
+) {
+  const hasConnections = pgSimpleCollections !== "only";
+  if (!hasConnections && !disableIssue397Fix) {
+    return null;
+  }
   builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
     const {
       extend,

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -4600,15 +4600,6 @@ input CompoundKeyPatch {
   personId2: Int
 }
 
-\\"\\"\\"A \`CompoundKey\` edge in the connection.\\"\\"\\"
-type CompoundKeysEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
-  node: CompoundKey!
-}
-
 \\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
 enum CompoundKeysOrderBy {
   EXTRA_ASC
@@ -4663,12 +4654,6 @@ type CreateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was created by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
-  compoundKeyEdge(
-    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
-    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
-  ): CompoundKeysEdge
-
   \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
   personByPersonId1: Person
 
@@ -4704,12 +4689,6 @@ type CreateEdgeCasePayload {
   \\"\\"\\"The \`EdgeCase\` that was created by this mutation.\\"\\"\\"
   edgeCase: EdgeCase
 
-  \\"\\"\\"An edge for our \`EdgeCase\`. May be used by Relay 1.\\"\\"\\"
-  edgeCaseEdge(
-    \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
-    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
-  ): EdgeCasesEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -4739,12 +4718,6 @@ type CreateIssue756Payload {
   \\"\\"\\"The \`Issue756\` that was created by this mutation.\\"\\"\\"
   issue756: Issue756
 
-  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
-  issue756Edge(
-    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
-    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
-  ): Issue756SEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -4773,12 +4746,6 @@ type CreateLeftArmPayload {
 
   \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
   leftArm: LeftArm
-
-  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
-  leftArmEdge(
-    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
-    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): LeftArmsEdge
 
   \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
   personByPersonId: Person
@@ -4812,12 +4779,6 @@ type CreateMyTablePayload {
   \\"\\"\\"The \`MyTable\` that was created by this mutation.\\"\\"\\"
   myTable: MyTable
 
-  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
-  myTableEdge(
-    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
-    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
-  ): MyTablesEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -4847,12 +4808,6 @@ type CreateNullTestRecordPayload {
   \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
   nullTestRecord: NullTestRecord
 
-  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
-  nullTestRecordEdge(
-    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
-    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): NullTestRecordsEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -4881,12 +4836,6 @@ type CreatePersonPayload {
 
   \\"\\"\\"The \`Person\` that was created by this mutation.\\"\\"\\"
   person: Person
-
-  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
-  personEdge(
-    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PeopleEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -4920,20 +4869,11 @@ type CreatePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
   personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
-  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
-  personSecretEdge(
-    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
-    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
   query: Query
 }
-
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
-scalar Cursor
 
 \\"\\"\\"
 A point in time as described by the [ISO
@@ -4978,12 +4918,6 @@ type DeleteCompoundKeyPayload {
 
   \\"\\"\\"The \`CompoundKey\` that was deleted by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
-
-  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
-  compoundKeyEdge(
-    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
-    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
-  ): CompoundKeysEdge
   deletedCompoundKeyId: ID
 
   \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
@@ -5033,12 +4967,6 @@ type DeleteIssue756Payload {
 
   \\"\\"\\"The \`Issue756\` that was deleted by this mutation.\\"\\"\\"
   issue756: Issue756
-
-  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
-  issue756Edge(
-    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
-    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
-  ): Issue756SEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -5092,12 +5020,6 @@ type DeleteLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
-  leftArmEdge(
-    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
-    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): LeftArmsEdge
-
   \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
   personByPersonId: Person
 
@@ -5143,12 +5065,6 @@ type DeleteMyTablePayload {
   \\"\\"\\"The \`MyTable\` that was deleted by this mutation.\\"\\"\\"
   myTable: MyTable
 
-  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
-  myTableEdge(
-    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
-    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
-  ): MyTablesEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -5190,12 +5106,6 @@ type DeleteNullTestRecordPayload {
 
   \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
   nullTestRecord: NullTestRecord
-
-  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
-  nullTestRecordEdge(
-    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
-    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -5251,12 +5161,6 @@ type DeletePersonPayload {
   \\"\\"\\"The \`Person\` that was deleted by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
-  personEdge(
-    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PeopleEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -5302,12 +5206,6 @@ type DeletePersonSecretPayload {
   \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
   personSecret: PersonSecret
 
-  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
-  personSecretEdge(
-    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
-    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -5341,15 +5239,6 @@ input EdgeCaseInput {
   notNullHasDefault: Boolean
   rowId: Int
   wontCastEasy: Int
-}
-
-\\"\\"\\"A \`EdgeCase\` edge in the connection.\\"\\"\\"
-type EdgeCasesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
-  node: EdgeCase!
 }
 
 \\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
@@ -5552,12 +5441,6 @@ type Issue756MutationPayload {
   clientMutationId: String
   issue756: Issue756
 
-  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
-  issue756Edge(
-    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
-    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
-  ): Issue756SEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -5570,15 +5453,6 @@ Represents an update to a \`Issue756\`. Fields that are set will be updated.
 input Issue756Patch {
   id: Int
   ts: NotNullTimestamp
-}
-
-\\"\\"\\"A \`Issue756\` edge in the connection.\\"\\"\\"
-type Issue756SEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`Issue756\` at the end of the edge.\\"\\"\\"
-  node: Issue756!
 }
 
 \\"\\"\\"All input for the \`issue756SetMutation\` mutation.\\"\\"\\"
@@ -5597,12 +5471,6 @@ type Issue756SetMutationPayload {
   unchanged and unused. May be used by a client to track mutations.
   \\"\\"\\"
   clientMutationId: String
-
-  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
-  issue756Edge(
-    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
-    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
-  ): Issue756SEdge
   issue756S: [Issue756]
 
   \\"\\"\\"
@@ -5794,12 +5662,6 @@ type LeftArmIdentityPayload {
   clientMutationId: String
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
-  leftArmEdge(
-    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
-    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): LeftArmsEdge
-
   \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
   personByPersonId: Person
 
@@ -5825,15 +5687,6 @@ input LeftArmPatch {
   lengthInMetres: Float
   mood: String
   personId: Int
-}
-
-\\"\\"\\"A \`LeftArm\` edge in the connection.\\"\\"\\"
-type LeftArmsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
-  node: LeftArm!
 }
 
 \\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
@@ -6662,12 +6515,6 @@ type MutationOutTablePayload {
   clientMutationId: String
   person: Person
 
-  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
-  personEdge(
-    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PeopleEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -6691,12 +6538,6 @@ type MutationOutTableSetofPayload {
   \\"\\"\\"
   clientMutationId: String
   people: [Person]
-
-  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
-  personEdge(
-    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PeopleEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -6850,15 +6691,6 @@ input MyTablePatch {
   jsonData: JSON
 }
 
-\\"\\"\\"A \`MyTable\` edge in the connection.\\"\\"\\"
-type MyTablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`MyTable\` at the end of the edge.\\"\\"\\"
-  node: MyTable!
-}
-
 \\"\\"\\"Methods to use when ordering \`MyTable\`.\\"\\"\\"
 enum MyTablesOrderBy {
   ID_ASC
@@ -6954,15 +6786,6 @@ input NullTestRecordPatch {
   nullableText: String
 }
 
-\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
-type NullTestRecordsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
-  node: NullTestRecord!
-}
-
 \\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
 enum NullTestRecordsOrderBy {
   ID_ASC
@@ -6976,15 +6799,6 @@ enum NullTestRecordsOrderBy {
   NULLABLE_TEXT_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
-}
-
-\\"\\"\\"A \`Person\` edge in the connection.\\"\\"\\"
-type PeopleEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
-  node: Person!
 }
 
 \\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
@@ -7237,15 +7051,6 @@ input PersonSecretPatch {
 
   \\"\\"\\"A secret held by the associated Person\\"\\"\\"
   secret: String
-}
-
-\\"\\"\\"A \`PersonSecret\` edge in the connection.\\"\\"\\"
-type PersonSecretsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
-  cursor: Cursor
-
-  \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
-  node: PersonSecret!
 }
 
 \\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
@@ -7643,12 +7448,6 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
-  personEdge(
-    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PeopleEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -7735,12 +7534,6 @@ type UpdateCompoundKeyPayload {
   \\"\\"\\"The \`CompoundKey\` that was updated by this mutation.\\"\\"\\"
   compoundKey: CompoundKey
 
-  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
-  compoundKeyEdge(
-    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
-    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
-  ): CompoundKeysEdge
-
   \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
   personByPersonId1: Person
 
@@ -7797,12 +7590,6 @@ type UpdateIssue756Payload {
 
   \\"\\"\\"The \`Issue756\` that was updated by this mutation.\\"\\"\\"
   issue756: Issue756
-
-  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
-  issue756Edge(
-    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
-    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
-  ): Issue756SEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -7870,12 +7657,6 @@ type UpdateLeftArmPayload {
   \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
   leftArm: LeftArm
 
-  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
-  leftArmEdge(
-    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
-    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): LeftArmsEdge
-
   \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
   personByPersonId: Person
 
@@ -7930,12 +7711,6 @@ type UpdateMyTablePayload {
   \\"\\"\\"The \`MyTable\` that was updated by this mutation.\\"\\"\\"
   myTable: MyTable
 
-  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
-  myTableEdge(
-    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
-    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
-  ): MyTablesEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -7986,12 +7761,6 @@ type UpdateNullTestRecordPayload {
 
   \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
   nullTestRecord: NullTestRecord
-
-  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
-  nullTestRecordEdge(
-    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
-    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): NullTestRecordsEdge
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -8061,12 +7830,6 @@ type UpdatePersonPayload {
   \\"\\"\\"The \`Person\` that was updated by this mutation.\\"\\"\\"
   person: Person
 
-  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
-  personEdge(
-    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PeopleEdge
-
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -8120,12 +7883,6 @@ type UpdatePersonSecretPayload {
 
   \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
   personSecret: PersonSecret
-
-  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
-  personSecretEdge(
-    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
-    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
 
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`prints a schema with simple collections 1`] = `
+exports[`prints a schema with both simple collections and relay connections 1`] = `
 "enum AnEnum {
   _ASTERISK_BAR_
   _ASTERISK_BAZ_ASTERISK_
@@ -3941,6 +3941,3638 @@ type Query implements Node {
     \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  tableSetQueryList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!]
+  ): [Person]
+  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+}
+
+\\"\\"\\"The return type of our \`queryOutputTwoRows\` query.\\"\\"\\"
+type QueryOutputTwoRowsRecord {
+  leftArm: LeftArm
+  post: Post
+  txt: String
+}
+
+\\"\\"\\"All input for the \`tableMutation\` mutation.\\"\\"\\"
+input TableMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int
+}
+
+\\"\\"\\"The output of our \`tableMutation\` mutation.\\"\\"\\"
+type TableMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  post: Post
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`tableSetMutation\` mutation.\\"\\"\\"
+input TableSetMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`tableSetMutation\` mutation.\\"\\"\\"
+type TableSetMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  people: [Person]
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`typesMutation\` mutation.\\"\\"\\"
+input TypesMutationInput {
+  a: BigInt!
+  b: Boolean!
+  c: String!
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  d: [Int]!
+  e: JSON!
+  f: FloatRangeInput!
+}
+
+\\"\\"\\"The output of our \`typesMutation\` mutation.\\"\\"\\"
+type TypesMutationPayload {
+  boolean: Boolean
+
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+All input for the \`updateCompoundKeyByPersonId1AndPersonId2\` mutation.
+\\"\\"\\"
+input UpdateCompoundKeyByPersonId1AndPersonId2Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  \\"\\"\\"
+  compoundKeyPatch: CompoundKeyPatch!
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"All input for the \`updateCompoundKey\` mutation.\\"\\"\\"
+input UpdateCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  \\"\\"\\"
+  compoundKeyPatch: CompoundKeyPatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`CompoundKey\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`CompoundKey\` mutation.\\"\\"\\"
+type UpdateCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was updated by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateIssue756ById\` mutation.\\"\\"\\"
+input UpdateIssue756ByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Issue756\` being updated.
+  \\"\\"\\"
+  issue756Patch: Issue756Patch!
+}
+
+\\"\\"\\"All input for the \`updateIssue756\` mutation.\\"\\"\\"
+input UpdateIssue756Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Issue756\` being updated.
+  \\"\\"\\"
+  issue756Patch: Issue756Patch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Issue756\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`Issue756\` mutation.\\"\\"\\"
+type UpdateIssue756Payload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Issue756\` that was updated by this mutation.\\"\\"\\"
+  issue756: Issue756
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateLeftArmById\` mutation.\\"\\"\\"
+input UpdateLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+}
+
+\\"\\"\\"All input for the \`updateLeftArmByPersonId\` mutation.\\"\\"\\"
+input UpdateLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`updateLeftArm\` mutation.\\"\\"\\"
+input UpdateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`LeftArm\` being updated.
+  \\"\\"\\"
+  leftArmPatch: LeftArmPatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`LeftArm\` mutation.\\"\\"\\"
+type UpdateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was updated by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateMyTableById\` mutation.\\"\\"\\"
+input UpdateMyTableByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`MyTable\` being updated.
+  \\"\\"\\"
+  myTablePatch: MyTablePatch!
+}
+
+\\"\\"\\"All input for the \`updateMyTable\` mutation.\\"\\"\\"
+input UpdateMyTableInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`MyTable\` being updated.
+  \\"\\"\\"
+  myTablePatch: MyTablePatch!
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`MyTable\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our update \`MyTable\` mutation.\\"\\"\\"
+type UpdateMyTablePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`MyTable\` that was updated by this mutation.\\"\\"\\"
+  myTable: MyTable
+
+  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
+  myTableEdge(
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecordById\` mutation.\\"\\"\\"
+input UpdateNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"All input for the \`updateNullTestRecord\` mutation.\\"\\"\\"
+input UpdateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`NullTestRecord\` being updated.
+  \\"\\"\\"
+  nullTestRecordPatch: NullTestRecordPatch!
+}
+
+\\"\\"\\"The output of our update \`NullTestRecord\` mutation.\\"\\"\\"
+type UpdateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was updated by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonByEmail\` mutation.\\"\\"\\"
+input UpdatePersonByEmailInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  email: Email!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonById\` mutation.\\"\\"\\"
+input UpdatePersonByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"All input for the \`updatePerson\` mutation.\\"\\"\\"
+input UpdatePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Person\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \\"\\"\\"
+  personPatch: PersonPatch!
+}
+
+\\"\\"\\"The output of our update \`Person\` mutation.\\"\\"\\"
+type UpdatePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` that was updated by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`updatePersonSecretByPersonId\` mutation.\\"\\"\\"
+input UpdatePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"All input for the \`updatePersonSecret\` mutation.\\"\\"\\"
+input UpdatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be updated.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"
+  An object where the defined keys will be set on the \`PersonSecret\` being updated.
+  \\"\\"\\"
+  personSecretPatch: PersonSecretPatch!
+}
+
+\\"\\"\\"The output of our update \`PersonSecret\` mutation.\\"\\"\\"
+type UpdatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` this \`PersonSecret\` belongs to.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was updated by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+\\"\\"\\"
+scalar UUID
+
+type WrappedUrl {
+  url: NotNullUrl!
+}
+
+\\"\\"\\"An input for mutations affecting \`WrappedUrl\`\\"\\"\\"
+input WrappedUrlInput {
+  url: NotNullUrl!
+}
+"
+`;
+
+exports[`prints a schema with only simple collections 1`] = `
+"enum AnEnum {
+  _ASTERISK_BAR_
+  _ASTERISK_BAZ_ASTERISK_
+  _FOO_ASTERISK
+  ASTERISK
+  ASTERISK_ASTERISK
+  ASTERISK_ASTERISK_ASTERISK
+  ASTERISK_BAR
+  ASTERISK_BAR_
+  ASTERISK_BAZ_ASTERISK
+  AWAITING
+  DOLLAR
+  FOO_ASTERISK
+  FOO_ASTERISK_
+  GREATER_THAN_OR_EQUAL
+  LIKE
+  PERCENT
+  PUBLISHED
+  REJECTED
+}
+
+\\"\\"\\"
+A signed eight-byte integer. The upper big integer values are greater then the
+max value for a JavaScript number. Therefore all big integers will be output as
+strings and not numbers.
+\\"\\"\\"
+scalar BigInt
+
+enum Color {
+  BLUE
+  GREEN
+  RED
+}
+
+type CompoundKey implements Node {
+  extra: Boolean
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`CompoundKey\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input CompoundKeyCondition {
+  \\"\\"\\"Checks for equality with the object’s \`extra\` field.\\"\\"\\"
+  extra: Boolean
+
+  \\"\\"\\"Checks for equality with the object’s \`personId1\` field.\\"\\"\\"
+  personId1: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`personId2\` field.\\"\\"\\"
+  personId2: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`CompoundKey\`\\"\\"\\"
+input CompoundKeyInput {
+  extra: Boolean
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"
+Represents an update to a \`CompoundKey\`. Fields that are set will be updated.
+\\"\\"\\"
+input CompoundKeyPatch {
+  extra: Boolean
+  personId1: Int
+  personId2: Int
+}
+
+\\"\\"\\"A \`CompoundKey\` edge in the connection.\\"\\"\\"
+type CompoundKeysEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`CompoundKey\` at the end of the edge.\\"\\"\\"
+  node: CompoundKey!
+}
+
+\\"\\"\\"Methods to use when ordering \`CompoundKey\`.\\"\\"\\"
+enum CompoundKeysOrderBy {
+  EXTRA_ASC
+  EXTRA_DESC
+  NATURAL
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"Awesome feature!\\"\\"\\"
+type CompoundType {
+  a: Int
+  b: String
+  c: Color
+  computedField: Int
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: Interval
+}
+
+type Comptype {
+  isOptimised: Boolean
+  schedule: Datetime
+}
+
+\\"\\"\\"All input for the create \`CompoundKey\` mutation.\\"\\"\\"
+input CreateCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` to be created by this mutation.\\"\\"\\"
+  compoundKey: CompoundKeyInput!
+}
+
+\\"\\"\\"The output of our create \`CompoundKey\` mutation.\\"\\"\\"
+type CreateCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was created by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`EdgeCase\` mutation.\\"\\"\\"
+input CreateEdgeCaseInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`EdgeCase\` to be created by this mutation.\\"\\"\\"
+  edgeCase: EdgeCaseInput!
+}
+
+\\"\\"\\"The output of our create \`EdgeCase\` mutation.\\"\\"\\"
+type CreateEdgeCasePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`EdgeCase\` that was created by this mutation.\\"\\"\\"
+  edgeCase: EdgeCase
+
+  \\"\\"\\"An edge for our \`EdgeCase\`. May be used by Relay 1.\\"\\"\\"
+  edgeCaseEdge(
+    \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
+  ): EdgeCasesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`Issue756\` mutation.\\"\\"\\"
+input CreateIssue756Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Issue756\` to be created by this mutation.\\"\\"\\"
+  issue756: Issue756Input!
+}
+
+\\"\\"\\"The output of our create \`Issue756\` mutation.\\"\\"\\"
+type CreateIssue756Payload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Issue756\` that was created by this mutation.\\"\\"\\"
+  issue756: Issue756
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`LeftArm\` mutation.\\"\\"\\"
+input CreateLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` to be created by this mutation.\\"\\"\\"
+  leftArm: LeftArmInput!
+}
+
+\\"\\"\\"The output of our create \`LeftArm\` mutation.\\"\\"\\"
+type CreateLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`LeftArm\` that was created by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`MyTable\` mutation.\\"\\"\\"
+input CreateMyTableInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`MyTable\` to be created by this mutation.\\"\\"\\"
+  myTable: MyTableInput!
+}
+
+\\"\\"\\"The output of our create \`MyTable\` mutation.\\"\\"\\"
+type CreateMyTablePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`MyTable\` that was created by this mutation.\\"\\"\\"
+  myTable: MyTable
+
+  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
+  myTableEdge(
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`NullTestRecord\` mutation.\\"\\"\\"
+input CreateNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` to be created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecordInput!
+}
+
+\\"\\"\\"The output of our create \`NullTestRecord\` mutation.\\"\\"\\"
+type CreateNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`NullTestRecord\` that was created by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`Person\` mutation.\\"\\"\\"
+input CreatePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` to be created by this mutation.\\"\\"\\"
+  person: PersonInput!
+}
+
+\\"\\"\\"The output of our create \`Person\` mutation.\\"\\"\\"
+type CreatePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` that was created by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the create \`PersonSecret\` mutation.\\"\\"\\"
+input CreatePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`PersonSecret\` to be created by this mutation.\\"\\"\\"
+  personSecret: PersonSecretInput!
+}
+
+\\"\\"\\"The output of our create \`PersonSecret\` mutation.\\"\\"\\"
+type CreatePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`Person\` this \`PersonSecret\` belongs to.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was created by this mutation.\\"\\"\\"
+  personSecret: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+scalar Cursor
+
+\\"\\"\\"
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+\\"\\"\\"
+scalar Datetime
+
+\\"\\"\\"
+All input for the \`deleteCompoundKeyByPersonId1AndPersonId2\` mutation.
+\\"\\"\\"
+input DeleteCompoundKeyByPersonId1AndPersonId2Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId1: Int!
+  personId2: Int!
+}
+
+\\"\\"\\"All input for the \`deleteCompoundKey\` mutation.\\"\\"\\"
+input DeleteCompoundKeyInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`CompoundKey\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`CompoundKey\` mutation.\\"\\"\\"
+type DeleteCompoundKeyPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The \`CompoundKey\` that was deleted by this mutation.\\"\\"\\"
+  compoundKey: CompoundKey
+
+  \\"\\"\\"An edge for our \`CompoundKey\`. May be used by Relay 1.\\"\\"\\"
+  compoundKeyEdge(
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+  deletedCompoundKeyId: ID
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId1: Person
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\\"\\"\\"
+  personByPersonId2: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteIssue756ById\` mutation.\\"\\"\\"
+input DeleteIssue756ByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteIssue756\` mutation.\\"\\"\\"
+input DeleteIssue756Input {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Issue756\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`Issue756\` mutation.\\"\\"\\"
+type DeleteIssue756Payload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedIssue756Id: ID
+
+  \\"\\"\\"The \`Issue756\` that was deleted by this mutation.\\"\\"\\"
+  issue756: Issue756
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmById\` mutation.\\"\\"\\"
+input DeleteLeftArmByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArmByPersonId\` mutation.\\"\\"\\"
+input DeleteLeftArmByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deleteLeftArm\` mutation.\\"\\"\\"
+input DeleteLeftArmInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`LeftArm\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`LeftArm\` mutation.\\"\\"\\"
+type DeleteLeftArmPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedLeftArmId: ID
+
+  \\"\\"\\"The \`LeftArm\` that was deleted by this mutation.\\"\\"\\"
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteMyTableById\` mutation.\\"\\"\\"
+input DeleteMyTableByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteMyTable\` mutation.\\"\\"\\"
+input DeleteMyTableInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`MyTable\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`MyTable\` mutation.\\"\\"\\"
+type DeleteMyTablePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedMyTableId: ID
+
+  \\"\\"\\"The \`MyTable\` that was deleted by this mutation.\\"\\"\\"
+  myTable: MyTable
+
+  \\"\\"\\"An edge for our \`MyTable\`. May be used by Relay 1.\\"\\"\\"
+  myTableEdge(
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MyTablesEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecordById\` mutation.\\"\\"\\"
+input DeleteNullTestRecordByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deleteNullTestRecord\` mutation.\\"\\"\\"
+input DeleteNullTestRecordInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`NullTestRecord\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`NullTestRecord\` mutation.\\"\\"\\"
+type DeleteNullTestRecordPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedNullTestRecordId: ID
+
+  \\"\\"\\"The \`NullTestRecord\` that was deleted by this mutation.\\"\\"\\"
+  nullTestRecord: NullTestRecord
+
+  \\"\\"\\"An edge for our \`NullTestRecord\`. May be used by Relay 1.\\"\\"\\"
+  nullTestRecordEdge(
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): NullTestRecordsEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonByEmail\` mutation.\\"\\"\\"
+input DeletePersonByEmailInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  email: Email!
+}
+
+\\"\\"\\"All input for the \`deletePersonById\` mutation.\\"\\"\\"
+input DeletePersonByIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int!
+}
+
+\\"\\"\\"All input for the \`deletePerson\` mutation.\\"\\"\\"
+input DeletePersonInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`Person\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`Person\` mutation.\\"\\"\\"
+type DeletePersonPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonId: ID
+
+  \\"\\"\\"The \`Person\` that was deleted by this mutation.\\"\\"\\"
+  person: Person
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`deletePersonSecretByPersonId\` mutation.\\"\\"\\"
+input DeletePersonSecretByPersonIdInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  personId: Int!
+}
+
+\\"\\"\\"All input for the \`deletePersonSecret\` mutation.\\"\\"\\"
+input DeletePersonSecretInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  The globally unique \`ID\` which will identify a single \`PersonSecret\` to be deleted.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"The output of our delete \`PersonSecret\` mutation.\\"\\"\\"
+type DeletePersonSecretPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  deletedPersonSecretId: ID
+
+  \\"\\"\\"The \`Person\` this \`PersonSecret\` belongs to.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"The \`PersonSecret\` that was deleted by this mutation.\\"\\"\\"
+  personSecret: PersonSecret
+
+  \\"\\"\\"An edge for our \`PersonSecret\`. May be used by Relay 1.\\"\\"\\"
+  personSecretEdge(
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonSecretsEdge @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+type EdgeCase {
+  computed: String
+  notNullHasDefault: Boolean!
+  rowId: Int
+  wontCastEasy: Int
+}
+
+\\"\\"\\"
+A condition to be used against \`EdgeCase\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input EdgeCaseCondition {
+  \\"\\"\\"Checks for equality with the object’s \`notNullHasDefault\` field.\\"\\"\\"
+  notNullHasDefault: Boolean
+
+  \\"\\"\\"Checks for equality with the object’s \`rowId\` field.\\"\\"\\"
+  rowId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`wontCastEasy\` field.\\"\\"\\"
+  wontCastEasy: Int
+}
+
+\\"\\"\\"An input for mutations affecting \`EdgeCase\`\\"\\"\\"
+input EdgeCaseInput {
+  notNullHasDefault: Boolean
+  rowId: Int
+  wontCastEasy: Int
+}
+
+\\"\\"\\"A \`EdgeCase\` edge in the connection.\\"\\"\\"
+type EdgeCasesEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`EdgeCase\` at the end of the edge.\\"\\"\\"
+  node: EdgeCase!
+}
+
+\\"\\"\\"Methods to use when ordering \`EdgeCase\`.\\"\\"\\"
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+}
+
+scalar Email
+
+enum EnumCaps {
+  _0_BAR
+  BAR_FOO
+  BAZ_QUX
+  FOO_BAR
+}
+
+enum EnumWithEmptyString {
+  _EMPTY_
+  ONE
+  TWO
+}
+
+\\"\\"\\"
+The value at one end of a range. A range can either include this value, or not.
+\\"\\"\\"
+input FloatRangeBoundInput {
+  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  inclusive: Boolean!
+
+  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  value: Float!
+}
+
+\\"\\"\\"A range of \`Float\`.\\"\\"\\"
+input FloatRangeInput {
+  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  end: FloatRangeBoundInput
+
+  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  start: FloatRangeBoundInput
+}
+
+\\"\\"\\"The return type of our \`funcOutComplex\` query.\\"\\"\\"
+type FuncOutComplexRecord {
+  x: Int
+  y: CompoundType
+  z: Person
+}
+
+\\"\\"\\"The return type of our \`funcOutComplexSetof\` query.\\"\\"\\"
+type FuncOutComplexSetofRecord {
+  x: Int
+  y: CompoundType
+  z: Person
+}
+
+\\"\\"\\"The return type of our \`funcOutOutCompoundType\` query.\\"\\"\\"
+type FuncOutOutCompoundTypeRecord {
+  o1: Int
+  o2: CompoundType
+}
+
+\\"\\"\\"The return type of our \`funcOutOut\` query.\\"\\"\\"
+type FuncOutOutRecord {
+  firstOut: Int
+  secondOut: String
+}
+
+\\"\\"\\"The return type of our \`funcOutOutSetof\` query.\\"\\"\\"
+type FuncOutOutSetofRecord {
+  o1: Int
+  o2: String
+}
+
+\\"\\"\\"The return type of our \`funcOutOutUnnamed\` query.\\"\\"\\"
+type FuncOutOutUnnamedRecord {
+  arg1: Int
+  arg2: String
+}
+
+\\"\\"\\"The return type of our \`funcOutUnnamedOutOutUnnamed\` query.\\"\\"\\"
+type FuncOutUnnamedOutOutUnnamedRecord {
+  arg1: Int
+  arg3: Int
+  o2: String
+}
+
+\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+type FuncReturnsTableMultiColRecord {
+  col1: Int
+  col2: String
+}
+
+\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+scalar InternetAddress
+
+\\"\\"\\"
+An interval of time that has passed where the smallest distinct unit is a second.
+\\"\\"\\"
+type Interval {
+  \\"\\"\\"A quantity of days.\\"\\"\\"
+  days: Int
+
+  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  hours: Int
+
+  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  minutes: Int
+
+  \\"\\"\\"A quantity of months.\\"\\"\\"
+  months: Int
+
+  \\"\\"\\"
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  \\"\\"\\"
+  seconds: Float
+
+  \\"\\"\\"A quantity of years.\\"\\"\\"
+  years: Int
+}
+
+\\"\\"\\"All input for the \`intSetMutation\` mutation.\\"\\"\\"
+input IntSetMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+\\"\\"\\"The output of our \`intSetMutation\` mutation.\\"\\"\\"
+type IntSetMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  integers: [Int]
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+type Issue756 implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  ts: NotNullTimestamp!
+}
+
+\\"\\"\\"
+A condition to be used against \`Issue756\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input Issue756Condition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`ts\` field.\\"\\"\\"
+  ts: NotNullTimestamp
+}
+
+\\"\\"\\"An input for mutations affecting \`Issue756\`\\"\\"\\"
+input Issue756Input {
+  id: Int
+  ts: NotNullTimestamp
+}
+
+\\"\\"\\"All input for the \`issue756Mutation\` mutation.\\"\\"\\"
+input Issue756MutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`issue756Mutation\` mutation.\\"\\"\\"
+type Issue756MutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  issue756: Issue756
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+Represents an update to a \`Issue756\`. Fields that are set will be updated.
+\\"\\"\\"
+input Issue756Patch {
+  id: Int
+  ts: NotNullTimestamp
+}
+
+\\"\\"\\"A \`Issue756\` edge in the connection.\\"\\"\\"
+type Issue756SEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Issue756\` at the end of the edge.\\"\\"\\"
+  node: Issue756!
+}
+
+\\"\\"\\"All input for the \`issue756SetMutation\` mutation.\\"\\"\\"
+input Issue756SetMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`issue756SetMutation\` mutation.\\"\\"\\"
+type Issue756SetMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"An edge for our \`Issue756\`. May be used by Relay 1.\\"\\"\\"
+  issue756Edge(
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): Issue756SEdge
+  issue756S: [Issue756]
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"Methods to use when ordering \`Issue756\`.\\"\\"\\"
+enum Issue756SOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TS_ASC
+  TS_DESC
+}
+
+\\"\\"\\"
+A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+\\"\\"\\"
+scalar JSON
+
+\\"\\"\\"All input for the \`jsonbIdentityMutation\` mutation.\\"\\"\\"
+input JsonbIdentityMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutation\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonbIdentityMutationPlpgsql\` mutation.\\"\\"\\"
+input JsonbIdentityMutationPlpgsqlInput {
+  _theJson: JSON!
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutationPlpgsql\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPlpgsqlPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonbIdentityMutationPlpgsqlWithDefault\` mutation.\\"\\"\\"
+input JsonbIdentityMutationPlpgsqlWithDefaultInput {
+  _theJson: JSON
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`jsonbIdentityMutationPlpgsqlWithDefault\` mutation.\\"\\"\\"
+type JsonbIdentityMutationPlpgsqlWithDefaultPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`jsonIdentityMutation\` mutation.\\"\\"\\"
+input JsonIdentityMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+}
+
+\\"\\"\\"The output of our \`jsonIdentityMutation\` mutation.\\"\\"\\"
+type JsonIdentityMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  json: JSON
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"
+A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
+\\"\\"\\"
+scalar KeyValueHash
+
+\\"\\"\\"Tracks metadata about the left arms of various people\\"\\"\\"
+type LeftArm implements Node {
+  id: Int!
+  lengthInMetres: Float
+  mood: String!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+}
+
+\\"\\"\\"An input representation of \`LeftArm\` with nullable fields.\\"\\"\\"
+input LeftArmBaseInput {
+  id: Int
+  lengthInMetres: Float
+  mood: String
+  personId: Int
+}
+
+\\"\\"\\"
+A condition to be used against \`LeftArm\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input LeftArmCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`lengthInMetres\` field.\\"\\"\\"
+  lengthInMetres: Float
+
+  \\"\\"\\"Checks for equality with the object’s \`mood\` field.\\"\\"\\"
+  mood: String
+
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+}
+
+\\"\\"\\"All input for the \`leftArmIdentity\` mutation.\\"\\"\\"
+input LeftArmIdentityInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  leftArm: LeftArmBaseInput
+}
+
+\\"\\"\\"The output of our \`leftArmIdentity\` mutation.\\"\\"\\"
+type LeftArmIdentityPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  leftArm: LeftArm
+
+  \\"\\"\\"An edge for our \`LeftArm\`. May be used by Relay 1.\\"\\"\\"
+  leftArmEdge(
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LeftArmsEdge
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`LeftArm\`.\\"\\"\\"
+  personByPersonId: Person
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"An input for mutations affecting \`LeftArm\`\\"\\"\\"
+input LeftArmInput {
+  id: Int
+  lengthInMetres: Float
+  mood: String
+  personId: Int
+}
+
+\\"\\"\\"
+Represents an update to a \`LeftArm\`. Fields that are set will be updated.
+\\"\\"\\"
+input LeftArmPatch {
+  id: Int
+  lengthInMetres: Float
+  mood: String
+  personId: Int
+}
+
+\\"\\"\\"A \`LeftArm\` edge in the connection.\\"\\"\\"
+type LeftArmsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`LeftArm\` at the end of the edge.\\"\\"\\"
+  node: LeftArm!
+}
+
+\\"\\"\\"Methods to use when ordering \`LeftArm\`.\\"\\"\\"
+enum LeftArmsOrderBy {
+  ID_ASC
+  ID_DESC
+  LENGTH_IN_METRES_ASC
+  LENGTH_IN_METRES_DESC
+  MOOD_ASC
+  MOOD_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"
+The root mutation type which contains root level fields which mutate data.
+\\"\\"\\"
+type Mutation {
+  \\"\\"\\"Creates a single \`CompoundKey\`.\\"\\"\\"
+  createCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateCompoundKeyInput!
+  ): CreateCompoundKeyPayload
+
+  \\"\\"\\"Creates a single \`EdgeCase\`.\\"\\"\\"
+  createEdgeCase(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateEdgeCaseInput!
+  ): CreateEdgeCasePayload
+
+  \\"\\"\\"Creates a single \`Issue756\`.\\"\\"\\"
+  createIssue756(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateIssue756Input!
+  ): CreateIssue756Payload
+
+  \\"\\"\\"Creates a single \`LeftArm\`.\\"\\"\\"
+  createLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateLeftArmInput!
+  ): CreateLeftArmPayload
+
+  \\"\\"\\"Creates a single \`MyTable\`.\\"\\"\\"
+  createMyTable(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateMyTableInput!
+  ): CreateMyTablePayload
+
+  \\"\\"\\"Creates a single \`NullTestRecord\`.\\"\\"\\"
+  createNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreateNullTestRecordInput!
+  ): CreateNullTestRecordPayload
+
+  \\"\\"\\"Creates a single \`Person\`.\\"\\"\\"
+  createPerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonInput!
+  ): CreatePersonPayload
+
+  \\"\\"\\"Creates a single \`PersonSecret\`.\\"\\"\\"
+  createPersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: CreatePersonSecretInput!
+  ): CreatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+
+  \\"\\"\\"Deletes a single \`CompoundKey\` using its globally unique id.\\"\\"\\"
+  deleteCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteCompoundKeyInput!
+  ): DeleteCompoundKeyPayload
+
+  \\"\\"\\"Deletes a single \`CompoundKey\` using a unique key.\\"\\"\\"
+  deleteCompoundKeyByPersonId1AndPersonId2(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
+  ): DeleteCompoundKeyPayload
+
+  \\"\\"\\"Deletes a single \`Issue756\` using its globally unique id.\\"\\"\\"
+  deleteIssue756(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteIssue756Input!
+  ): DeleteIssue756Payload
+
+  \\"\\"\\"Deletes a single \`Issue756\` using a unique key.\\"\\"\\"
+  deleteIssue756ById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteIssue756ByIdInput!
+  ): DeleteIssue756Payload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using its globally unique id.\\"\\"\\"
+  deleteLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`LeftArm\` using a unique key.\\"\\"\\"
+  deleteLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteLeftArmByPersonIdInput!
+  ): DeleteLeftArmPayload
+
+  \\"\\"\\"Deletes a single \`MyTable\` using its globally unique id.\\"\\"\\"
+  deleteMyTable(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteMyTableInput!
+  ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`MyTable\` using a unique key.\\"\\"\\"
+  deleteMyTableById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteMyTableByIdInput!
+  ): DeleteMyTablePayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using its globally unique id.\\"\\"\\"
+  deleteNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`NullTestRecord\` using a unique key.\\"\\"\\"
+  deleteNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeleteNullTestRecordByIdInput!
+  ): DeleteNullTestRecordPayload
+
+  \\"\\"\\"Deletes a single \`Person\` using its globally unique id.\\"\\"\\"
+  deletePerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`Person\` using a unique key.\\"\\"\\"
+  deletePersonByEmail(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonByEmailInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`Person\` using a unique key.\\"\\"\\"
+  deletePersonById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonByIdInput!
+  ): DeletePersonPayload
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using its globally unique id.\\"\\"\\"
+  deletePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretInput!
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+
+  \\"\\"\\"Deletes a single \`PersonSecret\` using a unique key.\\"\\"\\"
+  deletePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: DeletePersonSecretByPersonIdInput!
+  ): DeletePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+  intSetMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload
+  issue756Mutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: Issue756MutationInput!
+  ): Issue756MutationPayload
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Issue756\`.\\"\\"\\"
+  issue756SetMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: Issue756SetMutationInput!
+  ): Issue756SetMutationPayload
+  jsonIdentityMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload
+  jsonbIdentityMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationInput!
+  ): JsonbIdentityMutationPayload
+  jsonbIdentityMutationPlpgsql(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationPlpgsqlInput!
+  ): JsonbIdentityMutationPlpgsqlPayload
+  jsonbIdentityMutationPlpgsqlWithDefault(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: JsonbIdentityMutationPlpgsqlWithDefaultInput!
+  ): JsonbIdentityMutationPlpgsqlWithDefaultPayload
+  leftArmIdentity(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: LeftArmIdentityInput!
+  ): LeftArmIdentityPayload
+  mutationInInout(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationInInoutInput!
+  ): MutationInInoutPayload
+  mutationInOut(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationInOutInput!
+  ): MutationInOutPayload
+  mutationOut(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutInput!
+  ): MutationOutPayload
+  mutationOutComplex(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutComplexInput!
+  ): MutationOutComplexPayload
+  mutationOutComplexSetof(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutComplexSetofInput!
+  ): MutationOutComplexSetofPayload
+  mutationOutOut(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutOutInput!
+  ): MutationOutOutPayload
+  mutationOutOutCompoundType(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutOutCompoundTypeInput!
+  ): MutationOutOutCompoundTypePayload
+  mutationOutOutSetof(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutOutSetofInput!
+  ): MutationOutOutSetofPayload
+  mutationOutOutUnnamed(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutOutUnnamedInput!
+  ): MutationOutOutUnnamedPayload
+  mutationOutSetof(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutSetofInput!
+  ): MutationOutSetofPayload
+  mutationOutTable(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutTableInput!
+  ): MutationOutTablePayload
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  mutationOutTableSetof(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutTableSetofInput!
+  ): MutationOutTableSetofPayload
+  mutationOutUnnamed(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutUnnamedInput!
+  ): MutationOutUnnamedPayload
+  mutationOutUnnamedOutOutUnnamed(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationOutUnnamedOutOutUnnamedInput!
+  ): MutationOutUnnamedOutOutUnnamedPayload
+  mutationReturnsTableMultiCol(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationReturnsTableMultiColInput!
+  ): MutationReturnsTableMultiColPayload
+  mutationReturnsTableOneCol(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: MutationReturnsTableOneColInput!
+  ): MutationReturnsTableOneColPayload
+  noArgsMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload
+  tableMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TableMutationInput!
+  ): TableMutationPayload
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  tableSetMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload
+  typesMutation(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: TypesMutationInput!
+  ): TypesMutationPayload
+
+  \\"\\"\\"
+  Updates a single \`CompoundKey\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateCompoundKey(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateCompoundKeyInput!
+  ): UpdateCompoundKeyPayload
+
+  \\"\\"\\"Updates a single \`CompoundKey\` using a unique key and a patch.\\"\\"\\"
+  updateCompoundKeyByPersonId1AndPersonId2(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
+  ): UpdateCompoundKeyPayload
+
+  \\"\\"\\"Updates a single \`Issue756\` using its globally unique id and a patch.\\"\\"\\"
+  updateIssue756(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateIssue756Input!
+  ): UpdateIssue756Payload
+
+  \\"\\"\\"Updates a single \`Issue756\` using a unique key and a patch.\\"\\"\\"
+  updateIssue756ById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateIssue756ByIdInput!
+  ): UpdateIssue756Payload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using its globally unique id and a patch.\\"\\"\\"
+  updateLeftArm(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`LeftArm\` using a unique key and a patch.\\"\\"\\"
+  updateLeftArmByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateLeftArmByPersonIdInput!
+  ): UpdateLeftArmPayload
+
+  \\"\\"\\"Updates a single \`MyTable\` using its globally unique id and a patch.\\"\\"\\"
+  updateMyTable(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateMyTableInput!
+  ): UpdateMyTablePayload
+
+  \\"\\"\\"Updates a single \`MyTable\` using a unique key and a patch.\\"\\"\\"
+  updateMyTableById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateMyTableByIdInput!
+  ): UpdateMyTablePayload
+
+  \\"\\"\\"
+  Updates a single \`NullTestRecord\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updateNullTestRecord(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`NullTestRecord\` using a unique key and a patch.\\"\\"\\"
+  updateNullTestRecordById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdateNullTestRecordByIdInput!
+  ): UpdateNullTestRecordPayload
+
+  \\"\\"\\"Updates a single \`Person\` using its globally unique id and a patch.\\"\\"\\"
+  updatePerson(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"Updates a single \`Person\` using a unique key and a patch.\\"\\"\\"
+  updatePersonByEmail(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonByEmailInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"Updates a single \`Person\` using a unique key and a patch.\\"\\"\\"
+  updatePersonById(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonByIdInput!
+  ): UpdatePersonPayload
+
+  \\"\\"\\"
+  Updates a single \`PersonSecret\` using its globally unique id and a patch.
+  \\"\\"\\"
+  updatePersonSecret(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretInput!
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+
+  \\"\\"\\"Updates a single \`PersonSecret\` using a unique key and a patch.\\"\\"\\"
+  updatePersonSecretByPersonId(
+    \\"\\"\\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \\"\\"\\"
+    input: UpdatePersonSecretByPersonIdInput!
+  ): UpdatePersonSecretPayload @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+}
+
+\\"\\"\\"All input for the \`mutationInInout\` mutation.\\"\\"\\"
+input MutationInInoutInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  i: Int
+  ino: Int
+}
+
+\\"\\"\\"The output of our \`mutationInInout\` mutation.\\"\\"\\"
+type MutationInInoutPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  ino: Int
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`mutationInOut\` mutation.\\"\\"\\"
+input MutationInOutInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  i: Int
+}
+
+\\"\\"\\"The output of our \`mutationInOut\` mutation.\\"\\"\\"
+type MutationInOutPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  o: Int
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`mutationOutComplex\` mutation.\\"\\"\\"
+input MutationOutComplexInput {
+  a: Int
+  b: String
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutComplex\` mutation.\\"\\"\\"
+type MutationOutComplexPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+  result: MutationOutComplexRecord
+}
+
+\\"\\"\\"The return type of our \`mutationOutComplex\` mutation.\\"\\"\\"
+type MutationOutComplexRecord {
+  x: Int
+  y: CompoundType
+  z: Person
+}
+
+\\"\\"\\"All input for the \`mutationOutComplexSetof\` mutation.\\"\\"\\"
+input MutationOutComplexSetofInput {
+  a: Int
+  b: String
+
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutComplexSetof\` mutation.\\"\\"\\"
+type MutationOutComplexSetofPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+  results: [MutationOutComplexSetofRecord]
+}
+
+\\"\\"\\"The return type of our \`mutationOutComplexSetof\` mutation.\\"\\"\\"
+type MutationOutComplexSetofRecord {
+  x: Int
+  y: CompoundType
+  z: Person
+}
+
+\\"\\"\\"All input for the \`mutationOut\` mutation.\\"\\"\\"
+input MutationOutInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"All input for the \`mutationOutOutCompoundType\` mutation.\\"\\"\\"
+input MutationOutOutCompoundTypeInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  i1: Int
+}
+
+\\"\\"\\"The output of our \`mutationOutOutCompoundType\` mutation.\\"\\"\\"
+type MutationOutOutCompoundTypePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+  result: MutationOutOutCompoundTypeRecord
+}
+
+\\"\\"\\"The return type of our \`mutationOutOutCompoundType\` mutation.\\"\\"\\"
+type MutationOutOutCompoundTypeRecord {
+  o1: Int
+  o2: CompoundType
+}
+
+\\"\\"\\"All input for the \`mutationOutOut\` mutation.\\"\\"\\"
+input MutationOutOutInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutOut\` mutation.\\"\\"\\"
+type MutationOutOutPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+  result: MutationOutOutRecord
+}
+
+\\"\\"\\"The return type of our \`mutationOutOut\` mutation.\\"\\"\\"
+type MutationOutOutRecord {
+  firstOut: Int
+  secondOut: String
+}
+
+\\"\\"\\"All input for the \`mutationOutOutSetof\` mutation.\\"\\"\\"
+input MutationOutOutSetofInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutOutSetof\` mutation.\\"\\"\\"
+type MutationOutOutSetofPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+  results: [MutationOutOutSetofRecord]
+}
+
+\\"\\"\\"The return type of our \`mutationOutOutSetof\` mutation.\\"\\"\\"
+type MutationOutOutSetofRecord {
+  o1: Int
+  o2: String
+}
+
+\\"\\"\\"All input for the \`mutationOutOutUnnamed\` mutation.\\"\\"\\"
+input MutationOutOutUnnamedInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutOutUnnamed\` mutation.\\"\\"\\"
+type MutationOutOutUnnamedPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+  result: MutationOutOutUnnamedRecord
+}
+
+\\"\\"\\"The return type of our \`mutationOutOutUnnamed\` mutation.\\"\\"\\"
+type MutationOutOutUnnamedRecord {
+  arg1: Int
+  arg2: String
+}
+
+\\"\\"\\"The output of our \`mutationOut\` mutation.\\"\\"\\"
+type MutationOutPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  o: Int
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`mutationOutSetof\` mutation.\\"\\"\\"
+input MutationOutSetofInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutSetof\` mutation.\\"\\"\\"
+type MutationOutSetofPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  os: [Int]
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`mutationOutTable\` mutation.\\"\\"\\"
+input MutationOutTableInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutTable\` mutation.\\"\\"\\"
+type MutationOutTablePayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  person: Person
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`mutationOutTableSetof\` mutation.\\"\\"\\"
+input MutationOutTableSetofInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutTableSetof\` mutation.\\"\\"\\"
+type MutationOutTableSetofPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  people: [Person]
+
+  \\"\\"\\"An edge for our \`Person\`. May be used by Relay 1.\\"\\"\\"
+  personEdge(
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`mutationOutUnnamed\` mutation.\\"\\"\\"
+input MutationOutUnnamedInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"All input for the \`mutationOutUnnamedOutOutUnnamed\` mutation.\\"\\"\\"
+input MutationOutUnnamedOutOutUnnamedInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`mutationOutUnnamedOutOutUnnamed\` mutation.\\"\\"\\"
+type MutationOutUnnamedOutOutUnnamedPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+  result: MutationOutUnnamedOutOutUnnamedRecord
+}
+
+\\"\\"\\"The return type of our \`mutationOutUnnamedOutOutUnnamed\` mutation.\\"\\"\\"
+type MutationOutUnnamedOutOutUnnamedRecord {
+  arg1: Int
+  arg3: Int
+  o2: String
+}
+
+\\"\\"\\"The output of our \`mutationOutUnnamed\` mutation.\\"\\"\\"
+type MutationOutUnnamedPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  integer: Int
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"All input for the \`mutationReturnsTableMultiCol\` mutation.\\"\\"\\"
+input MutationReturnsTableMultiColInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  i: Int
+}
+
+\\"\\"\\"The output of our \`mutationReturnsTableMultiCol\` mutation.\\"\\"\\"
+type MutationReturnsTableMultiColPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+  results: [MutationReturnsTableMultiColRecord]
+}
+
+\\"\\"\\"The return type of our \`mutationReturnsTableMultiCol\` mutation.\\"\\"\\"
+type MutationReturnsTableMultiColRecord {
+  col1: Int
+  col2: String
+}
+
+\\"\\"\\"All input for the \`mutationReturnsTableOneCol\` mutation.\\"\\"\\"
+input MutationReturnsTableOneColInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+  i: Int
+}
+
+\\"\\"\\"The output of our \`mutationReturnsTableOneCol\` mutation.\\"\\"\\"
+type MutationReturnsTableOneColPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  col1S: [Int]
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+type MyTable implements Node {
+  id: Int!
+  jsonData: JSON
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"
+A condition to be used against \`MyTable\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input MyTableCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`jsonData\` field.\\"\\"\\"
+  jsonData: JSON
+}
+
+\\"\\"\\"An input for mutations affecting \`MyTable\`\\"\\"\\"
+input MyTableInput {
+  id: Int
+  jsonData: JSON
+}
+
+\\"\\"\\"
+Represents an update to a \`MyTable\`. Fields that are set will be updated.
+\\"\\"\\"
+input MyTablePatch {
+  id: Int
+  jsonData: JSON
+}
+
+\\"\\"\\"A \`MyTable\` edge in the connection.\\"\\"\\"
+type MyTablesEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`MyTable\` at the end of the edge.\\"\\"\\"
+  node: MyTable!
+}
+
+\\"\\"\\"Methods to use when ordering \`MyTable\`.\\"\\"\\"
+enum MyTablesOrderBy {
+  ID_ASC
+  ID_DESC
+  JSON_DATA_ASC
+  JSON_DATA_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"All input for the \`noArgsMutation\` mutation.\\"\\"\\"
+input NoArgsMutationInput {
+  \\"\\"\\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \\"\\"\\"
+  clientMutationId: String
+}
+
+\\"\\"\\"The output of our \`noArgsMutation\` mutation.\\"\\"\\"
+type NoArgsMutationPayload {
+  \\"\\"\\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \\"\\"\\"
+  clientMutationId: String
+  integer: Int
+
+  \\"\\"\\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \\"\\"\\"
+  query: Query
+}
+
+\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+interface Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+scalar NotNullTimestamp
+
+scalar NotNullUrl
+
+type NullTestRecord implements Node {
+  id: Int!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+A condition to be used against \`NullTestRecord\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input NullTestRecordCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nonNullText\` field.\\"\\"\\"
+  nonNullText: String
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableInt\` field.\\"\\"\\"
+  nullableInt: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`nullableText\` field.\\"\\"\\"
+  nullableText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`NullTestRecord\`\\"\\"\\"
+input NullTestRecordInput {
+  id: Int
+  nonNullText: String!
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"
+Represents an update to a \`NullTestRecord\`. Fields that are set will be updated.
+\\"\\"\\"
+input NullTestRecordPatch {
+  id: Int
+  nonNullText: String
+  nullableInt: Int
+  nullableText: String
+}
+
+\\"\\"\\"A \`NullTestRecord\` edge in the connection.\\"\\"\\"
+type NullTestRecordsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`NullTestRecord\` at the end of the edge.\\"\\"\\"
+  node: NullTestRecord!
+}
+
+\\"\\"\\"Methods to use when ordering \`NullTestRecord\`.\\"\\"\\"
+enum NullTestRecordsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  NON_NULL_TEXT_ASC
+  NON_NULL_TEXT_DESC
+  NULLABLE_INT_ASC
+  NULLABLE_INT_DESC
+  NULLABLE_TEXT_ASC
+  NULLABLE_TEXT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"A \`Person\` edge in the connection.\\"\\"\\"
+type PeopleEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Person\` at the end of the edge.\\"\\"\\"
+  node: Person!
+}
+
+\\"\\"\\"Methods to use when ordering \`Person\`.\\"\\"\\"
+enum PeopleOrderBy {
+  ABOUT_ASC
+  ABOUT_DESC
+  ALIASES_ASC
+  ALIASES_DESC
+  COMPUTED_OUT_ASC
+  COMPUTED_OUT_DESC
+  CONFIG_ASC
+  CONFIG_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  ID_ASC
+  ID_DESC
+  LAST_LOGIN_FROM_IP_ASC
+  LAST_LOGIN_FROM_IP_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SITE_ASC
+  SITE_DESC
+}
+
+\\"\\"\\"Person test comment\\"\\"\\"
+type Person implements Node {
+  about: String
+  aliases: [String]!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  compoundKeysByPersonId1List(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!]
+  ): [CompoundKey!]!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundKey\`.\\"\\"\\"
+  compoundKeysByPersonId2List(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!]
+  ): [CompoundKey!]!
+  computedComplex(a: Int, b: String): PersonComputedComplexRecord
+  computedFirstArgInout: Person
+  computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  computedInout(ino: String): String
+  computedInoutOut(ino: String): PersonComputedInoutOutRecord
+  computedOut: String!
+  computedOutOut: PersonComputedOutOutRecord
+  config: KeyValueHash
+  createdAt: Datetime
+  email: Email!
+  exists(email: Email): Boolean @deprecated(reason: \\"This is deprecated (comment on function c.person_exists).\\")
+  firstName: String
+  firstPost: Post
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  friendsList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!]
+  ): [Person]
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int!
+  lastLoginFromIp: InternetAddress
+
+  \\"\\"\\"Reads a single \`LeftArm\` that is related to this \`Person\`.\\"\\"\\"
+  leftArmByPersonId: LeftArm
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String!
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"This \`Person\`'s \`PersonSecret\`.\\"\\"\\"
+  personSecretByPersonId: PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+  site: WrappedUrl @deprecated(reason: \\"Don’t use me\\")
+}
+
+\\"\\"\\"The return type of our \`computedComplex\` query.\\"\\"\\"
+type PersonComputedComplexRecord {
+  x: Int
+  y: CompoundType
+  z: Person
+}
+
+\\"\\"\\"The return type of our \`computedFirstArgInoutOut\` query.\\"\\"\\"
+type PersonComputedFirstArgInoutOutRecord {
+  o: Int
+  person: Person
+}
+
+\\"\\"\\"The return type of our \`computedInoutOut\` query.\\"\\"\\"
+type PersonComputedInoutOutRecord {
+  ino: String
+  o: String
+}
+
+\\"\\"\\"The return type of our \`computedOutOut\` query.\\"\\"\\"
+type PersonComputedOutOutRecord {
+  o1: String
+  o2: String
+}
+
+\\"\\"\\"
+A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonCondition {
+  \\"\\"\\"Checks for equality with the object’s \`about\` field.\\"\\"\\"
+  about: String
+
+  \\"\\"\\"Checks for equality with the object’s \`aliases\` field.\\"\\"\\"
+  aliases: [String]
+
+  \\"\\"\\"Checks for equality with the object’s \`computedOut\` field.\\"\\"\\"
+  computedOut: String
+
+  \\"\\"\\"Checks for equality with the object’s \`config\` field.\\"\\"\\"
+  config: KeyValueHash
+
+  \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
+  createdAt: Datetime
+
+  \\"\\"\\"Checks for equality with the object’s \`email\` field.\\"\\"\\"
+  email: Email
+
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`lastLoginFromIp\` field.\\"\\"\\"
+  lastLoginFromIp: InternetAddress
+
+  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  name: String
+
+  \\"\\"\\"Checks for equality with the object’s \`site\` field.\\"\\"\\"
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"An input for mutations affecting \`Person\`\\"\\"\\"
+input PersonInput {
+  about: String
+  aliases: [String]
+  config: KeyValueHash
+  createdAt: Datetime
+  email: Email!
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int
+  lastLoginFromIp: InternetAddress
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String!
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"
+Represents an update to a \`Person\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonPatch {
+  about: String
+  aliases: [String]
+  config: KeyValueHash
+  createdAt: Datetime
+  email: Email
+
+  \\"\\"\\"The primary unique identifier for the person\\"\\"\\"
+  id: Int
+  lastLoginFromIp: InternetAddress
+
+  \\"\\"\\"The person’s name\\"\\"\\"
+  name: String
+  site: WrappedUrlInput
+}
+
+\\"\\"\\"Tracks the person's secret\\"\\"\\"
+type PersonSecret implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"The \`Person\` this \`PersonSecret\` belongs to.\\"\\"\\"
+  personByPersonId: Person
+  personId: Int!
+
+  \\"\\"\\"A secret held by the associated Person\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"
+A condition to be used against \`PersonSecret\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PersonSecretCondition {
+  \\"\\"\\"Checks for equality with the object’s \`personId\` field.\\"\\"\\"
+  personId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`secret\` field.\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"An input for mutations affecting \`PersonSecret\`\\"\\"\\"
+input PersonSecretInput {
+  personId: Int!
+
+  \\"\\"\\"A secret held by the associated Person\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"
+Represents an update to a \`PersonSecret\`. Fields that are set will be updated.
+\\"\\"\\"
+input PersonSecretPatch {
+  personId: Int
+
+  \\"\\"\\"A secret held by the associated Person\\"\\"\\"
+  secret: String
+}
+
+\\"\\"\\"A \`PersonSecret\` edge in the connection.\\"\\"\\"
+type PersonSecretsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`PersonSecret\` at the end of the edge.\\"\\"\\"
+  node: PersonSecret!
+}
+
+\\"\\"\\"Methods to use when ordering \`PersonSecret\`.\\"\\"\\"
+enum PersonSecretsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SECRET_ASC
+  SECRET_DESC
+}
+
+type Post {
+  authorId: Int
+  body: String
+  comptypes: [Comptype]
+  enums: [AnEnum]
+  headline: String!
+  id: Int!
+}
+
+\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query implements Node {
+  \\"\\"\\"Reads a set of \`CompoundKey\`.\\"\\"\\"
+  allCompoundKeysList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: CompoundKeyCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`CompoundKey\`.\\"\\"\\"
+    orderBy: [CompoundKeysOrderBy!]
+  ): [CompoundKey!]
+
+  \\"\\"\\"Reads a set of \`EdgeCase\`.\\"\\"\\"
+  allEdgeCasesList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: EdgeCaseCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`EdgeCase\`.\\"\\"\\"
+    orderBy: [EdgeCasesOrderBy!]
+  ): [EdgeCase!]
+
+  \\"\\"\\"Reads a set of \`Issue756\`.\\"\\"\\"
+  allIssue756SList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: Issue756Condition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Issue756\`.\\"\\"\\"
+    orderBy: [Issue756SOrderBy!]
+  ): [Issue756!]
+
+  \\"\\"\\"Reads a set of \`LeftArm\`.\\"\\"\\"
+  allLeftArmsList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: LeftArmCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`LeftArm\`.\\"\\"\\"
+    orderBy: [LeftArmsOrderBy!]
+  ): [LeftArm!]
+
+  \\"\\"\\"Reads a set of \`MyTable\`.\\"\\"\\"
+  allMyTablesList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: MyTableCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`MyTable\`.\\"\\"\\"
+    orderBy: [MyTablesOrderBy!]
+  ): [MyTable!]
+
+  \\"\\"\\"Reads a set of \`NullTestRecord\`.\\"\\"\\"
+  allNullTestRecordsList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: NullTestRecordCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`NullTestRecord\`.\\"\\"\\"
+    orderBy: [NullTestRecordsOrderBy!]
+  ): [NullTestRecord!]
+
+  \\"\\"\\"Reads a set of \`Person\`.\\"\\"\\"
+  allPeopleList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`Person\`.\\"\\"\\"
+    orderBy: [PeopleOrderBy!]
+  ): [Person!]
+
+  \\"\\"\\"Reads a set of \`PersonSecret\`.\\"\\"\\"
+  allPersonSecretsList(
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PersonSecretCondition
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"The method to use when ordering \`PersonSecret\`.\\"\\"\\"
+    orderBy: [PersonSecretsOrderBy!]
+  ): [PersonSecret!] @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  badlyBehavedFunctionList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [Person] @deprecated(reason: \\"This is deprecated (comment on function c.badly_behaved_function).\\")
+
+  \\"\\"\\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\\"\\"\\"
+  compoundKey(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+
+  \\"\\"\\"Reads and enables pagination through a set of \`CompoundType\`.\\"\\"\\"
+  compoundTypeSetQueryList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [CompoundType]
+  currentUserId: Int
+  funcInInout(i: Int, ino: Int): Int
+  funcInOut(i: Int): Int
+  funcOut: Int
+  funcOutComplex(a: Int, b: String): FuncOutComplexRecord
+  funcOutComplexSetofList(
+    a: Int
+    b: String
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [FuncOutComplexSetofRecord]
+  funcOutOut: FuncOutOutRecord
+  funcOutOutCompoundType(i1: Int): FuncOutOutCompoundTypeRecord
+  funcOutOutSetofList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [FuncOutOutSetofRecord]
+  funcOutOutUnnamed: FuncOutOutUnnamedRecord
+  funcOutSetofList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [Int]
+  funcOutTable: Person
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  funcOutTableSetofList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [Person]
+  funcOutUnnamed: Int
+  funcOutUnnamedOutOutUnnamed: FuncOutUnnamedOutOutUnnamedRecord
+  funcReturnsTableMultiColList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+    i: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [FuncReturnsTableMultiColRecord]
+  funcReturnsTableOneColList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+    i: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+  ): [Int]
+  intSetQueryList(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): [Int]
+
+  \\"\\"\\"Reads a single \`Issue756\` using its globally unique \`ID\`.\\"\\"\\"
+  issue756(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Issue756\`.\\"\\"\\"
+    nodeId: ID!
+  ): Issue756
+  issue756ById(id: Int!): Issue756
+  jsonIdentity(json: JSON): JSON
+  jsonbIdentity(json: JSON): JSON
+
+  \\"\\"\\"Reads a single \`LeftArm\` using its globally unique \`ID\`.\\"\\"\\"
+  leftArm(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`LeftArm\`.\\"\\"\\"
+    nodeId: ID!
+  ): LeftArm
+  leftArmById(id: Int!): LeftArm
+  leftArmByPersonId(personId: Int!): LeftArm
+
+  \\"\\"\\"Reads a single \`MyTable\` using its globally unique \`ID\`.\\"\\"\\"
+  myTable(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`MyTable\`.\\"\\"\\"
+    nodeId: ID!
+  ): MyTable
+  myTableById(id: Int!): MyTable
+  noArgsQuery: Int
+
+  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  node(
+    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    nodeId: ID!
+  ): Node
+
+  \\"\\"\\"
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Reads a single \`NullTestRecord\` using its globally unique \`ID\`.\\"\\"\\"
+  nullTestRecord(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`NullTestRecord\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): NullTestRecord
+  nullTestRecordById(id: Int!): NullTestRecord
+
+  \\"\\"\\"Reads a single \`Person\` using its globally unique \`ID\`.\\"\\"\\"
+  person(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Person\`.\\"\\"\\"
+    nodeId: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personById(id: Int!): Person
+
+  \\"\\"\\"Reads a single \`PersonSecret\` using its globally unique \`ID\`.\\"\\"\\"
+  personSecret(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`PersonSecret\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): PersonSecret @deprecated(reason: \\"This is deprecated (comment on table c.person_secret).\\")
+  personSecretByPersonId(personId: Int!): PersonSecret
+
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+  queryOutputTwoRows(leftArmId: Int, postId: Int, txt: String): QueryOutputTwoRowsRecord
+  returnTableWithoutGrants: CompoundKey
+  tableQuery(id: Int): Post
 
   \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
   tableSetQueryList(

--- a/packages/postgraphile-core/__tests__/integration/schema/simple-collections.test.js
+++ b/packages/postgraphile-core/__tests__/integration/schema/simple-collections.test.js
@@ -1,9 +1,17 @@
 const core = require("./core");
 
 test(
-  "prints a schema with simple collections",
+  "prints a schema with both simple collections and relay connections",
   core.test("c", {
     simpleCollections: "both",
+    setofFunctionsContainNulls: false,
+  })
+);
+
+test(
+  "prints a schema with only simple collections",
+  core.test("c", {
+    simpleCollections: "only",
     setofFunctionsContainNulls: false,
   })
 );


### PR DESCRIPTION
Fixes #397 

This is a bugfix, but people may be relying on this broken behaviour. If they are, they can opt out of this fix via `disableIssue397Fix` flag:

CLI: add to `.postgraphilerc.js`:

```js
module.exports = {
  options: {
    graphileBuildOptions: {
      disableIssue397Fix: true
    }
  }
}
```

Library:

```js
app.use(postgraphile(DB, SCHEMAS, {
  graphileBuildOptions: {
    disableIssue397Fix: true
  }
}));
```