### PR TITLE
feat: allow passing readCache as an object

### DIFF
--- a/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
+++ b/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
@@ -1,3 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`when cache file has invalid content, getPostGraphileBuilder should error 1`] = `[Error: Failed to parse cache file 'path/to/cache', perhaps it is corrupted? SyntaxError: Unexpected token h in JSON at position 1]`;
+
+exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Array 1`] = `undefined`;
+
+exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Boolean 1`] = `[Error: 'readCache' not understood; expected string or object, but received 'boolean']`;
+
+exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Number 1`] = `[Error: 'readCache' not understood; expected string or object, but received 'number']`;

--- a/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
+++ b/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`When readCache is String if cache file has invalid content, getPostGraphileBuilder should error 1`] = `[Error: Failed to parse cache file 'path/to/cache', perhaps it is corrupted? SyntaxError: Unexpected token h in JSON at position 1]`;
 
-exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Array 1`] = `[Error: 'readCache' not understood; expected string or object, but received 'object']`;
+exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Array 1`] = `[Error: 'readCache' not understood; expected string or object, but received 'array']`;
 
 exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Boolean 1`] = `[Error: 'readCache' not understood; expected string or object, but received 'boolean']`;
 

--- a/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
+++ b/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`when cache file has invalid content, getPostGraphileBuilder should error 1`] = `[Error: Failed to parse cache file 'path/to/cache', perhaps it is corrupted? SyntaxError: Unexpected token h in JSON at position 1]`;
+exports[`When readCache is String if cache file has invalid content, getPostGraphileBuilder should error 1`] = `[Error: Failed to parse cache file 'path/to/cache', perhaps it is corrupted? SyntaxError: Unexpected token h in JSON at position 1]`;
 
 exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Array 1`] = `undefined`;
 

--- a/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
+++ b/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`When readCache is String if cache file has invalid content, getPostGraphileBuilder should error 1`] = `[Error: Failed to parse cache file 'path/to/cache', perhaps it is corrupted? SyntaxError: Unexpected token h in JSON at position 1]`;
 
-exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Array 1`] = `undefined`;
+exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Array 1`] = `[Error: 'readCache' not understood; expected string or object, but received 'object']`;
 
 exports[`when readCache is not String or Object, getPostGraphileBuilder should error when its Boolean 1`] = `[Error: 'readCache' not understood; expected string or object, but received 'boolean']`;
 

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -87,6 +87,7 @@ describe("When readCache is String", () => {
     } catch (e) {
       error = e;
     }
+    expect(error).toBeDefined();
     expect(error).toMatchSnapshot();
     expect(fs.readFile).toHaveBeenCalledTimes(1);
   });
@@ -124,6 +125,7 @@ describe("when readCache is not String or Object, getPostGraphileBuilder should 
     } catch (e) {
       error = e;
     }
+    expect(error).toBeDefined();
     expect(error).toMatchSnapshot();
   });
   test("when its Array", async () => {
@@ -136,6 +138,7 @@ describe("when readCache is not String or Object, getPostGraphileBuilder should 
     } catch (e) {
       error = e;
     }
+    expect(error).toBeDefined();
     expect(error).toMatchSnapshot();
   });
   test("when its Number", async () => {
@@ -148,6 +151,7 @@ describe("when readCache is not String or Object, getPostGraphileBuilder should 
     } catch (e) {
       error = e;
     }
+    expect(error).toBeDefined();
     expect(error).toMatchSnapshot();
   });
 });

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -11,11 +11,16 @@ beforeEach(() => {
 });
 
 /*
-
 Current behaviour of getPostGraphileBuilder and readCache option:
 
+If readCache is String: 
 1. cacheString is loaded by reading the file defined by readCache
 2. memoizeCache is set by JSON.parse(cacheString)
+
+If readCache is Object:
+1. memoizeCache is set as readCache directly
+
+Then
 3. persistentMemoizeWithKey is a function created dynamically that will use memoizeCache
 4. getBuilder(imported from graphile-build) is called, passing persistentMemoizeWithKey as one of the arguments
 
@@ -24,34 +29,7 @@ Test strategy for readCache
 1. Mock fs.readFile to control input
 2. Mock getBuilder to control output
 3. Test different inputs and validate that getBuilder is called with expected output
-
 */
-
-test("when cache file has content, persistentMemoizeWithKey should be a valid function", async () => {
-  // mock fs.readFile to return an object
-  fs.readFile.mockImplementationOnce((path, options, cb) =>
-    cb(null, '{ "__test": true }')
-  );
-
-  // mock getBuilder to fake output
-  const expectedOutput = {};
-  graphileBuild.getBuilder.mockResolvedValueOnce(expectedOutput);
-  // call our method and test output
-  const output = await getPostGraphileBuilder({}, [], {
-    readCache: "path/to/cache",
-  });
-  expect(output).toBe(expectedOutput);
-  expect(fs.readFile).toHaveBeenCalledTimes(1);
-  expect(graphileBuild.getBuilder).toHaveBeenCalledTimes(1);
-  // check persistentMemoizeWithKey, the actual "result" of readCache flag
-  const {
-    persistentMemoizeWithKey,
-  } = graphileBuild.getBuilder.mock.calls[0][1];
-  expect(typeof persistentMemoizeWithKey).toBe("function");
-  expect(persistentMemoizeWithKey("__test")).toEqual(true);
-  expect(() => persistentMemoizeWithKey("unknown_key")).toThrow();
-});
-
 test("when no readCache flag, persistentMemoizeWithKey should be undefined", async () => {
   // mock getBuilder to fake output
   const expectedOutput = {};
@@ -67,24 +45,51 @@ test("when no readCache flag, persistentMemoizeWithKey should be undefined", asy
   expect(persistentMemoizeWithKey).toBeUndefined();
 });
 
-test("when cache file has invalid content, getPostGraphileBuilder should error", async () => {
-  // mock fs.readFile to return an object
-  fs.readFile.mockImplementationOnce((path, options, cb) =>
-    cb(null, "thisisnotjson")
-  );
+describe("When readCache is String", () => {
+  test("if cache file has content, persistentMemoizeWithKey should be a valid function", async () => {
+    // mock fs.readFile to return an object
+    fs.readFile.mockImplementationOnce((path, options, cb) =>
+      cb(null, '{ "__test": true }')
+    );
 
-  // call our method and check error
-
-  let error;
-  try {
-    await getPostGraphileBuilder({}, [], {
+    // mock getBuilder to fake output
+    const expectedOutput = {};
+    graphileBuild.getBuilder.mockResolvedValueOnce(expectedOutput);
+    // call our method and test output
+    const output = await getPostGraphileBuilder({}, [], {
       readCache: "path/to/cache",
     });
-  } catch (e) {
-    error = e;
-  }
-  expect(error).toMatchSnapshot();
-  expect(fs.readFile).toHaveBeenCalledTimes(1);
+    expect(output).toBe(expectedOutput);
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+    expect(graphileBuild.getBuilder).toHaveBeenCalledTimes(1);
+    // check persistentMemoizeWithKey, the actual "result" of readCache flag
+    const {
+      persistentMemoizeWithKey,
+    } = graphileBuild.getBuilder.mock.calls[0][1];
+    expect(typeof persistentMemoizeWithKey).toBe("function");
+    expect(persistentMemoizeWithKey("__test")).toEqual(true);
+    expect(() => persistentMemoizeWithKey("unknown_key")).toThrow();
+  });
+
+  test("if cache file has invalid content, getPostGraphileBuilder should error", async () => {
+    // mock fs.readFile to return an object
+    fs.readFile.mockImplementationOnce((path, options, cb) =>
+      cb(null, "thisisnotjson")
+    );
+
+    // call our method and check error
+
+    let error;
+    try {
+      await getPostGraphileBuilder({}, [], {
+        readCache: "path/to/cache",
+      });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toMatchSnapshot();
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("when readCache is not String or Object, getPostGraphileBuilder should error", () => {

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -92,6 +92,27 @@ describe("When readCache is String", () => {
   });
 });
 
+describe("When readCache is Object", () => {
+  test("persistentMemoizeWithKey should be a valid function", async () => {
+    // mock getBuilder to fake output
+    const expectedOutput = {};
+    graphileBuild.getBuilder.mockResolvedValueOnce(expectedOutput);
+    // call our method and test output
+    const output = await getPostGraphileBuilder({}, [], {
+      readCache: { __test: true },
+    });
+    expect(output).toBe(expectedOutput);
+    expect(graphileBuild.getBuilder).toHaveBeenCalledTimes(1);
+    // check persistentMemoizeWithKey, the actual "result" of readCache flag
+    const {
+      persistentMemoizeWithKey,
+    } = graphileBuild.getBuilder.mock.calls[0][1];
+    expect(typeof persistentMemoizeWithKey).toBe("function");
+    expect(persistentMemoizeWithKey("__test")).toEqual(true);
+    expect(() => persistentMemoizeWithKey("unknown_key")).toThrow();
+  });
+});
+
 describe("when readCache is not String or Object, getPostGraphileBuilder should error", () => {
   test("when its Boolean", async () => {
     // call our method with invalid readCache value and check error

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -86,3 +86,42 @@ test("when cache file has invalid content, getPostGraphileBuilder should error",
   expect(error).toMatchSnapshot();
   expect(fs.readFile).toHaveBeenCalledTimes(1);
 });
+
+describe("when readCache is not String or Object, getPostGraphileBuilder should error", () => {
+  test("when its Boolean", async () => {
+    // call our method with invalid readCache value and check error
+    let error;
+    try {
+      await getPostGraphileBuilder({}, [], {
+        readCache: true,
+      });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toMatchSnapshot();
+  });
+  test("when its Array", async () => {
+    // call our method with invalid readCache value and check error
+    let error;
+    try {
+      await getPostGraphileBuilder({}, [], {
+        readCache: [],
+      });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toMatchSnapshot();
+  });
+  test("when its Number", async () => {
+    // call our method with invalid readCache value and check error
+    let error;
+    try {
+      await getPostGraphileBuilder({}, [], {
+        readCache: 3,
+      });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toMatchSnapshot();
+  });
+});

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -293,7 +293,9 @@ export const getPostGraphileBuilder = async (
       memoizeCache = readCache;
     } else {
       throw new Error(
-        `'readCache' not understood; expected string or object, but received '${Array.isArray(readCache) ? 'array' : typeof readCache}'`
+        `'readCache' not understood; expected string or object, but received '${
+          Array.isArray(readCache) ? "array" : typeof readCache
+        }'`
       );
     }
   }

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -283,6 +283,8 @@ const getPostGraphileBuilder = async (
     }
   } else if (readCache && typeof readCache === "object") {
     memoizeCache = readCache;
+  } else {
+    throw new Error(`'readCache' not understood; expected string or object, but received '${typeof readCache}'`);
   }
   if (readCache || writeCache) {
     persistentMemoizeWithKey = (key: string, fn: () => any) => {

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -208,7 +208,7 @@ const getPostGraphileBuilder = async (
     pgColumnFilter,
     viewUniqueKey,
     enableTags = true,
-    readCache,
+    readCache, // string or Object
     writeCache,
     setWriteCacheCallback,
     legacyRelations = "deprecated", // TODO:v5: Change to 'omit' in v5
@@ -261,7 +261,7 @@ const getPostGraphileBuilder = async (
   let persistentMemoizeWithKey; // NOT null, otherwise it won't default correctly.
   let memoizeCache = {};
 
-  if (readCache) {
+  if (readCache && typeof readCache === "string") {
     const cacheString: string = await new Promise<string>((resolve, reject) => {
       fs.readFile(readCache, "utf8", (err?: Error | null, data?: string) => {
         if (err) {
@@ -278,6 +278,8 @@ const getPostGraphileBuilder = async (
         `Failed to parse cache file '${readCache}', perhaps it is corrupted? ${e}`
       );
     }
+  } else if (readCache && typeof readCache === "object") {
+    memoizeCache = readCache;
   }
   if (readCache || writeCache) {
     persistentMemoizeWithKey = (key: string, fn: () => any) => {

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -293,7 +293,7 @@ export const getPostGraphileBuilder = async (
       memoizeCache = readCache;
     } else {
       throw new Error(
-        `'readCache' not understood; expected string or object, but received '${typeof readCache}'`
+        `'readCache' not understood; expected string or object, but received '${Array.isArray(readCache) ? 'array' : typeof readCache}'`
       );
     }
   }

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -289,7 +289,7 @@ export const getPostGraphileBuilder = async (
           `Failed to parse cache file '${readCache}', perhaps it is corrupted? ${e}`
         );
       }
-    } else if (typeof readCache === "object") {
+    } else if (typeof readCache === "object" && !Array.isArray(readCache)) {
       memoizeCache = readCache;
     } else {
       throw new Error(

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -263,28 +263,37 @@ const getPostGraphileBuilder = async (
 
   let persistentMemoizeWithKey; // NOT null, otherwise it won't default correctly.
   let memoizeCache = {};
-
-  if (readCache && typeof readCache === "string") {
-    const cacheString: string = await new Promise<string>((resolve, reject) => {
-      fs.readFile(readCache, "utf8", (err?: Error | null, data?: string) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(data);
+  if (readCache) {
+    if (typeof readCache === "string") {
+      const cacheString: string = await new Promise<string>(
+        (resolve, reject) => {
+          fs.readFile(
+            readCache,
+            "utf8",
+            (err?: Error | null, data?: string) => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve(data);
+              }
+            }
+          );
         }
-      });
-    });
-    try {
-      memoizeCache = JSON.parse(cacheString);
-    } catch (e) {
+      );
+      try {
+        memoizeCache = JSON.parse(cacheString);
+      } catch (e) {
+        throw new Error(
+          `Failed to parse cache file '${readCache}', perhaps it is corrupted? ${e}`
+        );
+      }
+    } else if (typeof readCache === "object") {
+      memoizeCache = readCache;
+    } else {
       throw new Error(
-        `Failed to parse cache file '${readCache}', perhaps it is corrupted? ${e}`
+        `'readCache' not understood; expected string or object, but received '${typeof readCache}'`
       );
     }
-  } else if (readCache && typeof readCache === "object") {
-    memoizeCache = readCache;
-  } else {
-    throw new Error(`'readCache' not understood; expected string or object, but received '${typeof readCache}'`);
   }
   if (readCache || writeCache) {
     persistentMemoizeWithKey = (key: string, fn: () => any) => {

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -90,7 +90,7 @@ export interface PostGraphileCoreOptions {
    */
   viewUniqueKey?: string;
   enableTags?: boolean;
-  readCache?: string;
+  readCache?: string | object;
   writeCache?: string;
   setWriteCacheCallback?: (fn: () => Promise<void>) => void;
   legacyRelations?: "only" | "deprecated" | "omit";
@@ -208,7 +208,7 @@ const getPostGraphileBuilder = async (
     pgColumnFilter,
     viewUniqueKey,
     enableTags = true,
-    readCache, // string or Object
+    readCache,
     writeCache,
     setWriteCacheCallback,
     legacyRelations = "deprecated", // TODO:v5: Change to 'omit' in v5


### PR DESCRIPTION
*This is still a Work In Progress, do not merge :)*

This PR allows passing a `readCache object` to `getPostGraphileBuilder`. The functionality is backwards compatible, passing a `readCache` string with a path to a file will still work on the same way.