### PR TITLE
feat(aggregates): add support for aggregates

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js
@@ -7,6 +7,7 @@ export default (function PgConnectionTotalCount(builder) {
       extend,
       inflection,
       graphql: { GraphQLInt, GraphQLNonNull },
+      pgSql: sql,
     } = build;
     const {
       scope: { isPgRowConnectionType, pgIntrospection: table },
@@ -32,14 +33,19 @@ export default (function PgConnectionTotalCount(builder) {
           ({ addDataGenerator }) => {
             addDataGenerator(() => {
               return {
-                pgCalculateTotalCount: true,
+                pgAggregateQuery: aggregateQueryBuilder => {
+                  aggregateQueryBuilder.select(
+                    sql.fragment`count(*)`,
+                    "totalCount"
+                  );
+                },
               };
             });
             return {
               description: `The count of *all* \`${tableTypeName}\` you could get from the connection.`,
               type: new GraphQLNonNull(GraphQLInt),
               resolve(parent) {
-                return parent.totalCount || 0;
+                return (parent.aggregates && parent.aggregates.totalCount) || 0;
               },
             };
           },


### PR DESCRIPTION
`totalCount` is now implemented via aggregates:

https://github.com/graphile/graphile-engine/blob/e08dbb34ee904cb54349c2152b7fe18ec3a4d1ca/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js#L36-L41

Here's a plugin that adds the `sum` aggregate for numeric fields:

```js
module.exports = builder => {
  // Add some inflection rules so users can rename things (this is optional!)
  builder.hook('inflection', (inflection, build) => {
    return build.extend(inflection, {
      sumAggregate() {
        return 'sum';
      },
      summableFieldEnum(table) {
        return this.upperCamelCase(`${this._singularizedTableName(table)}-summable-field-enum`);
      },
    });
  });

  // Hook all connections to add the aggregate field
  builder.hook('GraphQLObjectType:fields', (fields, build, context) => {
    const {
      pgSql: sql,
      newWithHooks,
      graphql: { GraphQLEnumType, GraphQLNonNull, GraphQLFloat },
      inflection,
      getSafeAliasFromAlias,
      getSafeAliasFromResolveInfo,
    } = build;
    const {
      fieldWithHooks,
      scope: { isPgRowConnectionType, pgIntrospection: table },
    } = context;

    // If it's not a table connection, abort
    if (!isPgRowConnectionType || !table || table.kind !== 'class' || !table.namespace) {
      return fields;
    }

    // Figure out the columns that we're allowed to do a `SUM(...)` of
    const values = table.attributes.reduce((values, attr) => {
      // Didn't use 'numeric' here because it'd be confusing with the 'NUMERIC' type.
      const attrIsNumberLike = attr.type.category === 'N';
      if (attrIsNumberLike) {
        values[inflection.column(attr)] = {
          value: {
            // Note this expression generator is just an sql fragment, so you
            // could add CASE statements, function calls, or whatever you need
            // here
            expressionGenerator: queryBuilder =>
              sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(attr.name)}`,
          },
        };
      }
      return values;
    }, {});
    // If there's no summable columns, don't add the aggregate
    if (!Object.keys(values).length) {
      return fields;
    }
    // Build the enum for the summable fields using the fields above (this is
    // hookable so you could add computed columns or other fields you want to
    // sum)
    const summableFieldsEnum = newWithHooks(
      GraphQLEnumType,
      {
        name: inflection.summableFieldEnum(table),
        values,
      },
      {
        pgIntrospection: table,
        isPgSummableFieldEnum: true,
      }
    );

    // Add our aggregate 'sum' field to the schema
    const fieldName = inflection.sumAggregate(table);
    return {
      ...fields,
      [fieldName]: fieldWithHooks(
        fieldName,
        ({ addDataGenerator }) => {
          addDataGenerator(parsedResolveInfoFragment => {
            return {
              // This tells the query planner that we want to add an aggregate
              pgAggregateQuery: aggregateQueryBuilder => {
                const expr = parsedResolveInfoFragment.args.field.expressionGenerator(
                  aggregateQueryBuilder
                );
                aggregateQueryBuilder.select(
                  // You can put any aggregate expression here; I've wrapped it in `coalesce` so that it cannot be null
                  sql.fragment`coalesce(sum(${expr}), 0)`,
                  // We need a unique alias that we can later reference in the resolver
                  getSafeAliasFromAlias(parsedResolveInfoFragment.alias)
                );
              },
            };
          });
          return {
            description: `Sum`,
            args: {
              field: {
                type: new GraphQLNonNull(summableFieldsEnum),
              },
            },
            type: new GraphQLNonNull(GraphQLFloat),
            resolve(parent, _args, _context, resolveInfo) {
              if (!parent.aggregates) return 0; // This should never happen
              // Figure out the unique alias we chose earlier
              const safeAlias = getSafeAliasFromResolveInfo(resolveInfo);
              // All aggregates are stored into the 'aggregates' object, reference ours here
              return parent.aggregates[safeAlias];
            },
          };
        },
        {
          // In case anyone wants to hook us, describe ourselves
          isPgConnectionSumField: true,
        }
      ),
    };
  });
};
```