### PR TITLE
fix(lds): correct the set of LDS announcement types handled

### DIFF
--- a/packages/subscriptions-lds/src/PgLDSSourcePlugin.ts
+++ b/packages/subscriptions-lds/src/PgLDSSourcePlugin.ts
@@ -260,7 +260,8 @@ export class LDSLiveSource {
       const messageString = message.toString("utf8");
       const payload = JSON.parse(messageString);
       switch (payload._) {
-        case "insert":
+        case "insertC":
+        case "updateC":
         case "update":
         case "delete":
           return this.handleAnnouncement(payload);


### PR DESCRIPTION
This caused some events for live queries not to come through when using the LD server in a standalone configuration.