### PR TITLE
fix(pg-pubsub): module augmentation

### DIFF
--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -6,7 +6,7 @@ import PgGenericSubscriptionPlugin from "./PgGenericSubscriptionPlugin";
 import PgSubscriptionResolverPlugin from "./PgSubscriptionResolverPlugin";
 import * as pg from "pg";
 
-declare module "postgraphile" {
+declare module "postgraphile/build/interfaces" {
   interface PostGraphileOptions {
     simpleSubscriptions?: boolean;
     subscriptionAuthorizationFunction?: string;

--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -13,7 +13,7 @@ declare module "postgraphile/build/interfaces" {
   }
 }
 
-declare module "graphile-build" {
+declare module "graphile-build/node8plus/SchemaBuilder" {
   interface Options {
     pubsub: PubSub;
   }


### PR DESCRIPTION
When merging declarations, the specified module path must exactly match the path to the actual module. Since postgraphile exports the `PostGraphileOptions` from the interfaces file the path needs to be updated to reflect this, similarly with graphile-build `Options`