### PR TITLE
Get fieldName from scope, instead of field.name

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -97,6 +97,7 @@ export default (function PgConnectionArgCondition(builder) {
       } = build;
       const {
         scope: {
+          fieldName,
           isPgFieldConnection,
           isPgFieldSimpleCollection,
           pgFieldIntrospection,
@@ -104,7 +105,6 @@ export default (function PgConnectionArgCondition(builder) {
         },
         addArgDataGenerator,
         Self,
-        field,
       } = context;
 
       const shouldAddCondition =
@@ -186,7 +186,7 @@ export default (function PgConnectionArgCondition(builder) {
             type: TableConditionType,
           },
         },
-        `Adding condition to connection field '${field.name}' of '${Self.name}'`
+        `Adding condition to connection field '${fieldName}' of '${Self.name}'`
       );
     },
     ["PgConnectionArgCondition"]

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgFirstLastBeforeAfter.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgFirstLastBeforeAfter.js
@@ -14,12 +14,12 @@ export default (function PgConnectionArgs(builder) {
       } = build;
       const {
         scope: {
+          fieldName,
           isPgFieldConnection,
           isPgFieldSimpleCollection,
           pgFieldIntrospection: source,
         },
         addArgDataGenerator,
-        field,
         Self,
       } = context;
 
@@ -120,10 +120,10 @@ export default (function PgConnectionArgs(builder) {
             : null),
         },
         isPgFieldConnection
-          ? `Adding connection pagination args to field '${field.name}' of '${
+          ? `Adding connection pagination args to field '${fieldName}' of '${
               Self.name
             }'`
-          : `Adding simple collection args to field '${field.name}' of '${
+          : `Adding simple collection args to field '${fieldName}' of '${
               Self.name
             }'`
       );

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -69,6 +69,7 @@ export default (function PgConnectionArgOrderBy(builder, { orderByNullsLast }) {
       } = build;
       const {
         scope: {
+          fieldName,
           isPgFieldConnection,
           isPgFieldSimpleCollection,
           pgFieldIntrospection,
@@ -76,7 +77,6 @@ export default (function PgConnectionArgOrderBy(builder, { orderByNullsLast }) {
         },
         addArgDataGenerator,
         Self,
-        field,
       } = context;
 
       if (!isPgFieldConnection && !isPgFieldSimpleCollection) {
@@ -178,7 +178,7 @@ export default (function PgConnectionArgOrderBy(builder, { orderByNullsLast }) {
             type: new GraphQLList(new GraphQLNonNull(TableOrderByType)),
           },
         },
-        `Adding 'orderBy' argument to field '${field.name}' of '${Self.name}'`
+        `Adding 'orderBy' argument to field '${fieldName}' of '${Self.name}'`
       );
     },
     ["PgConnectionArgOrderBy"]

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
@@ -12,9 +12,8 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
         inflection,
       } = build;
       const {
-        scope: { isPgFieldConnection, pgFieldIntrospection: table },
+        scope: { fieldName, isPgFieldConnection, pgFieldIntrospection: table },
         Self,
-        field,
       } = context;
 
       if (
@@ -46,7 +45,7 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
           {
             defaultValue: defaultValueEnum && [defaultValueEnum.value],
           },
-          `Adding defaultValue to orderBy for field '${field.name}' of '${
+          `Adding defaultValue to orderBy for field '${fieldName}' of '${
             Self.name
           }'`
         ),

--- a/packages/graphile-build/src/plugins/ClientMutationIdDescriptionPlugin.js
+++ b/packages/graphile-build/src/plugins/ClientMutationIdDescriptionPlugin.js
@@ -6,7 +6,7 @@ export default (function ClientMutationIdDescriptionPlugin(
 ) {
   builder.hook(
     "GraphQLInputObjectType:fields:field",
-    (field: { name?: string }, build, context) => {
+    (field, build, context) => {
       const { extend } = build;
       const {
         scope: { isMutationInput, fieldName },
@@ -25,7 +25,7 @@ export default (function ClientMutationIdDescriptionPlugin(
           description:
             "An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client.",
         },
-        `Tweaking '${field.name || ""}' field in '${Self.name}'`
+        `Tweaking '${fieldName}' field in '${Self.name}'`
       );
     },
     ["ClientMutationIdDescription"]
@@ -33,7 +33,7 @@ export default (function ClientMutationIdDescriptionPlugin(
 
   builder.hook(
     "GraphQLObjectType:fields:field",
-    (field: { name?: string }, build, context) => {
+    (field, build, context) => {
       const { extend } = build;
       const {
         scope: { isMutationPayload, fieldName },
@@ -52,7 +52,7 @@ export default (function ClientMutationIdDescriptionPlugin(
           description:
             "The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations.",
         },
-        `Tweaking '${field.name || ""}' field in '${Self.name}'`
+        `Tweaking '${fieldName}' field in '${Self.name}'`
       );
     },
     ["ClientMutationIdDescription"]
@@ -63,9 +63,8 @@ export default (function ClientMutationIdDescriptionPlugin(
     (args: {}, build, context) => {
       const { extend } = build;
       const {
-        scope: { isRootMutation },
+        scope: { isRootMutation, fieldName },
         Self,
-        field,
       } = context;
       if (!isRootMutation || !args.input || args.input.description) {
         return args;
@@ -78,9 +77,9 @@ export default (function ClientMutationIdDescriptionPlugin(
             description:
               "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
           },
-          `Adding a description to input arg for field '${
-            field.name
-          }' field in '${Self.name}'`
+          `Adding a description to input arg for field '${fieldName}' field in '${
+            Self.name
+          }'`
         ),
       };
     },


### PR DESCRIPTION
Follow up to #488. `name` is not a field on `GraphQLFieldConfig` ([see the docs for `graphql-js`](https://graphql.org/graphql-js/type/#graphqlobjecttype)) so any reference to `field.name` returns `undefined`. Instead, we should use the `fieldName` from the `scope` object.