### PR TITLE
chore(deps): Update peerDependencies of graphile-utils

### DIFF
--- a/packages/graphile-utils/package.json
+++ b/packages/graphile-utils/package.json
@@ -49,8 +49,8 @@
     "typescript": "^3.4.5"
   },
   "peerDependencies": {
-    "graphile-build": "^4.4.1-alpha.2",
-    "graphile-build-pg": "^4.4.1-alpha.2"
+    "graphile-build": "^4.4.2",
+    "graphile-build-pg": "^4.4.2"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
I'm getting a warning at the moment when installing. Are `peerDependencies` skipped on purpose?