### PR TITLE
feat(query): improve unique orderBy error message

### DIFF
--- a/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
+++ b/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
@@ -313,7 +313,7 @@ exists(
       if (orderByExpressionsAndDirections.length > 0) {
         if (!queryBuilder.isOrderUnique()) {
           throw new Error(
-            "The cursor requires a primary key or an unique key combination for orderBy clause"
+            "The order supplied is not unique, so before/after cursors cannot be used. Please ensure the supplied order includes all the columns from the primary key or a unique constraint."
           );
         }
         const rawPrefixes = cursorValue.slice(0, cursorValue.length - 1);


### PR DESCRIPTION
When using the cursor for pagination (```before``` and ```after```) Graphile requires that the ```orderBy``` clause must be composed by unique value, either referring the table PK or mixing values that returns a unique result.

Currently when the query fails due to that error the message returned is ```Cannot use cursors without orderBy```, which is misleading, because there might be an ```orderBy``` clause passed, but it's not correctly assigned.

This PR uses a validation that already exists in the codebase and throws an error message based on the flag returned from it.