### PR TITLE
Unit Test read cache

### DIFF
--- a/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
+++ b/packages/postgraphile-core/__tests__/unit/__snapshots__/read-cache.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when cache file has invalid content, getPostGraphileBuilder should error 1`] = `[Error: Failed to parse cache file 'path/to/cache', perhaps it is corrupted? SyntaxError: Unexpected token h in JSON at position 1]`;

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -62,3 +62,23 @@ test("when no readCache flag, persistentMemoizeWithKey should be undefined", asy
   } = graphileBuild.getBuilder.mock.calls[0][1];
   expect(persistentMemoizeWithKey).toBeUndefined();
 });
+
+test("when cache file has invalid content, getPostGraphileBuilder should error", async () => {
+  // mock fs.readFile to return an object
+  fs.readFile.mockImplementationOnce((path, options, cb) =>
+    cb(null, "thisisnotjson")
+  );
+
+  // call our method and check error
+
+  let error;
+  try {
+    await getPostGraphileBuilder({}, [], {
+      readCache: true,
+    });
+  } catch (e) {
+    error = e;
+  }
+  expect(error).toEqual(expect.any(Error));
+  expect(fs.readFile).toHaveBeenCalledTimes(1);
+});

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -36,7 +36,7 @@ test("when cache file has empty object, persistentMemoizeWithKey should be a fun
   graphileBuild.getBuilder.mockResolvedValueOnce(expectedOuput);
   // call our method and test output
   const output = await getPostGraphileBuilder({}, [], {
-    readCache: true,
+    readCache: "path/to/cache",
   });
   expect(output).toBe(expectedOuput);
   expect(fs.readFile).toHaveBeenCalledTimes(1);
@@ -74,7 +74,7 @@ test("when cache file has invalid content, getPostGraphileBuilder should error",
   let error;
   try {
     await getPostGraphileBuilder({}, [], {
-      readCache: true,
+      readCache: "path/to/cache",
     });
   } catch (e) {
     error = e;

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -34,13 +34,13 @@ test("when cache file has content, persistentMemoizeWithKey should be a valid fu
   );
 
   // mock getBuilder to fake output
-  const expectedOuput = {};
-  graphileBuild.getBuilder.mockResolvedValueOnce(expectedOuput);
+  const expectedOutput = {};
+  graphileBuild.getBuilder.mockResolvedValueOnce(expectedOutput);
   // call our method and test output
   const output = await getPostGraphileBuilder({}, [], {
     readCache: "path/to/cache",
   });
-  expect(output).toBe(expectedOuput);
+  expect(output).toBe(expectedOutput);
   expect(fs.readFile).toHaveBeenCalledTimes(1);
   expect(graphileBuild.getBuilder).toHaveBeenCalledTimes(1);
   // check persistentMemoizeWithKey, the actual "result" of readCache flag
@@ -54,11 +54,11 @@ test("when cache file has content, persistentMemoizeWithKey should be a valid fu
 
 test("when no readCache flag, persistentMemoizeWithKey should be undefined", async () => {
   // mock getBuilder to fake output
-  const expectedOuput = {};
-  graphileBuild.getBuilder.mockResolvedValueOnce(expectedOuput);
+  const expectedOutput = {};
+  graphileBuild.getBuilder.mockResolvedValueOnce(expectedOutput);
   // call our method and test output
   const output = await getPostGraphileBuilder({}, [], {});
-  expect(output).toBe(expectedOuput);
+  expect(output).toBe(expectedOutput);
   expect(graphileBuild.getBuilder).toHaveBeenCalledTimes(1);
   // check persistentMemoizeWithKey, the actual "result" of readCache flag
   const {

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -47,3 +47,18 @@ test("when cache file has empty object, persistentMemoizeWithKey should be a fun
   } = graphileBuild.getBuilder.mock.calls[0][1];
   expect(typeof persistentMemoizeWithKey).toBe("function");
 });
+
+test("when no readCache flag, persistentMemoizeWithKey should be undefined", async () => {
+  // mock getBuilder to fake output
+  const expectedOuput = {};
+  graphileBuild.getBuilder.mockResolvedValueOnce(expectedOuput);
+  // call our method and test output
+  const output = await getPostGraphileBuilder({}, [], {});
+  expect(output).toBe(expectedOuput);
+  expect(graphileBuild.getBuilder).toHaveBeenCalledTimes(1);
+  // check persistentMemoizeWithKey, the actual "result" of readCache flag
+  const {
+    persistentMemoizeWithKey,
+  } = graphileBuild.getBuilder.mock.calls[0][1];
+  expect(persistentMemoizeWithKey).toBeUndefined();
+});

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -27,9 +27,11 @@ Test strategy for readCache
 
 */
 
-test("when cache file has empty object, persistentMemoizeWithKey should be a function", async () => {
+test("when cache file has content, persistentMemoizeWithKey should be a valid function", async () => {
   // mock fs.readFile to return an object
-  fs.readFile.mockImplementationOnce((path, options, cb) => cb(null, "{}"));
+  fs.readFile.mockImplementationOnce((path, options, cb) =>
+    cb(null, '{ "__test": true }')
+  );
 
   // mock getBuilder to fake output
   const expectedOuput = {};
@@ -46,6 +48,8 @@ test("when cache file has empty object, persistentMemoizeWithKey should be a fun
     persistentMemoizeWithKey,
   } = graphileBuild.getBuilder.mock.calls[0][1];
   expect(typeof persistentMemoizeWithKey).toBe("function");
+  expect(persistentMemoizeWithKey("__test")).toEqual(true);
+  expect(() => persistentMemoizeWithKey("unknown_key")).toThrow();
 });
 
 test("when no readCache flag, persistentMemoizeWithKey should be undefined", async () => {

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -79,6 +79,6 @@ test("when cache file has invalid content, getPostGraphileBuilder should error",
   } catch (e) {
     error = e;
   }
-  expect(error).toEqual(expect.any(Error));
+  expect(error).toMatchSnapshot();
   expect(fs.readFile).toHaveBeenCalledTimes(1);
 });

--- a/packages/postgraphile-core/__tests__/unit/read-cache.test.js
+++ b/packages/postgraphile-core/__tests__/unit/read-cache.test.js
@@ -1,0 +1,49 @@
+const fs = require("fs");
+const graphileBuild = require("graphile-build");
+const { getPostGraphileBuilder } = require("../..");
+
+jest.mock("fs");
+jest.mock("graphile-build");
+
+beforeEach(() => {
+  // required for mocks assertions
+  jest.resetAllMocks();
+});
+
+/*
+
+Current behaviour of getPostGraphileBuilder and readCache option:
+
+1. cacheString is loaded by reading the file defined by readCache
+2. memoizeCache is set by JSON.parse(cacheString)
+3. persistentMemoizeWithKey is a function created dynamically that will use memoizeCache
+4. getBuilder(imported from graphile-build) is called, passing persistentMemoizeWithKey as one of the arguments
+
+Test strategy for readCache
+
+1. Mock fs.readFile to control input
+2. Mock getBuilder to control output
+3. Test different inputs and validate that getBuilder is called with expected output
+
+*/
+
+test("when cache file has empty object, persistentMemoizeWithKey should be a function", async () => {
+  // mock fs.readFile to return an object
+  fs.readFile.mockImplementationOnce((path, options, cb) => cb(null, "{}"));
+
+  // mock getBuilder to fake output
+  const expectedOuput = {};
+  graphileBuild.getBuilder.mockResolvedValueOnce(expectedOuput);
+  // call our method and test output
+  const output = await getPostGraphileBuilder({}, [], {
+    readCache: true,
+  });
+  expect(output).toBe(expectedOuput);
+  expect(fs.readFile).toHaveBeenCalledTimes(1);
+  expect(graphileBuild.getBuilder).toHaveBeenCalledTimes(1);
+  // check persistentMemoizeWithKey, the actual "result" of readCache flag
+  const {
+    persistentMemoizeWithKey,
+  } = graphileBuild.getBuilder.mock.calls[0][1];
+  expect(typeof persistentMemoizeWithKey).toBe("function");
+});

--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -180,7 +180,7 @@ const awaitKeys = async (obj: { [key: string]: Promise<any> }) => {
   return result;
 };
 
-const getPostGraphileBuilder = async (
+export const getPostGraphileBuilder = async (
   pgConfig: PgConfig,
   schemas: string | Array<string>,
   options: PostGraphileCoreOptions = {}


### PR DESCRIPTION
This is still a Work in progress, I'm opening the PR to discuss the changes.

This PR add unit tests for `readCache` option in `getPostGraphileBuilder`. See test suite for details

There are no changes to `src` files (except exporting `getPostGraphileBuilder` function) , so it should be safe to merge once accepted.