### PR TITLE
Add TYPE for introspection error messages

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -287,6 +287,8 @@ function sqlCommentByAddingTags(entity, tagsToAdd) {
       sqlThing = `VIEW ${identifier}`;
     } else if (entity.classKind === "m") {
       sqlThing = `MATERIALIZED VIEW ${identifier}`;
+    } else if (entity.classKind === "c") {
+      sqlThing = `TYPE ${identifier}`;
     } else {
       sqlThing = `PLEASE_SEND_A_PULL_REQUEST_TO_FIX_THIS ${identifier}`;
     }


### PR DESCRIPTION
This PR adds a more useful error messages for introspection name clashes like this:

```
⚠️⚠️⚠️ An error occured when building the schema on watch:
Error: A type naming conflict has occurred - two entities have tried to define the same type 'Ilk'.

  The first entity was:

    Adding table type for table "maker"."ilks". You can rename the table's GraphQL type via:
    
      COMMENT ON TABLE "maker"."ilks" IS E'@name newNameHere';

  The second entity was:

    Adding table type for composite type "maker"."ilk". You can rename the table's GraphQL type via:
    
      COMMENT ON PLEASE_SEND_A_PULL_REQUEST_TO_FIX_THIS "maker"."ilk" IS E'@name newNameHere';
```