### PR TITLE
Warning has typo in command line option suggestion

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -888,7 +888,7 @@ export default (async function PgIntrospectionPlugin(
                     );
                     console.warn(
                       chalk.yellow(
-                        "This is likely because the PostgreSQL user in the connection string does not have sufficient privileges; you can solve this by passing the 'owner' connection string via '--owner-connection-string' / 'ownerConnectionString'. If the fixtures already exist, the watch functionality may still work."
+                        "This is likely because the PostgreSQL user in the connection string does not have sufficient privileges; you can solve this by passing the 'owner' connection string via '--owner-connection' / 'ownerConnectionString'. If the fixtures already exist, the watch functionality may still work."
                       )
                     );
                     console.warn(


### PR DESCRIPTION
The "Failed to setup watch fixtures in Postgres database" has been corrected to suggest that the command line option is --owner-connection instead of --owner-connection-string.