### PR TITLE
feat(postgraphile): ignore schema and rely on search_path

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -122,7 +122,7 @@ class QueryBuilder {
       typeof options.ignoreSchemas === "undefined" ||
       options.ignoreSchemas === null
         ? false
-        : !!options.ignoreSchemas
+        : !!options.ignoreSchemas;
     this.locks = {
       // As a performance optimisation, we're going to list a number of lock
       // types so that V8 doesn't need to mutate the object too much
@@ -805,7 +805,7 @@ order by (row_number() over (partition by 1)) desc`;
       if (this.data.from) {
         const f = this.data.from;
         let _f = [callIfNecessary(f[0], context), f[1]];
-        if (this.ignoreSchemas) {
+        if (this.ignoreSchemas && _f[0].type === 'IDENTIFIER') {
           _f[0] = { ..._f[0], names: _f[0].names.slice(-1) };
         }
         this.compiledData.from = _f;

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -319,6 +319,7 @@ export default (function PgBasicsPlugin(
     pgStrictFunctions = false,
     pgColumnFilter = defaultPgColumnFilter,
     pgIgnoreRBAC = false,
+    pgIgnoreSchemas = false,
     pgIgnoreIndexes = true, // TODO:v5: change this to false
     pgLegacyJsonUuid = false, // TODO:v5: remove this
   }
@@ -343,7 +344,7 @@ export default (function PgBasicsPlugin(
 
         // TODO:v5: remove this workaround
         // BEWARE: this may be overridden in PgIntrospectionPlugin for PG < 9.5
-        pgQueryFromResolveData: queryFromResolveDataFactory(),
+        pgQueryFromResolveData: queryFromResolveDataFactory({ pgIgnoreSchemas }),
 
         pgAddStartEndCursor: addStartEndCursor,
         pgOmit,

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -101,6 +101,7 @@ export interface PostGraphileCoreOptions {
   ignoreRBAC?: boolean;
   legacyFunctionsOnly?: boolean;
   ignoreIndexes?: boolean;
+  ignoreSchemas?: boolean;
   subscriptions?: boolean;
   live?: boolean;
   ownerConnectionString?: string;
@@ -219,6 +220,7 @@ const getPostGraphileBuilder = async (
     ignoreRBAC = true, // TODO:v5: Change to 'false' in v5
     legacyFunctionsOnly = false, // TODO:v5: Remove in v5
     ignoreIndexes = true, // TODO:v5: Change to 'false' in v5
+    ignoreSchemas = false,
     subscriptions: inSubscriptions = false, // TODO:v5: Change to 'true' in v5
     live = false,
     ownerConnectionString,
@@ -380,6 +382,7 @@ const getPostGraphileBuilder = async (
     pgIgnoreRBAC: ignoreRBAC,
     pgLegacyFunctionsOnly: legacyFunctionsOnly,
     pgIgnoreIndexes: ignoreIndexes,
+    pgIgnoreSchemas: ignoreSchemas,
     pgOwnerConnectionString: ownerConnectionString,
 
     /*


### PR DESCRIPTION
Per [graphile/postgraphile #191](https://github.com/graphile/postgraphile/issues/191), creates an `ignoreSchemas` (default: `false`) configuration option to disable automatic prepending of the schema name to the table name.  In the case of multi-tenant applications (where there's a schema per tenant), `search_path` can instead be supplied via the callback to `pgSettings` based on the inbound JWT.

I've sought to accomplish this with minimal changes to the pre-existing codebase, however I'm open to alternative approaches if desired.