### PR TITLE
Replace Object.assign() with object spread operator

### DIFF
--- a/packages/graphile-build-pg/src/inflections.js
+++ b/packages/graphile-build-pg/src/inflections.js
@@ -86,270 +86,260 @@ export const newInflector = (
   }
 
   return deprecateEverything(
-    preventEmptyResult(
-      Object.assign(
-        {
-          pluralize,
-          argument(name: ?string, index: number) {
-            return camelCase(name || `arg${index}`);
-          },
-          orderByType(typeName: string) {
-            return upperCamelCase(`${pluralize(typeName)}-order-by`);
-          },
-          orderByEnum(
-            name: string,
-            ascending: boolean,
-            _table: string,
-            _schema: ?string
-          ) {
-            return constantCase(`${name}_${ascending ? "asc" : "desc"}`);
-          },
-          domainType(name: string) {
-            return upperCamelCase(name);
-          },
-          enumName(inValue: string) {
-            let value = inValue;
+    preventEmptyResult({
+      pluralize,
+      argument(name: ?string, index: number) {
+        return camelCase(name || `arg${index}`);
+      },
+      orderByType(typeName: string) {
+        return upperCamelCase(`${pluralize(typeName)}-order-by`);
+      },
+      orderByEnum(
+        name: string,
+        ascending: boolean,
+        _table: string,
+        _schema: ?string
+      ) {
+        return constantCase(`${name}_${ascending ? "asc" : "desc"}`);
+      },
+      domainType(name: string) {
+        return upperCamelCase(name);
+      },
+      enumName(inValue: string) {
+        let value = inValue;
 
-            if (value === "") {
-              return "_EMPTY_";
-            }
+        if (value === "") {
+          return "_EMPTY_";
+        }
 
-            // Some enums use asterisks to signify wildcards - this might be for
-            // the whole item, or prefixes/suffixes, or even in the middle.  This
-            // is provided on a best efforts basis, if it doesn't suit your
-            // purposes then please pass a custom inflector as mentioned below.
-            value = value
-              .replace(/\*/g, "_ASTERISK_")
-              .replace(/^(_?)_+ASTERISK/, "$1ASTERISK")
-              .replace(/ASTERISK_(_?)_*$/, "ASTERISK$1");
+        // Some enums use asterisks to signify wildcards - this might be for
+        // the whole item, or prefixes/suffixes, or even in the middle.  This
+        // is provided on a best efforts basis, if it doesn't suit your
+        // purposes then please pass a custom inflector as mentioned below.
+        value = value
+          .replace(/\*/g, "_ASTERISK_")
+          .replace(/^(_?)_+ASTERISK/, "$1ASTERISK")
+          .replace(/ASTERISK_(_?)_*$/, "ASTERISK$1");
 
-            // This is a best efforts replacement for common symbols that you
-            // might find in enums. Generally we only support enums that are
-            // alphanumeric, if these replacements don't work for you, you should
-            // pass a custom inflector that replaces this `enumName` method
-            // with one of your own chosing.
-            value =
-              {
-                // SQL comparison operators
-                ">": "GREATER_THAN",
-                ">=": "GREATER_THAN_OR_EQUAL",
-                "=": "EQUAL",
-                "!=": "NOT_EQUAL",
-                "<>": "DIFFERENT",
-                "<=": "LESS_THAN_OR_EQUAL",
-                "<": "LESS_THAN",
+        // This is a best efforts replacement for common symbols that you
+        // might find in enums. Generally we only support enums that are
+        // alphanumeric, if these replacements don't work for you, you should
+        // pass a custom inflector that replaces this `enumName` method
+        // with one of your own chosing.
+        value =
+          {
+            // SQL comparison operators
+            ">": "GREATER_THAN",
+            ">=": "GREATER_THAN_OR_EQUAL",
+            "=": "EQUAL",
+            "!=": "NOT_EQUAL",
+            "<>": "DIFFERENT",
+            "<=": "LESS_THAN_OR_EQUAL",
+            "<": "LESS_THAN",
 
-                // PostgreSQL LIKE shortcuts
-                "~~": "LIKE",
-                "~~*": "ILIKE",
-                "!~~": "NOT_LIKE",
-                "!~~*": "NOT_ILIKE",
+            // PostgreSQL LIKE shortcuts
+            "~~": "LIKE",
+            "~~*": "ILIKE",
+            "!~~": "NOT_LIKE",
+            "!~~*": "NOT_ILIKE",
 
-                // '~' doesn't necessarily represent regexps, but the three
-                // operators following it likely do, so we'll use the word TILDE
-                // in all for consistency.
-                "~": "TILDE",
-                "~*": "TILDE_ASTERISK",
-                "!~": "NOT_TILDE",
-                "!~*": "NOT_TILDE_ASTERISK",
+            // '~' doesn't necessarily represent regexps, but the three
+            // operators following it likely do, so we'll use the word TILDE
+            // in all for consistency.
+            "~": "TILDE",
+            "~*": "TILDE_ASTERISK",
+            "!~": "NOT_TILDE",
+            "!~*": "NOT_TILDE_ASTERISK",
 
-                // A number of other symbols where we're not sure of their
-                // meaning.  We give them common generic names so that they're
-                // suitable for multiple purposes, e.g. favouring 'PLUS' over
-                // 'ADDITION' and 'DOT' over 'FULL_STOP'
-                "%": "PERCENT",
-                "+": "PLUS",
-                "-": "MINUS",
-                "/": "SLASH",
-                "\\": "BACKSLASH",
-                _: "UNDERSCORE",
-                "#": "POUND",
-                "£": "STERLING",
-                $: "DOLLAR",
-                "&": "AMPERSAND",
-                "@": "AT",
-                "'": "APOSTROPHE",
-                '"': "QUOTE",
-                "`": "BACKTICK",
-                ":": "COLON",
-                ";": "SEMICOLON",
-                "!": "EXCLAMATION_POINT",
-                "?": "QUESTION_MARK",
-                ",": "COMMA",
-                ".": "DOT",
-                "^": "CARET",
-                "|": "BAR",
-                "[": "OPEN_BRACKET",
-                "]": "CLOSE_BRACKET",
-                "(": "OPEN_PARENTHESIS",
-                ")": "CLOSE_PARENTHESIS",
-                "{": "OPEN_BRACE",
-                "}": "CLOSE_BRACE",
-              }[value] || value;
-            return value;
-          },
-          enumType(name: string) {
-            return upperCamelCase(name);
-          },
-          conditionType(typeName: string) {
-            return upperCamelCase(`${typeName}-condition`);
-          },
-          inputType(typeName: string) {
-            return upperCamelCase(`${typeName}-input`);
-          },
-          rangeBoundType(typeName: string) {
-            return upperCamelCase(`${typeName}-range-bound`);
-          },
-          rangeType(typeName: string) {
-            return upperCamelCase(`${typeName}-range`);
-          },
-          patchType(typeName: string) {
-            return upperCamelCase(`${typeName}-patch`);
-          },
-          patchField(itemName: string) {
-            return camelCase(`${itemName}-patch`);
-          },
-          tableName(name: string, _schema: ?string) {
-            return camelCase(singularizeTable(name));
-          },
-          tableNode(name: string, _schema: ?string) {
-            return camelCase(singularizeTable(name));
-          },
-          allRows(name: string, schema: ?string) {
-            return camelCase(
-              `all-${this.pluralize(this.tableName(name, schema))}`
-            );
-          },
-          functionName(name: string, _schema: ?string) {
-            return camelCase(name);
-          },
-          functionPayloadType(name: string, _schema: ?string) {
-            return upperCamelCase(`${name}-payload`);
-          },
-          functionInputType(name: string, _schema: ?string) {
-            return upperCamelCase(`${name}-input`);
-          },
-          tableType(name: string, schema: ?string) {
-            return upperCamelCase(this.tableName(name, schema));
-          },
-          column(name: string, _table: string, _schema: ?string) {
-            return camelCase(name);
-          },
-          singleRelationByKeys(
-            detailedKeys: Keys,
-            table: string,
-            schema: ?string
-          ) {
-            return camelCase(
-              `${this.tableName(table, schema)}-by-${detailedKeys
-                .map(key => this.column(key.column, key.table, key.schema))
-                .join("-and-")}`
-            );
-          },
-          rowByUniqueKeys(detailedKeys: Keys, table: string, schema: ?string) {
-            return camelCase(
-              `${this.tableName(table, schema)}-by-${detailedKeys
-                .map(key => this.column(key.column, key.table, key.schema))
-                .join("-and-")}`
-            );
-          },
-          updateByKeys(detailedKeys: Keys, table: string, schema: ?string) {
-            return camelCase(
-              `update-${this.tableName(table, schema)}-by-${detailedKeys
-                .map(key => this.column(key.column, key.table, key.schema))
-                .join("-and-")}`
-            );
-          },
-          deleteByKeys(detailedKeys: Keys, table: string, schema: ?string) {
-            return camelCase(
-              `delete-${this.tableName(table, schema)}-by-${detailedKeys
-                .map(key => this.column(key.column, key.table, key.schema))
-                .join("-and-")}`
-            );
-          },
-          updateNode(name: string, _schema: ?string) {
-            return camelCase(`update-${singularizeTable(name)}`);
-          },
-          deleteNode(name: string, _schema: ?string) {
-            return camelCase(`delete-${singularizeTable(name)}`);
-          },
-          updateByKeysInputType(
-            detailedKeys: Keys,
-            name: string,
-            _schema: ?string
-          ) {
-            return upperCamelCase(
-              `update-${singularizeTable(name)}-by-${detailedKeys
-                .map(key => this.column(key.column, key.table, key.schema))
-                .join("-and-")}-input`
-            );
-          },
-          deleteByKeysInputType(
-            detailedKeys: Keys,
-            name: string,
-            _schema: ?string
-          ) {
-            return upperCamelCase(
-              `delete-${singularizeTable(name)}-by-${detailedKeys
-                .map(key => this.column(key.column, key.table, key.schema))
-                .join("-and-")}-input`
-            );
-          },
-          updateNodeInputType(name: string, _schema: ?string) {
-            return upperCamelCase(`update-${singularizeTable(name)}-input`);
-          },
-          deleteNodeInputType(name: string, _schema: ?string) {
-            return upperCamelCase(`delete-${singularizeTable(name)}-input`);
-          },
-          manyRelationByKeys(
-            detailedKeys: Keys,
-            table: string,
-            schema: ?string,
-            _foreignTable: string,
-            _foreignSchema: ?string
-          ) {
-            return camelCase(
-              `${this.pluralize(
-                this.tableName(table, schema)
-              )}-by-${detailedKeys
-                .map(key => this.column(key.column, key.table, key.schema))
-                .join("-and-")}`
-            );
-          },
-          edge(typeName: string) {
-            return upperCamelCase(`${pluralize(typeName)}-edge`);
-          },
-          edgeField(name: string, _schema: ?string) {
-            return camelCase(`${singularizeTable(name)}-edge`);
-          },
-          connection(typeName: string) {
-            return upperCamelCase(`${this.pluralize(typeName)}-connection`);
-          },
-          scalarFunctionConnection(procName: string, _procSchema: ?string) {
-            return upperCamelCase(`${procName}-connection`);
-          },
-          scalarFunctionEdge(procName: string, _procSchema: ?string) {
-            return upperCamelCase(`${procName}-edge`);
-          },
-          createField(name: string, _schema: ?string) {
-            return camelCase(`create-${singularizeTable(name)}`);
-          },
-          createInputType(name: string, _schema: ?string) {
-            return upperCamelCase(`create-${singularizeTable(name)}-input`);
-          },
-          createPayloadType(name: string, _schema: ?string) {
-            return upperCamelCase(`create-${singularizeTable(name)}-payload`);
-          },
-          updatePayloadType(name: string, _schema: ?string) {
-            return upperCamelCase(`update-${singularizeTable(name)}-payload`);
-          },
-          deletePayloadType(name: string, _schema: ?string) {
-            return upperCamelCase(`delete-${singularizeTable(name)}-payload`);
-          },
-        },
-        overrides
-      )
-    )
+            // A number of other symbols where we're not sure of their
+            // meaning.  We give them common generic names so that they're
+            // suitable for multiple purposes, e.g. favouring 'PLUS' over
+            // 'ADDITION' and 'DOT' over 'FULL_STOP'
+            "%": "PERCENT",
+            "+": "PLUS",
+            "-": "MINUS",
+            "/": "SLASH",
+            "\\": "BACKSLASH",
+            _: "UNDERSCORE",
+            "#": "POUND",
+            "£": "STERLING",
+            $: "DOLLAR",
+            "&": "AMPERSAND",
+            "@": "AT",
+            "'": "APOSTROPHE",
+            '"': "QUOTE",
+            "`": "BACKTICK",
+            ":": "COLON",
+            ";": "SEMICOLON",
+            "!": "EXCLAMATION_POINT",
+            "?": "QUESTION_MARK",
+            ",": "COMMA",
+            ".": "DOT",
+            "^": "CARET",
+            "|": "BAR",
+            "[": "OPEN_BRACKET",
+            "]": "CLOSE_BRACKET",
+            "(": "OPEN_PARENTHESIS",
+            ")": "CLOSE_PARENTHESIS",
+            "{": "OPEN_BRACE",
+            "}": "CLOSE_BRACE",
+          }[value] || value;
+        return value;
+      },
+      enumType(name: string) {
+        return upperCamelCase(name);
+      },
+      conditionType(typeName: string) {
+        return upperCamelCase(`${typeName}-condition`);
+      },
+      inputType(typeName: string) {
+        return upperCamelCase(`${typeName}-input`);
+      },
+      rangeBoundType(typeName: string) {
+        return upperCamelCase(`${typeName}-range-bound`);
+      },
+      rangeType(typeName: string) {
+        return upperCamelCase(`${typeName}-range`);
+      },
+      patchType(typeName: string) {
+        return upperCamelCase(`${typeName}-patch`);
+      },
+      patchField(itemName: string) {
+        return camelCase(`${itemName}-patch`);
+      },
+      tableName(name: string, _schema: ?string) {
+        return camelCase(singularizeTable(name));
+      },
+      tableNode(name: string, _schema: ?string) {
+        return camelCase(singularizeTable(name));
+      },
+      allRows(name: string, schema: ?string) {
+        return camelCase(`all-${this.pluralize(this.tableName(name, schema))}`);
+      },
+      functionName(name: string, _schema: ?string) {
+        return camelCase(name);
+      },
+      functionPayloadType(name: string, _schema: ?string) {
+        return upperCamelCase(`${name}-payload`);
+      },
+      functionInputType(name: string, _schema: ?string) {
+        return upperCamelCase(`${name}-input`);
+      },
+      tableType(name: string, schema: ?string) {
+        return upperCamelCase(this.tableName(name, schema));
+      },
+      column(name: string, _table: string, _schema: ?string) {
+        return camelCase(name);
+      },
+      singleRelationByKeys(detailedKeys: Keys, table: string, schema: ?string) {
+        return camelCase(
+          `${this.tableName(table, schema)}-by-${detailedKeys
+            .map(key => this.column(key.column, key.table, key.schema))
+            .join("-and-")}`
+        );
+      },
+      rowByUniqueKeys(detailedKeys: Keys, table: string, schema: ?string) {
+        return camelCase(
+          `${this.tableName(table, schema)}-by-${detailedKeys
+            .map(key => this.column(key.column, key.table, key.schema))
+            .join("-and-")}`
+        );
+      },
+      updateByKeys(detailedKeys: Keys, table: string, schema: ?string) {
+        return camelCase(
+          `update-${this.tableName(table, schema)}-by-${detailedKeys
+            .map(key => this.column(key.column, key.table, key.schema))
+            .join("-and-")}`
+        );
+      },
+      deleteByKeys(detailedKeys: Keys, table: string, schema: ?string) {
+        return camelCase(
+          `delete-${this.tableName(table, schema)}-by-${detailedKeys
+            .map(key => this.column(key.column, key.table, key.schema))
+            .join("-and-")}`
+        );
+      },
+      updateNode(name: string, _schema: ?string) {
+        return camelCase(`update-${singularizeTable(name)}`);
+      },
+      deleteNode(name: string, _schema: ?string) {
+        return camelCase(`delete-${singularizeTable(name)}`);
+      },
+      updateByKeysInputType(
+        detailedKeys: Keys,
+        name: string,
+        _schema: ?string
+      ) {
+        return upperCamelCase(
+          `update-${singularizeTable(name)}-by-${detailedKeys
+            .map(key => this.column(key.column, key.table, key.schema))
+            .join("-and-")}-input`
+        );
+      },
+      deleteByKeysInputType(
+        detailedKeys: Keys,
+        name: string,
+        _schema: ?string
+      ) {
+        return upperCamelCase(
+          `delete-${singularizeTable(name)}-by-${detailedKeys
+            .map(key => this.column(key.column, key.table, key.schema))
+            .join("-and-")}-input`
+        );
+      },
+      updateNodeInputType(name: string, _schema: ?string) {
+        return upperCamelCase(`update-${singularizeTable(name)}-input`);
+      },
+      deleteNodeInputType(name: string, _schema: ?string) {
+        return upperCamelCase(`delete-${singularizeTable(name)}-input`);
+      },
+      manyRelationByKeys(
+        detailedKeys: Keys,
+        table: string,
+        schema: ?string,
+        _foreignTable: string,
+        _foreignSchema: ?string
+      ) {
+        return camelCase(
+          `${this.pluralize(
+            this.tableName(table, schema)
+          )}-by-${detailedKeys
+            .map(key => this.column(key.column, key.table, key.schema))
+            .join("-and-")}`
+        );
+      },
+      edge(typeName: string) {
+        return upperCamelCase(`${pluralize(typeName)}-edge`);
+      },
+      edgeField(name: string, _schema: ?string) {
+        return camelCase(`${singularizeTable(name)}-edge`);
+      },
+      connection(typeName: string) {
+        return upperCamelCase(`${this.pluralize(typeName)}-connection`);
+      },
+      scalarFunctionConnection(procName: string, _procSchema: ?string) {
+        return upperCamelCase(`${procName}-connection`);
+      },
+      scalarFunctionEdge(procName: string, _procSchema: ?string) {
+        return upperCamelCase(`${procName}-edge`);
+      },
+      createField(name: string, _schema: ?string) {
+        return camelCase(`create-${singularizeTable(name)}`);
+      },
+      createInputType(name: string, _schema: ?string) {
+        return upperCamelCase(`create-${singularizeTable(name)}-input`);
+      },
+      createPayloadType(name: string, _schema: ?string) {
+        return upperCamelCase(`create-${singularizeTable(name)}-payload`);
+      },
+      updatePayloadType(name: string, _schema: ?string) {
+        return upperCamelCase(`update-${singularizeTable(name)}-payload`);
+      },
+      deletePayloadType(name: string, _schema: ?string) {
+        return upperCamelCase(`delete-${singularizeTable(name)}-payload`);
+      },
+      ...overrides,
+    })
   );
 };
 

--- a/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js
@@ -256,7 +256,11 @@ function sqlCommentByAddingTags(entity, tagsToAdd) {
     );
 
   // tagsToAdd is here twice to ensure that the keys in tagsToAdd come first, but that they also "win" any conflicts.
-  const tags = Object.assign({}, tagsToAdd, entity.tags, tagsToAdd);
+  const tags = {
+    ...tagsToAdd,
+    ...entity.tags,
+    ...tagsToAdd,
+  };
 
   const description = entity.description;
   const tagsSql = Object.keys(tags)

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -460,9 +460,7 @@ export default (async function PgIntrospectionPlugin(
     const cacheKey = `PgIntrospectionPlugin-introspectionResultsByKind-v${version}`;
     const cloneResults = obj => {
       const result = Object.keys(obj).reduce((memo, k) => {
-        memo[k] = Array.isArray(obj[k])
-          ? obj[k].map(v => Object.assign({}, v))
-          : obj[k];
+        memo[k] = Array.isArray(obj[k]) ? obj[k].map(v => ({ ...v })) : obj[k];
         return memo;
       }, {});
       return result;

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -115,18 +115,20 @@ export default (function PgMutationPayloadEdgePlugin(
 
                 if (!order) {
                   if (edge.__identifiers) {
-                    return Object.assign({}, edge, {
+                    return {
+                      ...edge,
                       __cursor: ["primary_key_asc", edge.__identifiers],
-                    });
+                    };
                   } else {
                     return edge;
                   }
                 }
 
-                return Object.assign({}, edge, {
+                return {
+                  ...edge,
                   __cursor:
                     edge[`__order_${order.map(item => item.alias).join("__")}`],
-                });
+                };
               },
             },
             {

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -83,14 +83,12 @@ export default (function PgTypesPlugin(
           "Sorry! This interface is no longer supported because it is not granular enough. It's not hard to port it to the new system - please contact Benjie and he'll walk you through it."
         );
       }
-      const gqlTypeByTypeIdAndModifier = Object.assign(
-        {},
-        build.pgGqlTypeByTypeIdAndModifier
-      );
-      const gqlInputTypeByTypeIdAndModifier = Object.assign(
-        {},
-        build.pgGqlInputTypeByTypeIdAndModifier
-      );
+      const gqlTypeByTypeIdAndModifier = {
+        ...build.pgGqlTypeByTypeIdAndModifier,
+      };
+      const gqlInputTypeByTypeIdAndModifier = {
+        ...build.pgGqlInputTypeByTypeIdAndModifier,
+      };
       const isNull = val => val == null || val.__isNull;
       const pg2GqlMapper = {};
       const pg2gqlForType = type => {
@@ -255,25 +253,24 @@ export default (function PgTypesPlugin(
       const tweakToNumericText = fragment =>
         sql.fragment`(${fragment})::numeric::text`;
       const pgTweaksByTypeIdAndModifer = {};
-      const pgTweaksByTypeId = Object.assign(
+      const pgTweaksByTypeId = {
         // '::text' rawTypes
-        rawTypes.reduce((memo, typeId) => {
+        ...rawTypes.reduce((memo, typeId) => {
           memo[typeId] = tweakToText;
           return memo;
         }, {}),
-        {
-          // cast numbers above our ken to strings to avoid loss of precision
-          "20": tweakToText,
-          "1700": tweakToText,
-          // to_json all dates to make them ISO (overrides rawTypes above)
-          "1082": tweakToJson,
-          "1114": tweakToJson,
-          "1184": tweakToJson,
-          "1083": tweakToJson,
-          "1266": tweakToJson,
-          "790": tweakToNumericText,
-        }
-      );
+
+        // cast numbers above our ken to strings to avoid loss of precision
+        "20": tweakToText,
+        "1700": tweakToText,
+        // to_json all dates to make them ISO (overrides rawTypes above)
+        "1082": tweakToJson,
+        "1114": tweakToJson,
+        "1184": tweakToJson,
+        "1083": tweakToJson,
+        "1266": tweakToJson,
+        "790": tweakToNumericText,
+      };
 
       const pgTweakFragmentForTypeAndModifier = (
         fragment,

--- a/packages/graphile-build-pg/src/plugins/addStartEndCursor.js
+++ b/packages/graphile-build-pg/src/plugins/addStartEndCursor.js
@@ -10,8 +10,9 @@ export default (function addStartEndCursor(value) {
   const data = value && value.data && value.data.length ? value.data : null;
   const startCursor = cursorify(data && data[0]);
   const endCursor = cursorify(data && data[value.data.length - 1]);
-  return Object.assign({}, value, {
+  return {
+    ...value,
     startCursor,
     endCursor,
-  });
+  };
 }: Plugin);

--- a/packages/graphile-build-pg/src/plugins/makeProcField.js
+++ b/packages/graphile-build-pg/src/plugins/makeProcField.js
@@ -518,21 +518,18 @@ export default function makeProcField(
               );
             },
           },
-          Object.assign(
-            {},
-            {
-              __origin: `Adding mutation function payload type for ${describePgEntity(
-                proc
-              )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  ${sqlCommentByAddingTags(
-                proc,
-                {
-                  name: "newNameHere",
-                }
-              )}`,
-              isMutationPayload: true,
-            },
-            payloadTypeScope
-          )
+          {
+            __origin: `Adding mutation function payload type for ${describePgEntity(
+              proc
+            )}. You can rename the function's GraphQL field (and its dependent types) via:\n\n  ${sqlCommentByAddingTags(
+              proc,
+              {
+                name: "newNameHere",
+              }
+            )}`,
+            isMutationPayload: true,
+            ...payloadTypeScope,
+          }
         );
         ReturnType = PayloadType;
         const InputType = newWithHooks(
@@ -542,14 +539,12 @@ export default function makeProcField(
             description: `All input for the \`${inflection.functionMutationName(
               proc
             )}\` mutation.`,
-            fields: Object.assign(
-              {
-                clientMutationId: {
-                  type: GraphQLString,
-                },
+            fields: {
+              clientMutationId: {
+                type: GraphQLString,
               },
-              args
-            ),
+              ...args,
+            },
           },
           {
             __origin: `Adding mutation function input type for ${describePgEntity(

--- a/packages/graphile-build-pg/src/utils.js
+++ b/packages/graphile-build-pg/src/utils.js
@@ -3,27 +3,25 @@ export const parseTags = (str: string) => {
   return str.split(/\r?\n/).reduce(
     (prev, curr) => {
       if (prev.text !== "") {
-        return Object.assign({}, prev, {
-          text: `${prev.text}\n${curr}`,
-        });
+        return { ...prev, text: `${prev.text}\n${curr}` };
       }
       const match = curr.match(/^@[a-zA-Z][a-zA-Z0-9_]*($|\s)/);
       if (!match) {
-        return Object.assign({}, prev, {
-          text: curr,
-        });
+        return { ...prev, text: curr };
       }
       const key = match[0].substr(1).trim();
       const value = match[0] === curr ? true : curr.replace(match[0], "");
-      return Object.assign({}, prev, {
-        tags: Object.assign({}, prev.tags, {
+      return {
+        ...prev,
+        tags: {
+          ...prev.tags,
           [key]: !prev.tags.hasOwnProperty(key)
             ? value
             : Array.isArray(prev.tags[key])
             ? [...prev.tags[key], value]
             : [prev.tags[key], value],
-        }),
-      });
+        },
+      };
     },
     {
       tags: {},

--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -477,10 +477,11 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
           this,
           "GraphQLObjectType",
           newSpec,
-          Object.assign({}, commonContext, {
+          {
+            ...commonContext,
             addDataGeneratorForField,
             recurseDataGeneratorsForField,
-          }),
+          },
           `|${newSpec.name}`
         );
 
@@ -641,18 +642,20 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
                   `|${getNameFromType(Self)}.fields.${fieldName}`
                 );
                 newSpec.args = newSpec.args || {};
-                newSpec = Object.assign({}, newSpec, {
+                newSpec = {
+                  ...newSpec,
                   args: builder.applyHooks(
                     this,
                     "GraphQLObjectType:fields:field:args",
                     newSpec.args,
-                    Object.assign({}, context, {
+                    {
+                      ...context,
                       field: newSpec,
                       returnType: newSpec.type,
-                    }),
+                    },
                     `|${getNameFromType(Self)}.fields.${fieldName}`
                   ),
-                });
+                };
                 const finalSpec = newSpec;
                 processedFields.push(finalSpec);
                 return finalSpec;
@@ -711,7 +714,8 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
           ...newSpec,
           fields: () => {
             const processedFields = [];
-            const fieldsContext = Object.assign({}, commonContext, {
+            const fieldsContext = {
+              ...commonContext,
               Self,
               GraphQLInputObjectType: rawSpec,
               fieldWithHooks: ((fieldName, spec, fieldScope = {}) => {
@@ -754,7 +758,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
                 processedFields.push(finalSpec);
                 return finalSpec;
               }: InputFieldWithHooksFunction),
-            });
+            };
             let rawFields = rawSpec.fields;
             if (typeof rawFields === "function") {
               rawFields = rawFields(fieldsContext);
@@ -831,7 +835,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
           this,
           "GraphQLUnionType",
           newSpec,
-          Object.assign({}, commonContext),
+          { ...commonContext },
           `|${newSpec.name}`
         );
 

--- a/packages/postgraphile-core/__tests__/integration/queries-jwt.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries-jwt.test.js
@@ -106,13 +106,15 @@ const tests = [
     schema: "withJwt",
     process: ({ data: { authenticatePayload } }) => {
       const { jwt: str } = authenticatePayload.authPayload;
-      return Object.assign({}, authenticatePayload, {
-        authPayload: Object.assign({}, authenticatePayload.authPayload, {
+      return {
+        ...authenticatePayload,
+        authPayload: {
+          ...authenticatePayload.authPayload,
           jwt: Object.assign(jwt.verify(str, jwtSecret), {
             iat: "[timestamp]",
           }),
-        }),
-      });
+        },
+      };
     },
   },
 ];


### PR DESCRIPTION
The [object spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals) is shorter and clearer to read than `Object.assign()`. This pull request changes several usages of `Object.assign()` to the object spread operator.

Note that there are several other usages of `Object.assign()` in the codebase that I did _not_ change in this pull request. It looks like the code is sometimes doing some fancy stuff with object prototypes, and I didn't want to risk accidentally breaking something. This pull request only changes code that is clearly expecting a plain object literal out of the result of `Object.assign()`, which makes them safe to rewrite using the object spread operator.