### PR TITLE
fix(live): solve race conditions in live queries

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.d.ts
+++ b/packages/graphile-build-pg/src/QueryBuilder.d.ts
@@ -21,6 +21,7 @@ export type CursorComparator = (val: CursorValue, isAfter: boolean) => void;
 export default class QueryBuilder {
   public parentQueryBuilder: QueryBuilder | void;
   public context: GraphQLContext;
+  public rootValue: any;
   public beforeLock(field: string, fn: () => void): void;
   public makeLiveCollection(
     table: PgClass,

--- a/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
@@ -162,7 +162,8 @@ export default (function PgForwardRelationPlugin(builder, { subscriptions }) {
                                 );
                               });
                             },
-                            queryBuilder.context
+                            queryBuilder.context,
+                            queryBuilder.rootValue
                           );
                           return sql.fragment`(${query})`;
                         }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
@@ -181,12 +182,11 @@ export default (function PgForwardRelationPlugin(builder, { subscriptions }) {
                         resolveInfo
                       );
                       const record = data[safeAlias];
-                      if (record && resolveContext.liveRecord) {
-                        resolveContext.liveRecord(
-                          "pg",
-                          foreignTable,
-                          record.__identifiers
-                        );
+                      const liveRecord =
+                        resolveInfo.rootValue &&
+                        resolveInfo.rootValue.liveRecord;
+                      if (record && liveRecord) {
+                        liveRecord("pg", foreignTable, record.__identifiers);
                       }
                       return record;
                     },

--- a/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationCreatePlugin.js
@@ -197,7 +197,8 @@ export default (function PgMutationCreatePlugin(
                         resolveData,
                         {},
                         null,
-                        resolveContext
+                        resolveContext,
+                        resolveInfo.rootValue
                       );
                       const sqlColumns = [];
                       const sqlValues = [];

--- a/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js
@@ -152,7 +152,8 @@ export default (async function PgMutationUpdateDeletePlugin(
                   resolveData,
                   {},
                   null,
-                  resolveContext
+                  resolveContext,
+                  resolveInfo.rootValue
                 );
                 let row;
                 try {

--- a/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowByUniqueConstraint.js
@@ -91,7 +91,10 @@ export default (async function PgRowByUniqueConstraint(
                       return memo;
                     }, {}),
                     async resolve(parent, args, resolveContext, resolveInfo) {
-                      const { pgClient, liveRecord } = resolveContext;
+                      const { pgClient } = resolveContext;
+                      const liveRecord =
+                        resolveInfo.rootValue &&
+                        resolveInfo.rootValue.liveRecord;
                       const parsedResolveInfoFragment = parseResolveInfo(
                         resolveInfo
                       );
@@ -123,7 +126,8 @@ export default (async function PgRowByUniqueConstraint(
                             );
                           });
                         },
-                        resolveContext
+                        resolveContext,
+                        resolveInfo.rootValue
                       );
                       const { text, values } = sql.compile(query);
                       if (debugSql.enabled) debugSql(text);

--- a/packages/graphile-build-pg/src/plugins/PgRowNode.js
+++ b/packages/graphile-build-pg/src/plugins/PgRowNode.js
@@ -40,9 +40,14 @@ export default (async function PgRowNode(builder, { subscriptions }) {
           resolveContext,
           parsedResolveInfoFragment,
           ReturnType,
-          resolveData
+          resolveData,
+          resolveInfo
         ) => {
-          const { pgClient, liveRecord } = resolveContext;
+          const { pgClient } = resolveContext;
+          const liveRecord =
+            resolveInfo &&
+            resolveInfo.rootValue &&
+            resolveInfo.rootValue.liveRecord;
           if (identifiers.length !== primaryKeys.length) {
             throw new Error("Invalid ID");
           }
@@ -69,7 +74,8 @@ export default (async function PgRowNode(builder, { subscriptions }) {
                 );
               });
             },
-            resolveContext
+            resolveContext,
+            resolveInfo && resolveInfo.rootValue
           );
           const { text, values } = sql.compile(query);
           if (debugSql.enabled) debugSql(text);
@@ -158,7 +164,10 @@ export default (async function PgRowNode(builder, { subscriptions }) {
                         },
                       },
                       async resolve(parent, args, resolveContext, resolveInfo) {
-                        const { pgClient, liveRecord } = resolveContext;
+                        const { pgClient } = resolveContext;
+                        const liveRecord =
+                          resolveInfo.rootValue &&
+                          resolveInfo.rootValue.liveRecord;
                         const nodeId = args[nodeIdFieldName];
                         try {
                           const {
@@ -203,7 +212,8 @@ export default (async function PgRowNode(builder, { subscriptions }) {
                                 );
                               });
                             },
-                            resolveContext
+                            resolveContext,
+                            resolveInfo.rootValue
                           );
                           const { text, values } = sql.compile(query);
                           if (debugSql.enabled) debugSql(text);

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -433,21 +433,25 @@ export default (function PgTablesPlugin(
                           const safeAlias = getSafeAliasFromResolveInfo(
                             resolveInfo
                           );
+                          const liveRecord =
+                            resolveInfo.rootValue &&
+                            resolveInfo.rootValue.liveRecord;
                           return data.data.map(entry => {
                             const record = handleNullRow(
                               entry[safeAlias],
-                              entry.__identifiers
+                              entry[safeAlias].__identifiers
                             );
-                            const liveRecord =
-                              resolveInfo.rootValue &&
-                              resolveInfo.rootValue.liveRecord;
                             if (
                               record &&
                               liveRecord &&
                               primaryKeys &&
-                              entry.__identifiers
+                              entry[safeAlias].__identifiers
                             ) {
-                              liveRecord("pg", table, entry.__identifiers);
+                              liveRecord(
+                                "pg",
+                                table,
+                                entry[safeAlias].__identifiers
+                              );
                             }
 
                             return record;

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -362,17 +362,16 @@ export default (function PgTablesPlugin(
                             data[safeAlias],
                             data.__identifiers
                           );
+                          const liveRecord =
+                            resolveInfo.rootValue &&
+                            resolveInfo.rootValue.liveRecord;
                           if (
                             record &&
                             primaryKeys &&
-                            resolveContext.liveRecord &&
+                            liveRecord &&
                             data.__identifiers
                           ) {
-                            resolveContext.liveRecord(
-                              "pg",
-                              table,
-                              data.__identifiers
-                            );
+                            liveRecord("pg", table, data.__identifiers);
                           }
                           return record;
                         },
@@ -439,17 +438,16 @@ export default (function PgTablesPlugin(
                               entry[safeAlias],
                               entry.__identifiers
                             );
+                            const liveRecord =
+                              resolveInfo.rootValue &&
+                              resolveInfo.rootValue.liveRecord;
                             if (
                               record &&
-                              resolveContext.liveRecord &&
+                              liveRecord &&
                               primaryKeys &&
                               entry.__identifiers
                             ) {
-                              resolveContext.liveRecord(
-                                "pg",
-                                table,
-                                entry.__identifiers
-                              );
+                              liveRecord("pg", table, entry.__identifiers);
                             }
 
                             return record;

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -347,7 +347,8 @@ export default function makeProcField(
         sqlMutationQuery,
         functionAlias,
         parentQueryBuilder,
-        resolveContext
+        resolveContext,
+        resolveInfo
       ) {
         const resolveData = getDataFromParsedResolveInfoFragment(
           parsedResolveInfoFragment,
@@ -410,7 +411,10 @@ export default function makeProcField(
               innerQueryBuilder.selectIdentifiers(returnTypeTable);
             }
           },
-          parentQueryBuilder ? parentQueryBuilder.context : resolveContext
+          parentQueryBuilder ? parentQueryBuilder.context : resolveContext,
+          parentQueryBuilder
+            ? parentQueryBuilder.rootValue
+            : resolveInfo && resolveInfo.rootValue
         );
         return query;
       }
@@ -578,7 +582,8 @@ export default function makeProcField(
         args: args,
         resolve: computed
           ? (data, _args, resolveContext, resolveInfo) => {
-              const { liveRecord } = resolveContext;
+              const liveRecord =
+                resolveInfo.rootValue && resolveInfo.rootValue.liveRecord;
               const safeAlias = getSafeAliasFromResolveInfo(resolveInfo);
               const value = data[safeAlias];
               if (returnFirstValueAsValue) {
@@ -628,7 +633,9 @@ export default function makeProcField(
               }
             }
           : async (data, args, resolveContext, resolveInfo) => {
-              const { pgClient, liveRecord } = resolveContext;
+              const { pgClient } = resolveContext;
+              const liveRecord =
+                resolveInfo.rootValue && resolveInfo.rootValue.liveRecord;
               const parsedResolveInfoFragment = parseResolveInfo(resolveInfo);
               parsedResolveInfoFragment.args = args; // Allow overriding via makeWrapResolversPlugin
               const functionAlias = sql.identifier(Symbol());
@@ -646,7 +653,8 @@ export default function makeProcField(
                   functionAlias,
                   functionAlias,
                   null,
-                  resolveContext
+                  resolveContext,
+                  resolveInfo
                 );
                 const intermediateIdentifier = sql.identifier(Symbol());
                 const isVoid = returnType.id === "2278";
@@ -695,7 +703,8 @@ export default function makeProcField(
                   sqlMutationQuery,
                   functionAlias,
                   null,
-                  resolveContext
+                  resolveContext,
+                  resolveInfo
                 );
                 const { text, values } = sql.compile(query);
                 if (debugSql.enabled) debugSql(text);

--- a/packages/graphile-build-pg/src/plugins/pgField.js
+++ b/packages/graphile-build-pg/src/plugins/pgField.js
@@ -80,7 +80,8 @@ export default function pgField(
                     });
                   }
                 },
-                queryBuilder.context
+                queryBuilder.context,
+                queryBuilder.rootValue
               );
               return sql.fragment`(${query})`;
             }, safeAlias);

--- a/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
+++ b/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
@@ -29,7 +29,8 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
   },
   // TODO:v5: context is not optional
   withBuilder?: ((builder: QueryBuilder) => void) | null | void,
-  context?: GraphQLContext = {}
+  context?: GraphQLContext = {},
+  rootValue?: any // eslint-disable-line flowtype/no-weak-types
 ) => {
   const {
     pgQuery,
@@ -49,7 +50,12 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
     reallyRawCursorPrefix && reallyRawCursorPrefix.filter(identity);
 
   // $FlowFixMe
-  const queryBuilder = new QueryBuilder(queryBuilderOptions, context);
+  const queryBuilder = new QueryBuilder(
+    // $FlowFixMe
+    queryBuilderOptions,
+    context,
+    rootValue
+  );
   queryBuilder.from(from, fromAlias ? fromAlias : undefined);
 
   if (withBuilder) {
@@ -405,8 +411,10 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
     }
     if (pgAggregateQuery && pgAggregateQuery.length) {
       const aggregateQueryBuilder = new QueryBuilder(
+        // $FlowFixMe
         queryBuilderOptions,
-        context
+        context,
+        rootValue
       );
       aggregateQueryBuilder.from(
         queryBuilder.getTableExpression(),

--- a/packages/graphile-build/src/Live.d.ts
+++ b/packages/graphile-build/src/Live.d.ts
@@ -65,10 +65,7 @@ export class LiveCoordinator {
 
   registerSource(namespace: string, source: LiveSource): void;
 
-  getMonitorAndContext(): {
-    monitor: LiveMonitor;
-    context: any;
-  };
+  getMonitor(): LiveMonitor;
 
   subscribe(
     _parent: any,

--- a/packages/graphile-build/src/plugins/AddQueriesToSubscriptionsPlugin.js
+++ b/packages/graphile-build/src/plugins/AddQueriesToSubscriptionsPlugin.js
@@ -49,9 +49,12 @@ const AddQueriesToSubscriptionsPlugin: Plugin = function(
                       try {
                         return await oldResolve(...args);
                       } catch (e) {
-                        const context = args[2];
-                        if (typeof context.liveAbort === "function") {
-                          context.liveAbort(e);
+                        const info = args[3];
+                        if (
+                          info.rootValue &&
+                          typeof info.rootValue.liveAbort === "function"
+                        ) {
+                          info.rootValue.liveAbort(e);
                         }
                         throw e;
                       }

--- a/packages/graphile-build/src/plugins/NodePlugin.js
+++ b/packages/graphile-build/src/plugins/NodePlugin.js
@@ -8,7 +8,11 @@ import type {
 } from "../SchemaBuilder";
 import resolveNode from "../resolveNode";
 import type { ResolveTree } from "graphql-parse-resolve-info";
-import type { GraphQLType, GraphQLInterfaceType } from "graphql";
+import type {
+  GraphQLType,
+  GraphQLInterfaceType,
+  GraphQLResolveInfo,
+} from "graphql";
 import type { BuildExtensionQuery } from "./QueryPlugin";
 
 const base64 = str => Buffer.from(String(str)).toString("base64");
@@ -20,7 +24,8 @@ export type NodeFetcher = (
   context: mixed,
   parsedResolveInfoFragment: ResolveTree,
   type: GraphQLType,
-  resolveData: DataForType
+  resolveData: DataForType,
+  resolveInfo: GraphQLResolveInfo
 ) => {};
 
 export type BuildExtensionNode = {|

--- a/packages/graphile-utils/src/fieldHelpers.ts
+++ b/packages/graphile-utils/src/fieldHelpers.ts
@@ -66,22 +66,25 @@ export function makeFieldHelpers<TSource>(
         if (typeof builderCallback === "function") {
           builderCallback(tableAlias, sqlBuilder);
         }
-      }
+      },
+      context,
+      resolveInfo.rootValue
     );
     const { text, values } = sql.compile(query);
     const { rows } = await pgClient.query(text, values);
     if (isConnection) {
       return build.pgAddStartEndCursor(rows[0]);
     } else {
+      const liveRecord =
+        resolveInfo.rootValue && resolveInfo.rootValue.liveRecord;
       if (
         build.options.subscriptions &&
         !isConnection &&
         primaryKeys &&
-        context.liveRecord
+        liveRecord
       ) {
         rows.forEach(
-          (row: any) =>
-            row && context.liveRecord("pg", table, row.__identifiers)
+          (row: any) => row && liveRecord("pg", table, row.__identifiers)
         );
       }
       return rows;

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -625,26 +625,26 @@ function getFields<TSource>(
             return (
               data: any,
               _args: any,
-              resolveContext: any,
+              _resolveContext: any,
               resolveInfo: any
             ) => {
               const safeAlias = build.getSafeAliasFromResolveInfo(resolveInfo);
+              const liveRecord =
+                resolveInfo.rootValue && resolveInfo.rootValue.liveRecord;
               if (isConnection) {
                 return build.pgAddStartEndCursor(data[safeAlias]);
               } else if (isListType) {
                 const records = data[safeAlias];
-                if (table && resolveContext.liveRecord) {
+                if (table && liveRecord) {
                   records.forEach(
-                    (r: any) =>
-                      r &&
-                      resolveContext.liveRecord("pg", table, r.__identifiers)
+                    (r: any) => r && liveRecord("pg", table, r.__identifiers)
                   );
                 }
                 return records;
               } else {
                 const record = data[safeAlias];
-                if (record && resolveContext.liveRecord && table) {
-                  resolveContext.liveRecord("pg", table, record.__identifiers);
+                if (record && liveRecord && table) {
+                  liveRecord("pg", table, record.__identifiers);
                 }
                 return record;
               }
@@ -771,7 +771,8 @@ function getFields<TSource>(
                           );
                         }
                       },
-                      queryBuilder.context
+                      queryBuilder.context,
+                      queryBuilder.rootValue
                     );
                     return sql.fragment`(${query})`;
                   }, build.getSafeAliasFromAlias(parsedResolveInfoFragment.alias));

--- a/packages/lds/__tests__/pg-logical-decoding.test.ts
+++ b/packages/lds/__tests__/pg-logical-decoding.test.ts
@@ -1,6 +1,8 @@
 import PgLogicalDecoding from "../src/pg-logical-decoding";
 import { tryDropSlot, DATABASE_URL, query, withLdAndClient } from "./helpers";
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
 test("opens and closes cleanly", async () => {
   const ld = new PgLogicalDecoding(DATABASE_URL, {
     temporary: true,
@@ -58,6 +60,8 @@ test("temporary creates slot for itself, PostgreSQL automatically cleans up for 
   );
   expect(initialPgRows.length).toEqual(1);
   await ld.close();
+  // Give half a second to clean up the slot
+  await sleep(500);
   const { rows: finalPgRows } = await query(
     "select * from pg_catalog.pg_replication_slots where slot_name = $1",
     [slotName]

--- a/packages/subscriptions-lds/src/PgLDSSourcePlugin.ts
+++ b/packages/subscriptions-lds/src/PgLDSSourcePlugin.ts
@@ -190,8 +190,13 @@ export class LDSLiveSource {
       done = true;
       const i = this.subscriptions[topic].indexOf(entry);
       this.subscriptions[topic].splice(i, 1);
-      if (this.ws && this.subscriptions[topic].length === 0) {
-        this.ws.send("UNSUB " + topic);
+      if (this.subscriptions[topic].length === 0) {
+        // Solve potential memory leak
+        delete this.subscriptions[topic];
+
+        if (this.ws) {
+          this.ws.send("UNSUB " + topic);
+        }
       }
     };
   }


### PR DESCRIPTION
Moves everything from `context` (which was a hack) to `rootValue` (which is our "payload" from the `subscribe` async iterator, so is officially under our control). 

If this is used outside of PostGraphile and you don't use a custom `liveSubscribe` function then the memory will increase unbounded; PostGraphile uses a custom subscribe function when live queries are enabled that triggers the release of each of the `rootValue`s that are generated.