### PR TITLE
feat(plugins): enable plugins to prevent using asterisk

### DIFF
--- a/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
+++ b/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
@@ -18,7 +18,7 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
   from: SQL,
   fromAlias: ?SQL,
   resolveData: DataForType,
-  options: {
+  inOptions: {
     withPagination?: boolean,
     withPaginationAsFields?: boolean,
     asJson?: boolean,
@@ -36,10 +36,20 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
     pgQuery,
     pgAggregateQuery,
     pgCursorPrefix: reallyRawCursorPrefix,
+    pgDontUseAsterisk,
     calculateHasNextPage,
     calculateHasPreviousPage,
     usesCursor: explicitlyUsesCursor,
   } = resolveData;
+
+  const preventAsterisk = pgDontUseAsterisk
+    ? pgDontUseAsterisk.length > 0
+    : false;
+  const options = {
+    ...inOptions,
+    // Allow pgDontUseAsterisk to override useAsterisk
+    useAsterisk: inOptions.useAsterisk && !preventAsterisk,
+  };
 
   const usesCursor: boolean =
     (explicitlyUsesCursor && explicitlyUsesCursor.length > 0) ||


### PR DESCRIPTION
This is important for plugins that need to get access to certain special
table properties, such as `ctid`.

Once such example is https://github.com/mlipscombe/postgraphile-plugin-zombodb