### PR TITLE
Make sure the name property is on the field spec

### DIFF
--- a/packages/graphile-build/src/makeNewBuild.js
+++ b/packages/graphile-build/src/makeNewBuild.js
@@ -641,7 +641,7 @@ export default function makeNewBuild(builder: SchemaBuilder): { ...Build } {
                   `|${getNameFromType(Self)}.fields.${fieldName}`
                 );
                 newSpec.args = newSpec.args || {};
-                newSpec = Object.assign({}, newSpec, {
+                newSpec = Object.assign({}, { name: fieldName }, newSpec, {
                   args: builder.applyHooks(
                     this,
                     "GraphQLObjectType:fields:field:args",


### PR DESCRIPTION
I noticed that some fields didn't have the `name` field properly populated on the spec -- which is ironic, considering that `fieldWithHooks` must be called with a `fieldName` argument. This pull request uses that argument to set that name on the spec, although other specs can override it as necessary.