### PR TITLE
feat(perf): use more optimal query when no column-level select grants

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -575,6 +575,7 @@ class QueryBuilder {
       asJsonAggregate?: boolean,
       onlyJsonField?: boolean,
       addNullCase?: boolean,
+      useAsterisk?: boolean,
     } = {}
   ) {
     const {
@@ -582,6 +583,7 @@ class QueryBuilder {
       asJsonAggregate = false,
       onlyJsonField = false,
       addNullCase = false,
+      useAsterisk = false,
     } = options;
 
     this.lockEverything();
@@ -595,7 +597,7 @@ class QueryBuilder {
         : this.buildSelectFields();
 
     let fragment = sql.fragment`
-      select ${fields}
+      select ${useAsterisk ? sql.fragment`${this.getTableAlias()}.*` : fields}
       ${this.compiledData.from &&
         sql.fragment`from ${
           this.compiledData.from[0]
@@ -636,6 +638,9 @@ class QueryBuilder {
         from ${sql.identifier(flipAlias)}
         order by (row_number() over (partition by 1)) desc
         `;
+    }
+    if (useAsterisk) {
+      fragment = sql.fragment`select ${fields} from (${fragment}) ${this.getTableAlias()}`;
     }
     if (asJsonAggregate) {
       const aggAlias = Symbol();

--- a/packages/graphile-build-pg/src/plugins/PgAllRows.js
+++ b/packages/graphile-build-pg/src/plugins/PgAllRows.js
@@ -103,6 +103,7 @@ export default (async function PgAllRows(
                     undefined,
                     resolveData,
                     {
+                      useAsterisk: table.canUseAsterisk,
                       withPaginationAsFields: isConnection,
                     },
                     queryBuilder => {

--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -157,6 +157,7 @@ export default (function PgBackwardRelationPlugin(
                             tableAlias,
                             resolveData,
                             {
+                              useAsterisk: false, // Because it's only a single relation, no need
                               asJson: true,
                               addNullCase: true,
                               withPagination: false,
@@ -265,6 +266,7 @@ export default (function PgBackwardRelationPlugin(
                               tableAlias,
                               resolveData,
                               {
+                                useAsterisk: table.canUseAsterisk,
                                 withPagination: isConnection,
                                 withPaginationAsFields: false,
                                 asJsonAggregate: !isConnection,

--- a/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
@@ -125,7 +125,10 @@ export default (function PgForwardRelationPlugin(builder, { subscriptions }) {
                           sql.identifier(foreignSchema.name, foreignTable.name),
                           foreignTableAlias,
                           resolveData,
-                          { asJson: true },
+                          {
+                            useAsterisk: false, // Because it's only a single relation, no need
+                            asJson: true,
+                          },
                           innerQueryBuilder => {
                             innerQueryBuilder.parentQueryBuilder = queryBuilder;
                             if (subscriptions && table.primaryKeyConstraint) {

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -28,6 +28,7 @@ export interface PgProc {
   tags: { [tag: string]: true | string | Array<string> };
   cost: number;
   aclExecutable: boolean;
+  language: string;
 }
 
 export interface PgClass {
@@ -56,6 +57,7 @@ export interface PgClass {
   aclInsertable: boolean;
   aclUpdatable: boolean;
   aclDeletable: boolean;
+  canUseAsterisk: boolean;
 }
 
 export interface PgType {
@@ -101,6 +103,7 @@ export interface PgAttribute {
   aclUpdatable: boolean;
   isIndexed: boolean | void;
   isUnique: boolean | void;
+  columnLevelSelectGrant: boolean;
 }
 
 export interface PgConstraint {

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -48,6 +48,7 @@ export type PgProc = {
   tags: { [string]: string },
   cost: number,
   aclExecutable: boolean,
+  language: string,
 };
 
 export type PgClass = {
@@ -76,6 +77,7 @@ export type PgClass = {
   aclInsertable: boolean,
   aclUpdatable: boolean,
   aclDeletable: boolean,
+  canUseAsterisk: boolean,
 };
 
 export type PgType = {
@@ -121,6 +123,7 @@ export type PgAttribute = {
   aclUpdatable: boolean,
   isIndexed: ?boolean,
   isUnique: ?boolean,
+  columnLevelSelectGrant: boolean,
 };
 
 export type PgConstraint = {
@@ -739,6 +742,9 @@ export default (async function PgIntrospectionPlugin(
     introspectionResultsByKind.class.forEach(klass => {
       klass.attributes = introspectionResultsByKind.attribute.filter(
         attr => attr.classId === klass.id
+      );
+      klass.canUseAsterisk = !klass.attributes.some(
+        attr => attr.columnLevelSelectGrant
       );
       klass.constraints = introspectionResultsByKind.constraint.filter(
         constraint => constraint.classId === klass.id

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -99,7 +99,9 @@ export default (async function PgRowByUniqueConstraint(
                       sqlFullTableName,
                       undefined,
                       resolveData,
-                      {},
+                      {
+                        useAsterisk: false, // Because it's only a single relation, no need
+                      },
                       queryBuilder => {
                         if (subscriptions && table.primaryKeyConstraint) {
                           queryBuilder.selectIdentifiers(table);

--- a/packages/graphile-build-pg/src/plugins/PgRowNode.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowNode.js
@@ -48,7 +48,9 @@ export default (async function PgRowNode(builder, { subscriptions }) {
           sqlFullTableName,
           undefined,
           resolveData,
-          {},
+          {
+            useAsterisk: false, // Because it's only a single relation, no need
+          },
           queryBuilder => {
             if (subscriptions && table.primaryKeyConstraint) {
               queryBuilder.selectIdentifiers(table);
@@ -173,7 +175,9 @@ export default (async function PgRowNode(builder, { subscriptions }) {
                           sqlFullTableName,
                           undefined,
                           resolveData,
-                          {},
+                          {
+                            useAsterisk: false, // Because it's only a single relation, no need
+                          },
                           queryBuilder => {
                             if (subscriptions && table.primaryKeyConstraint) {
                               queryBuilder.selectIdentifiers(table);

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -358,6 +358,11 @@ export default function makeProcField(
           functionAlias,
           resolveData,
           {
+            useAsterisk:
+              !isMutation &&
+              (isTableLike || isRecordLike) &&
+              (forceList || proc.returnsSet || rawReturnType.isPgArray) && // only bother with lists
+              proc.language !== "sql", // sql functions can be inlined, so GRANTs still apply
             withPagination: !forceList && !isMutation && proc.returnsSet,
             withPaginationAsFields:
               !forceList && !isMutation && proc.returnsSet && !computed,

--- a/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
+++ b/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
@@ -25,6 +25,7 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
     asJsonAggregate?: boolean,
     addNullCase?: boolean,
     onlyJsonField?: boolean,
+    useAsterisk?: boolean,
   },
   // TODO:v5: context is not optional
   withBuilder?: ((builder: QueryBuilder) => void) | null | void,


### PR DESCRIPTION
No need for user intervention, we auto-detect the permissions for each table.

Using this schema:

```sql
drop schema if exists perf cascade;
create schema perf;

set search_path to perf, public;

create table a (
  id serial primary key,
  name text not null,
  foo text not null default 'slkdjfgp3ojtgo;irghpow jeg;sorijt ;w0ja;sdojrg 09a3[jw4 at;oidsfgj 90wej4t ;soejgr ajt34 ;oesjrg osdrg;sergeps89ngpse9trgpsdh9fg',
  bar text not null default 'slkdjfgp3ojtgo;irghpow jeg;sorijt ;w0ja;sdojrg 09a3[jw4 at;oidsfgj 90wej4t ;soejgr ajt34 ;oesjrg osdrg;sergeps89ngpse9trgpsdh9fg',
  baz text not null default 'slkdjfgp3ojtgo;irghpow jeg;sorijt ;w0ja;sdojrg 09a3[jw4 at;oidsfgj 90wej4t ;soejgr ajt34 ;oesjrg osdrg;sergeps89ngpse9trgpsdh9fg'
);

create table b (
  id serial primary key,
  a_id int not null references a,
  foo text not null default 'slkdjfgp3ojtgo;irghpow jeg;sorijt ;w0ja;sdojrg 09a3[jw4 at;oidsfgj 90wej4t ;soejgr ajt34 ;oesjrg osdrg;sergeps89ngpse9trgpsdh9fg',
  bar text not null default 'slkdjfgp3ojtgo;irghpow jeg;sorijt ;w0ja;sdojrg 09a3[jw4 at;oidsfgj 90wej4t ;soejgr ajt34 ;oesjrg osdrg;sergeps89ngpse9trgpsdh9fg',
  baz text not null default 'slkdjfgp3ojtgo;irghpow jeg;sorijt ;w0ja;sdojrg 09a3[jw4 at;oidsfgj 90wej4t ;soejgr ajt34 ;oesjrg osdrg;sergeps89ngpse9trgpsdh9fg'
);

insert into a (name)
  select chr(65 + floor(i/26)::int % 26) || ' ' || chr(65 + i % 26)
  from generate_series(0, 100000) i;

insert into b (a_id) select id from a inner join generate_series(1,3) i on (true);
```

and this query:

```graphql
{
  allAs(first: 1, orderBy: NAME_DESC) {
    nodes {
      ...a
      bsByAId {
        totalCount
        nodes {
          ...b
          aByAId {
            ...a
            bsByAId {
              totalCount
              nodes {
                ...b
              }
            }
          }
        }
      }
    }
    totalCount
    pageInfo {
      hasNextPage
    }
  }
}

fragment a on A {
  nodeId
  id
  name
  foo
  bar
  baz
}

fragment b on B {
  nodeId
  id
  foo
  bar
  baz
}
```

Query time goes down from ~900ms to ~575ms on my machine when no column-level select grants are in use.

Optimisation is done on a per-table basis, so everyone benefits!