### PR TITLE
Update error message for watch

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -888,7 +888,7 @@ export default (async function PgIntrospectionPlugin(
                     );
                     console.warn(
                       chalk.yellow(
-                        "This is likely because the PostgreSQL user in the connection string does not have sufficient privileges; you can solve this by passing the 'owner' connection string via '--owner-connection' / 'ownerConnectionString'. If the fixtures already exist, the watch functionality may still work."
+                        "This is likely because the PostgreSQL user in the connection string does not have sufficient privileges; you can solve this by passing the 'owner' connection string via '--owner-connection' (cli argument), 'ownerConnectionString' (library), or 'options.ownerConnection' (configuring the cli from .postgraphilerc.js). If the fixtures already exist, the watch functionality may still work."
                       )
                     );
                     console.warn(


### PR DESCRIPTION
Hello, this is a first PR for this project. I hope you don't mind I skipped the "ask first" instruction because this is a minor change to an error message, so simply typing this description was more time consuming than the actual PR.

While trying to setup new roles, I broke watching and got an error like:
```
Failed to setup watch fixtures in Postgres database ️️⚠️
This is likely because the PostgreSQL user in the connection string does not have sufficient privileges; you can solve this by passing the 'owner' connection string via '--owner-connection' / 'ownerConnectionString'. If the fixtures already exist, the watch functionality may still work.
Enable DEBUG='graphile-build-pg' to see the error
```

I am using the CLI and passing configuration via the options prop in `.postgraphilerc.js`. Per this message, I added `options.ownerConnectionString`. It appears that it should be options.ownerConnection. My guess is the existing language is meant for `library.ownerConnection`. Anyhow, I thought this PR might provide some clarity for any future newbie who stumbles on it.

If this is unwelcome or simply reflects some user error on my part, feel free to close. If you think it might be preferable to use the same property name in both cases or some other alternative, I'm happy to try that instead, I would like to contribute in some way as I make use of this project.