### PR TITLE
Run pluralize on only the last segment of a name

### DIFF
--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -14,10 +14,15 @@ import {
 } from "graphql-parse-resolve-info";
 import debugFactory from "debug";
 import type { ResolveTree } from "graphql-parse-resolve-info";
-import pluralize from "pluralize";
 import LRU from "@graphile/lru";
 import semver from "semver";
-import { upperCamelCase, camelCase, constantCase } from "./utils";
+import {
+  upperCamelCase,
+  camelCase,
+  constantCase,
+  pluralize,
+  singularize
+} from "./utils";
 import swallowError from "./swallowError";
 import resolveNode from "./resolveNode";
 import { LiveCoordinator } from "./Live";
@@ -886,7 +891,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
     fieldArgDataGeneratorsByFieldNameByType,
     inflection: {
       pluralize,
-      singularize: pluralize.singular,
+      singularize,
       upperCamelCase,
       camelCase,
       constantCase,

--- a/packages/graphile-build/src/utils.js
+++ b/packages/graphile-build/src/utils.js
@@ -32,11 +32,22 @@ export const formatInsideUnderscores = (fn: (input: string) => string) => (
   return `${start}${fn(middle)}${end}`;
 };
 
+export const formatLastSegment = (fn: (input: string) => string) => (
+  str: string
+) => {
+  const matches = str.match(/^([\s\S]*?)([A-Z]?[a-z0-9]*)$/);
+  if (!matches) {
+    throw new Error("Impossible?"); // Satiate Flow
+  }
+  const [, start, end] = matches;
+  return `${start}${fn(end)}`;
+};
+
 export const upperFirst = formatInsideUnderscores(upperFirstAll);
 export const camelCase = formatInsideUnderscores(camelCaseAll);
 export const constantCase = formatInsideUnderscores(constantCaseAll);
 export const upperCamelCase = (str: string): string =>
   upperFirst(camelCase(str));
 
-export const pluralize = (str: string) => plz(str);
-export const singularize = (str: string) => plz.singular(str);
+export const pluralize = formatInsideUnderscores(formatLastSegment(plz));
+export const singularize = formatInsideUnderscores(formatLastSegment(plz.singular));


### PR DESCRIPTION
My fix for https://github.com/graphile/graphile-engine/issues/471. Not sure if this is how you would want to resolve this but thought I would share since this solution was quick.

Switched `makeNewBuild` to use pluralize from utils and created in `formatLastSegment ` in the style of `formatInsideUnderscores`. Now `pluralize` and `singularize` will only be run on the final segment of a word, so special cased words will return proper results.

I believe this may increase the number of naming conflicts as many words would now pluralize to themselves, for example 'species'.