### PR TITLE
Pin prettier==1.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lerna": "^3.13.4",
     "pg": "^7.10.0",
     "postgraphile": "^4.4.0",
-    "prettier": "^1.17.0",
+    "prettier": "1.18.2",
     "typescript": "^3.6.3"
   },
   "workspaces": [

--- a/packages/graphile-utils/package.json
+++ b/packages/graphile-utils/package.json
@@ -41,7 +41,7 @@
     "graphile-build": "4.4.5",
     "graphile-build-pg": "4.4.5",
     "jest": "^24.8.0",
-    "prettier": "^1.17.0",
+    "prettier": "1.18.2",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   },

--- a/packages/lru/package.json
+++ b/packages/lru/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "eslint_d": "^8.0.0",
     "jest": "^24.8.0",
-    "prettier": "^1.17.0",
+    "prettier": "1.18.2",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   },

--- a/packages/postgraphile-core/package.json
+++ b/packages/postgraphile-core/package.json
@@ -31,7 +31,7 @@
     "jest-silent-reporter": "^0.1.2",
     "jsonwebtoken": "^8.5.1",
     "pg-connection-string": "^2.1.0",
-    "prettier": "^1.17.0",
+    "prettier": "1.18.2",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7463,7 +7463,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.18.2, prettier@^1.17.0:
+prettier@1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==


### PR DESCRIPTION
Prettier recommends pinning an exact version of the package, because they sometimes introduce stylistic changes in patch releases. See https://prettier.io/docs/en/install.html