### PR TITLE
feat(utils): make extend schema plugin more powerful

### DIFF
--- a/packages/graphile-build/src/SchemaBuilder.d.ts
+++ b/packages/graphile-build/src/SchemaBuilder.d.ts
@@ -3,6 +3,7 @@ import {
   GraphQLSchemaConfig,
   GraphQLObjectTypeConfig,
   GraphQLInterfaceType,
+  GraphQLObjectType,
   GraphQLInputObjectTypeConfig,
   GraphQLEnumTypeConfig,
   GraphQLFieldConfigArgumentMap,
@@ -12,6 +13,7 @@ import {
   GraphQLEnumValueConfig,
   GraphQLInputFieldConfigMap,
   GraphQLInputFieldConfig,
+  GraphQLUnionTypeConfig,
 } from "graphql";
 import { EventEmitter } from "events";
 
@@ -160,6 +162,20 @@ export default class SchemaBuilder extends EventEmitter {
   hook(
     hookName: "GraphQLEnumType:values:value",
     fn: Hook<GraphQLEnumValueConfig>,
+    provides?: Array<string>,
+    before?: Array<string>,
+    after?: Array<string>
+  ): void;
+  hook<TSource, TContext>(
+    hookName: "GraphQLUnionType",
+    fn: Hook<GraphQLUnionTypeConfig<TSource, TContext>>,
+    provides?: Array<string>,
+    before?: Array<string>,
+    after?: Array<string>
+  ): void;
+  hook(
+    hookName: "GraphQLUnionType:types",
+    fn: Hook<Array<GraphQLObjectType>>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -17,6 +17,7 @@ import type {
   parseResolveInfo,
 } from "graphql-parse-resolve-info";
 import type { GraphQLResolveInfo } from "graphql/type/definition";
+import type resolveNode from "./resolveNode";
 
 import type { FieldWithHooksFunction } from "./makeNewBuild";
 const { GraphQLSchema } = graphql;
@@ -71,6 +72,8 @@ export type Build = {|
     [string]: (...args: Array<any>) => string,
   },
   swallowError: (e: Error) => void,
+  // resolveNode: EXPERIMENTAL, API might change!
+  resolveNode: resolveNode,
   status: {
     currentHookName: ?string,
     currentHookEvent: ?string,

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -217,6 +217,13 @@ class SchemaBuilder extends EventEmitter {
       GraphQLEnumType: [],
       "GraphQLEnumType:values": [],
       "GraphQLEnumType:values:value": [],
+
+      // When creating a GraphQLUnionType via `newWithHooks`, we'll
+      // execute, the following hooks:
+      // - 'GraphQLUnionType' to add any root-level attributes, e.g. add a description
+      // - 'GraphQLUnionType:types' to add additional types to this union
+      GraphQLUnionType: [],
+      "GraphQLUnionType:types": [],
     };
   }
 

--- a/packages/graphile-build/src/plugins/NodePlugin.js
+++ b/packages/graphile-build/src/plugins/NodePlugin.js
@@ -6,7 +6,6 @@ import type {
   Context,
   ContextGraphQLObjectTypeFields,
 } from "../SchemaBuilder";
-import resolveNode from "../resolveNode";
 import type { ResolveTree } from "graphql-parse-resolve-info";
 import type {
   GraphQLType,
@@ -198,6 +197,7 @@ export default (function NodePlugin(
         extend,
         graphql: { GraphQLNonNull, GraphQLID },
         inflection,
+        resolveNode,
       } = build;
       return extend(
         fields,


### PR DESCRIPTION
Adds support for makeExtendSchemaPlugin defining unions and directives required for Apollo Federation support.

Does not have tests.

HIGHLY EXPERIMENTAL.

_Note: don't get excited, this does not improve support for unions, it just allows you to express them via SDL rather than having to write them out manually. The same "root and leaves only" union rule applies to unions - you can't have unions in the middle of the tree because our query planner still doesn't understand them in that position._