### PR TITLE
feat(smart-comments): @foreignKey smart comments on composite types

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js
@@ -71,6 +71,10 @@ export default (function PgBackwardRelationPlugin(
           }
           const table =
             introspectionResultsByKind.classById[constraint.classId];
+          if (!table.isSelectable) {
+            // Could be a composite type
+            return memo;
+          }
           const tableTypeName = inflection.tableType(table);
           const gqlTableType = pgGetGqlTypeByTypeIdAndModifier(
             table.type.id,

--- a/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgForwardRelationPlugin.js
@@ -24,6 +24,7 @@ export default (function PgForwardRelationPlugin(builder, { subscriptions }) {
       const {
         scope: {
           isPgRowType,
+          isPgCompositeType,
           isMutationPayload,
           pgIntrospection,
           pgIntrospectionTable,
@@ -34,7 +35,7 @@ export default (function PgForwardRelationPlugin(builder, { subscriptions }) {
 
       const table = pgIntrospectionTable || pgIntrospection;
       if (
-        !(isPgRowType || isMutationPayload) ||
+        !(isPgRowType || isMutationPayload || isPgCompositeType) ||
         !table ||
         table.kind !== "class" ||
         !table.namespace

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -329,11 +329,12 @@ function smartCommentConstraints(introspectionResults) {
     if (!namespace) {
       return;
     }
-    if (klass.tags.foreignKey) {
+    const getType = () =>
+      introspectionResults.type.find(t => t.id === klass.typeId);
+    const foreignKey = klass.tags.foreignKey || getType().tags.foreignKey;
+    if (foreignKey) {
       const foreignKeys =
-        typeof klass.tags.foreignKey === "string"
-          ? [klass.tags.foreignKey]
-          : klass.tags.foreignKey;
+        typeof foreignKey === "string" ? [foreignKey] : foreignKey;
       if (!Array.isArray(foreignKeys)) {
         throw new Error(
           `Invalid foreign key smart comment specified on '${

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -155,7 +155,8 @@ export default (function PgTablesPlugin(
                 )}`,
                 pgIntrospection: table,
                 isPgRowType: table.isSelectable,
-                isPgCompoundType: !table.isSelectable,
+                isPgCompoundType: !table.isSelectable, // TODO:v5: remove - typo
+                isPgCompositeType: !table.isSelectable,
               }
             );
             cb(TableType);

--- a/packages/graphile-build-pg/src/plugins/introspectionQuery.js
+++ b/packages/graphile-build-pg/src/plugins/introspectionQuery.js
@@ -286,13 +286,13 @@ with
     where
       typ.id in (
         select "typeId" from class
-      union
+      union all
         select "typeId" from attribute
-      union
+      union all
         select "returnTypeId" from procedure
-      union
+      union all
         select unnest("argTypeIds") from procedure
-      union
+      union all
       -- If this type is a base type for *any* domain type, we will include it
       -- in our selection. This may mean we fetch more types than we need, but
       -- the alternative is to do some funky SQL recursion which would be hard
@@ -301,9 +301,9 @@ with
       --
       -- We also do this for range sub types and array item types.
         select "domainBaseTypeId" from type_all
-      union
+      union all
         select "rangeSubTypeId" from type_all
-      union
+      union all
         select "arrayItemTypeId" from type_all
       )
     order by

--- a/packages/graphile-build-pg/src/plugins/introspectionQuery.js
+++ b/packages/graphile-build-pg/src/plugins/introspectionQuery.js
@@ -284,10 +284,15 @@ with
     from
       type_all as typ
     where
-      typ.id in (select "typeId" from class) or
-      typ.id in (select "typeId" from attribute) or
-      typ.id in (select "returnTypeId" from procedure) or
-      typ.id in (select unnest("argTypeIds") from procedure) or
+      typ.id in (
+        select "typeId" from class
+      union
+        select "typeId" from attribute
+      union
+        select "returnTypeId" from procedure
+      union
+        select unnest("argTypeIds") from procedure
+      union
       -- If this type is a base type for *any* domain type, we will include it
       -- in our selection. This may mean we fetch more types than we need, but
       -- the alternative is to do some funky SQL recursion which would be hard
@@ -295,9 +300,12 @@ with
       -- 4 less type rows.
       --
       -- We also do this for range sub types and array item types.
-      typ.id in (select "domainBaseTypeId" from type_all) or
-      typ.id in (select "rangeSubTypeId" from type_all) or
-      typ.id in (select "arrayItemTypeId" from type_all)
+        select "domainBaseTypeId" from type_all
+      union
+        select "rangeSubTypeId" from type_all
+      union
+        select "arrayItemTypeId" from type_all
+      )
     order by
       "namespaceId", "name"
   ),

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries-jwt.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries-jwt.test.js.snap
@@ -41,17 +41,27 @@ Object {
 
 exports[`jwt pgJwtTypeIdentifier with payload 1`] = `
 Object {
-  "admin": true,
-  "id": 1,
-  "jwt": Object {
-    "a": 1,
-    "aud": "postgraphile",
-    "b": 2,
-    "c": 3,
-    "exp": 2130969600,
-    "iat": "[timestamp]",
-    "iss": "postgraphile",
-    "role": "yay",
+  "authPayload": Object {
+    "admin": true,
+    "id": 1,
+    "jwt": Object {
+      "a": 1,
+      "aud": "postgraphile",
+      "b": 2,
+      "c": 3,
+      "exp": 2130969600,
+      "iat": "[timestamp]",
+      "iss": "postgraphile",
+      "role": "yay",
+    },
+    "personById": Object {
+      "id": 1,
+      "name": "John Smith",
+    },
+  },
+  "personById": Object {
+    "id": 1,
+    "name": "John Smith",
   },
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/queries-jwt.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries-jwt.test.js
@@ -92,19 +92,25 @@ const tests = [
           jwt
           id
           admin
+          personById {
+            id
+            name
+          }
+        }
+        personById {
+          id
+          name
         }
       }
     }`,
     schema: "withJwt",
-    process: ({
-      data: {
-        authenticatePayload: { authPayload },
-      },
-    }) => {
-      const { jwt: str } = authPayload;
-      return Object.assign({}, authPayload, {
-        jwt: Object.assign(jwt.verify(str, jwtSecret), {
-          iat: "[timestamp]",
+    process: ({ data: { authenticatePayload } }) => {
+      const { jwt: str } = authenticatePayload.authPayload;
+      return Object.assign({}, authenticatePayload, {
+        authPayload: Object.assign({}, authenticatePayload.authPayload, {
+          jwt: Object.assign(jwt.verify(str, jwtSecret), {
+            iat: "[timestamp]",
+          }),
         }),
       });
     },

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -304,6 +304,9 @@ type AuthenticatePayloadPayload {
   \\"\\"\\"
   clientMutationId: String
 
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
+
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -314,6 +317,9 @@ type AuthPayload {
   admin: Boolean
   id: Int
   jwt: JwtToken
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
 }
 
 \\"\\"\\"
@@ -10340,6 +10346,9 @@ type AuthenticatePayloadPayload {
   \\"\\"\\"
   clientMutationId: String
 
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
+
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -10350,6 +10359,9 @@ type AuthPayload {
   admin: Boolean
   id: Int
   jwt: JwtToken
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
 }
 
 \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
@@ -304,6 +304,9 @@ type AuthenticatePayloadPayload {
   \\"\\"\\"
   clientMutationId: String
 
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
+
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -314,6 +317,9 @@ type AuthPayload {
   admin: Boolean
   id: Int
   jwt: JwtToken
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
 }
 
 \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
@@ -309,6 +309,9 @@ type AuthenticatePayloadPayload {
   \\"\\"\\"
   clientMutationId: String
 
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
+
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -319,6 +322,9 @@ type AuthPayload {
   admin: Boolean
   id: Int
   jwt: JwtToken
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
 }
 
 \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -1619,6 +1619,9 @@ type AuthenticatePayloadPayload {
   \\"\\"\\"
   clientMutationId: String
 
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
+
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -1629,6 +1632,9 @@ type AuthPayload {
   admin: Boolean
   id: Int
   jwt: JwtToken
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
 }
 
 \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
@@ -304,6 +304,9 @@ type AuthenticatePayloadPayload {
   \\"\\"\\"
   clientMutationId: String
 
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
+
   \\"\\"\\"
   Our root query field type. Allows us to run any query from our mutation payload.
   \\"\\"\\"
@@ -314,6 +317,9 @@ type AuthPayload {
   admin: Boolean
   id: Int
   jwt: JwtToken
+
+  \\"\\"\\"Reads a single \`Person\` that is related to this \`AuthPayload\`.\\"\\"\\"
+  personById: Person
 }
 
 \\"\\"\\"

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -393,6 +393,8 @@ create type b.auth_payload as (
   admin bool
 );
 
+comment on type b.auth_payload is E'@foreignKey (id) references c.person';
+
 create function b.authenticate_payload(a integer, b numeric, c bigint) returns b.auth_payload as $$ select (('yay', extract(epoch from '2037-07-12'::timestamp), a, b, c)::b.jwt_token, 1, true)::b.auth_payload $$ language sql;
 
 create table a.similar_table_1 (


### PR DESCRIPTION
Enables the one-way relation required for `@foreignKey` to make sense on composite types that have no backing table/view/materialized view.