### PR TITLE
chore(deps): remove prettier from subpackages

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "jest": "^24.8.0",
     "lerna": "^3.13.4",
     "pg": "^7.10.0",
-    "postgraphile": "^4.4.0",
-    "prettier": "^1.17.0",
+    "postgraphile": "^4.4.4",
+    "prettier": "^1.18.2",
     "typescript": "^3.6.3"
   },
   "workspaces": [

--- a/packages/graphile-utils/package.json
+++ b/packages/graphile-utils/package.json
@@ -37,11 +37,9 @@
     "node": ">=8.6"
   },
   "devDependencies": {
-    "eslint_d": "^8.0.0",
     "graphile-build": "4.4.5",
     "graphile-build-pg": "4.4.5",
     "jest": "^24.8.0",
-    "prettier": "^1.17.0",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   },

--- a/packages/lru/package.json
+++ b/packages/lru/package.json
@@ -26,9 +26,7 @@
     "node": ">=8.6"
   },
   "devDependencies": {
-    "eslint_d": "^8.0.0",
     "jest": "^24.8.0",
-    "prettier": "^1.17.0",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   },

--- a/packages/pg-sql2/package.json
+++ b/packages/pg-sql2/package.json
@@ -38,7 +38,6 @@
     "@types/node": "12.7.5",
     "jest": "24.9.0",
     "markdown-doctest": "^0.9.1",
-    "prettier": "1.18.2",
     "ts-jest": "24.1.0",
     "ts-node": "8.4.1",
     "typescript": "3.6.3"

--- a/packages/postgraphile-core/package.json
+++ b/packages/postgraphile-core/package.json
@@ -26,12 +26,10 @@
     "@types/node": "^12.0.0",
     "@types/pg": "^7.4.14",
     "debug": "^4.1.1",
-    "eslint_d": "^8.0.0",
     "jest": "^24.8.0",
     "jest-silent-reporter": "^0.1.2",
     "jsonwebtoken": "^8.5.1",
     "pg-connection-string": "^2.1.0",
-    "prettier": "^1.17.0",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,13 +1767,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/graphql@^14.0.3":
-  version "14.5.0"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.5.0.tgz#a545fb3bc8013a3547cf2f07f5e13a33642b75d6"
-  integrity sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==
-  dependencies:
-    graphql "*"
-
 "@types/http-assert@*":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.5.1.tgz#d775e93630c2469c2f980fc27e3143240335db3b"
@@ -3987,14 +3980,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
-  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
-  dependencies:
-    once "^1.4.0"
-
-end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.2.tgz#080bf028edce8312b665ff18ea03cae0c3ac0ecb"
   integrity sha512-gUSUszrsxlDnUbUwEI9Oygyrk4ZEWtVaHQc+uZHphVeNxl+qeqMV/jDWoTkjN1RmGlZ5QWAP7o458p/JMlikQg==
@@ -4855,7 +4841,7 @@ graphql-subscriptions@^1.1.0:
   dependencies:
     iterall "^1.2.1"
 
-graphql@*, "graphql@>=0.6 <15", "graphql@>=0.9 <0.14 || ^14.0.2", "graphql@^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.2":
+"graphql@>=0.6 <15", "graphql@>=0.9 <0.14 || ^14.0.2", "graphql@^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.2":
   version "14.5.7"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.7.tgz#8646a3fcc07922319cc3967eba4a64b32929f77f"
   integrity sha512-as410RMJSUFqF8RcH2QWxZ5ioqHzsH9VWnWbaU+UnDXJ/6azMDIYPrtXCBPXd8rlunEVb7W8z6fuUnNHMbFu9A==
@@ -7400,13 +7386,12 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-postgraphile@^4.4.0:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/postgraphile/-/postgraphile-4.4.3.tgz#7af5f245c8f1535761a35342959fec9e7595118b"
-  integrity sha512-kmfFj2ysypSwKvSoENEJuAfT/9MA6gy3iozDJJHyiPypsvTeTeSytZpT6IeMG7GmrFK6sZVEWccuJUkuMJYUTw==
+postgraphile@^4.4.0, postgraphile@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/postgraphile/-/postgraphile-4.4.4.tgz#2f8df890251d35cc469161538ec3d82dd504d4a1"
+  integrity sha512-kT6Ygjet3RmzNBL+Ci87txRRisdu+HDY/peGpk+rsj8MTmRrkqR4oAifI9tyf0wwqGxmXymk9YP2L8KE8E+XOA==
   dependencies:
     "@graphile/lru" "^4.4.1-alpha.2"
-    "@types/graphql" "^14.0.3"
     "@types/jsonwebtoken" "^8.3.2"
     "@types/koa" "^2.0.44"
     "@types/pg" "^7.4.10"
@@ -7424,7 +7409,7 @@ postgraphile@^4.4.0:
     pg ">=6.1.0 <8"
     pg-connection-string "^2.0.0"
     pg-sql2 "^4.4.1-alpha.2"
-    postgraphile-core "4.4.4"
+    postgraphile-core "4.4.5"
     subscriptions-transport-ws "^0.9.15"
     tslib "^1.5.0"
     ws "^6.1.3"
@@ -7463,7 +7448,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.18.2, prettier@^1.17.0:
+prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==


### PR DESCRIPTION
We use root-level `eslint` only, so no need for per-package prettier.