### PR TITLE
fix(nodeId): fix object IDs for arbitrary precision numbers and ints > 9 quadrillion

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -79,6 +79,7 @@ export interface PgType {
   classId: string | void;
   class: PgClass | void;
   domainBaseTypeId: string | void;
+  domainBaseType: PgType | void;
   domainTypeModifier: number | void;
   tags: { [tag: string]: true | string | Array<string> };
 }

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -101,6 +101,7 @@ export type PgType = {
   classId: ?string,
   class: ?PgClass,
   domainBaseTypeId: ?string,
+  domainBaseType: ?PgType,
   domainTypeModifier: ?number,
   tags: { [string]: string },
 };

--- a/packages/postgraphile-core/__tests__/fixtures/queries/large_bigint.issue491.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/large_bigint.issue491.graphql
@@ -1,0 +1,9 @@
+{
+  allLargeNodeIds {
+    nodes {
+      nodeId
+      id
+      text
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/fixtures/queries/large_bigint.issue491.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/large_bigint.issue491.graphql
@@ -6,4 +6,14 @@
       text
     }
   }
+  safeInt: largeNodeId(nodeId: "WyJsYXJnZV9ub2RlX2lkcyIsOTAwNzE5OTI1NDc0MDk5MF0=") {
+    nodeId
+    id
+    text
+  }
+  largeInt: largeNodeId(nodeId: "WyJsYXJnZV9ub2RlX2lkcyIsIjIwOTgyODg2NjkyMTg1NzE3NjAiXQ==") {
+    nodeId
+    id
+    text
+  }
 }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1832,6 +1832,16 @@ Object {
         },
       ],
     },
+    "largeInt": Object {
+      "id": "2098288669218571760",
+      "nodeId": "WyJsYXJnZV9ub2RlX2lkcyIsIjIwOTgyODg2NjkyMTg1NzE3NjAiXQ==",
+      "text": "Graphile Engine issue #491",
+    },
+    "safeInt": Object {
+      "id": "9007199254740990",
+      "nodeId": "WyJsYXJnZV9ub2RlX2lkcyIsOTAwNzE5OTI1NDc0MDk5MF0=",
+      "text": "Should be fine",
+    },
   },
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1815,6 +1815,27 @@ Object {
 }
 `;
 
+exports[`large_bigint.issue491.graphql 1`] = `
+Object {
+  "data": Object {
+    "allLargeNodeIds": Object {
+      "nodes": Array [
+        Object {
+          "id": "9007199254740990",
+          "nodeId": "WyJsYXJnZV9ub2RlX2lkcyIsOTAwNzE5OTI1NDc0MDk5MF0=",
+          "text": "Should be fine",
+        },
+        Object {
+          "id": "2098288669218571760",
+          "nodeId": "WyJsYXJnZV9ub2RlX2lkcyIsMjA5ODI4ODY2OTIxODU3MTc2MF0=",
+          "text": "Graphile Engine issue #491",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`longAliases.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1827,7 +1827,7 @@ Object {
         },
         Object {
           "id": "2098288669218571760",
-          "nodeId": "WyJsYXJnZV9ub2RlX2lkcyIsMjA5ODI4ODY2OTIxODU3MTc2MF0=",
+          "nodeId": "WyJsYXJnZV9ub2RlX2lkcyIsIjIwOTgyODg2NjkyMTg1NzE3NjAiXQ==",
           "text": "Graphile Engine issue #491",
         },
       ],

--- a/packages/postgraphile-core/__tests__/integration/queries.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries.test.js
@@ -54,6 +54,7 @@ beforeAll(() => {
       simpleCollections,
       orderByNullsLast,
       smartCommentRelations,
+      largeBigint,
     ] = await Promise.all([
       createPostGraphileSchema(pgClient, ["a", "b", "c"], {
         subscriptions: true,
@@ -89,6 +90,7 @@ beforeAll(() => {
         },
       }),
       createPostGraphileSchema(pgClient, ["smart_comment_relations"], {}),
+      createPostGraphileSchema(pgClient, ["large_bigint"], {}),
     ]);
     // Now for RBAC-enabled tests
     await pgClient.query("set role postgraphile_test_authenticator");
@@ -109,6 +111,7 @@ beforeAll(() => {
       orderByNullsLast,
       rbac,
       smartCommentRelations,
+      largeBigint,
     };
   });
 
@@ -164,6 +167,8 @@ beforeAll(() => {
               gqlSchema = gqlSchemas.rbac;
             } else if (fileName.startsWith("smart_comment_relations.")) {
               gqlSchema = gqlSchemas.smartCommentRelations;
+            } else if (fileName.startsWith("large_bigint")) {
+              gqlSchema = gqlSchemas.largeBigint;
             } else {
               gqlSchema = gqlSchemas.normal;
             }

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -215,3 +215,6 @@ insert into smart_comment_relations.buildings (id, property_id, name, floors, is
   (3, 3, 'Our shed', 1, false),
   (4, 1, 'Home sweet home', 2, true),
   (5, 4, 'The Tower', 200, true);
+
+insert into large_bigint.large_node_id (id, text) values (9007199254740990, 'Should be fine');
+insert into large_bigint.large_node_id (id, text) values (2098288669218571760, 'Graphile Engine issue #491');

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -1,5 +1,5 @@
 -- WARNING: this database is shared with graphile-utils, don't run the tests in parallel!
-drop schema if exists a, b, c, d, inheritence, smart_comment_relations, ranges, index_expressions, simple_collections, live_test cascade;
+drop schema if exists a, b, c, d, inheritence, smart_comment_relations, ranges, index_expressions, simple_collections, live_test, large_bigint cascade;
 drop extension if exists tablefunc;
 drop extension if exists intarray;
 drop extension if exists hstore;
@@ -8,6 +8,7 @@ create schema a;
 create schema b;
 create schema c;
 create schema d;
+create schema large_bigint;
 
 alter default privileges revoke execute on functions from public;
 
@@ -1047,4 +1048,9 @@ create table live_test.todos_log_viewed (
   todo_id int not null,
   viewed_at timestamp not null default now(),
   foreign key (user_id, todo_id) references live_test.todos_log(user_id, todo_id) on delete cascade
+);
+
+create table large_bigint.large_node_id (
+  id bigint primary key,
+  text text
 );


### PR DESCRIPTION
Changing a primary key column from `int` to `bigint` does not change the nodeId (deliberately), but all nodeIds over 9 quadrillion (2^53 - 1) have now changed.

This also changes the representation for node identifiers for numeric/decimal (arbitrary precision) numbers and money to use numeric strings to maintain precision.

This is a fix to behaviour that was previously broken; it should only affect you if the full range of your primary key fields cannot be safely represented in a JavaScript number (e.g. bigint > 9 quadrillion, numeric/decimal arbitrary precision numbers, etc) or if you're using the "money" type in a primary key.

Fixes #491 