### PR TITLE
feat(utils): @pgQuery support for scalars

### DIFF
--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
@@ -2856,53 +2856,53 @@ enum UsersOrderBy {
 `;
 
 exports[`allows to retrieve a single scalar value 1`] = `
-"type Complex {
+type Complex {
   numberInt: Int
   stringText: String
 }
 
-\\"\\"\\"An input for mutations affecting \`Complex\`\\"\\"\\"
+"""An input for mutations affecting \`Complex\`"""
 input ComplexInput {
   numberInt: Int
   stringText: String
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 }
 
 type Pet implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   id: Int!
   userId: Int!
@@ -2910,50 +2910,50 @@ type Pet implements Node {
   type: String!
 }
 
-\\"\\"\\"
+"""
 A condition to be used against \`Pet\` object types. All fields are tested for equality and combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input PetCondition {
-  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`id\` field."""
   id: Int
 
-  \\"\\"\\"Checks for equality with the object’s \`userId\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`userId\` field."""
   userId: Int
 
-  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`name\` field."""
   name: String
 
-  \\"\\"\\"Checks for equality with the object’s \`type\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`type\` field."""
   type: String
 }
 
-\\"\\"\\"A connection to a list of \`Pet\` values.\\"\\"\\"
+"""A connection to a list of \`Pet\` values."""
 type PetsConnection {
-  \\"\\"\\"A list of \`Pet\` objects.\\"\\"\\"
+  """A list of \`Pet\` objects."""
   nodes: [Pet]!
 
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Pet\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [PetsEdge!]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Pet\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Pet\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Pet\` edge in the connection.\\"\\"\\"
+"""A \`Pet\` edge in the connection."""
 type PetsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Pet\` at the end of the edge.\\"\\"\\"
+  """The \`Pet\` at the end of the edge."""
   node: Pet
 }
 
-\\"\\"\\"Methods to use when ordering \`Pet\`.\\"\\"\\"
+"""Methods to use when ordering \`Pet\`."""
 enum PetsOrderBy {
   NATURAL
   ID_ASC
@@ -2968,102 +2968,102 @@ enum PetsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Pet\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Pet\`."""
   allPets(
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"The method to use when ordering \`Pet\`.\\"\\"\\"
+    """The method to use when ordering \`Pet\`."""
     orderBy: [PetsOrderBy!] = [PRIMARY_KEY_ASC]
 
-    \\"\\"\\"
+    """
     A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     condition: PetCondition
   ): PetsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`User\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`User\`."""
   allUsers(
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"The method to use when ordering \`User\`.\\"\\"\\"
+    """The method to use when ordering \`User\`."""
     orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
 
-    \\"\\"\\"
+    """
     A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     condition: UserCondition
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
 
-  \\"\\"\\"Reads a single \`Pet\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Pet\` using its globally unique \`ID\`."""
   pet(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Pet\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Pet\`."""
     nodeId: ID!
   ): Pet
 
-  \\"\\"\\"Reads a single \`User\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`User\` using its globally unique \`ID\`."""
   user(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`User\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`User\`."""
     nodeId: ID!
   ): User
 }
 
 type User implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   id: Int!
   name: String!
@@ -3072,60 +3072,60 @@ type User implements Node {
   renamedComplexColumn: [Complex]
   createdAt: Datetime!
   myCustomScalar: Int!
-  myCustomScalarWithFunction: Int!
+  myCustomScalarWithFunction: String!
   myCustomScalarWithFunctionAndArgument(test: Int!): Int!
 }
 
-\\"\\"\\"
+"""
 A condition to be used against \`User\` object types. All fields are tested for equality and combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UserCondition {
-  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`id\` field."""
   id: Int
 
-  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`name\` field."""
   name: String
 
-  \\"\\"\\"Checks for equality with the object’s \`email\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`email\` field."""
   email: String
 
-  \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`bio\` field."""
   bio: String
 
-  \\"\\"\\"Checks for equality with the object’s \`renamedComplexColumn\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`renamedComplexColumn\` field."""
   renamedComplexColumn: [ComplexInput]
 
-  \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`createdAt\` field."""
   createdAt: Datetime
 }
 
-\\"\\"\\"A connection to a list of \`User\` values.\\"\\"\\"
+"""A connection to a list of \`User\` values."""
 type UsersConnection {
-  \\"\\"\\"A list of \`User\` objects.\\"\\"\\"
+  """A list of \`User\` objects."""
   nodes: [User]!
 
-  \\"\\"\\"
+  """
   A list of edges which contains the \`User\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UsersEdge!]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`User\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`User\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`User\` edge in the connection.\\"\\"\\"
+"""A \`User\` edge in the connection."""
 type UsersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`User\` at the end of the edge.\\"\\"\\"
+  """The \`User\` at the end of the edge."""
   node: User
 }
 
-\\"\\"\\"Methods to use when ordering \`User\`.\\"\\"\\"
+"""Methods to use when ordering \`User\`."""
 enum UsersOrderBy {
   NATURAL
   ID_ASC
@@ -3143,57 +3143,57 @@ enum UsersOrderBy {
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
-"
+
 `;
 
 exports[`allows to retrieve array scalar values 1`] = `
-"type Complex {
+type Complex {
   numberInt: Int
   stringText: String
 }
 
-\\"\\"\\"An input for mutations affecting \`Complex\`\\"\\"\\"
+"""An input for mutations affecting \`Complex\`"""
 input ComplexInput {
   numberInt: Int
   stringText: String
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 }
 
 type Pet implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   id: Int!
   userId: Int!
@@ -3201,50 +3201,50 @@ type Pet implements Node {
   type: String!
 }
 
-\\"\\"\\"
+"""
 A condition to be used against \`Pet\` object types. All fields are tested for equality and combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input PetCondition {
-  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`id\` field."""
   id: Int
 
-  \\"\\"\\"Checks for equality with the object’s \`userId\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`userId\` field."""
   userId: Int
 
-  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`name\` field."""
   name: String
 
-  \\"\\"\\"Checks for equality with the object’s \`type\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`type\` field."""
   type: String
 }
 
-\\"\\"\\"A connection to a list of \`Pet\` values.\\"\\"\\"
+"""A connection to a list of \`Pet\` values."""
 type PetsConnection {
-  \\"\\"\\"A list of \`Pet\` objects.\\"\\"\\"
+  """A list of \`Pet\` objects."""
   nodes: [Pet]!
 
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Pet\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [PetsEdge!]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Pet\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Pet\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Pet\` edge in the connection.\\"\\"\\"
+"""A \`Pet\` edge in the connection."""
 type PetsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Pet\` at the end of the edge.\\"\\"\\"
+  """The \`Pet\` at the end of the edge."""
   node: Pet
 }
 
-\\"\\"\\"Methods to use when ordering \`Pet\`.\\"\\"\\"
+"""Methods to use when ordering \`Pet\`."""
 enum PetsOrderBy {
   NATURAL
   ID_ASC
@@ -3259,102 +3259,102 @@ enum PetsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Pet\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Pet\`."""
   allPets(
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"The method to use when ordering \`Pet\`.\\"\\"\\"
+    """The method to use when ordering \`Pet\`."""
     orderBy: [PetsOrderBy!] = [PRIMARY_KEY_ASC]
 
-    \\"\\"\\"
+    """
     A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     condition: PetCondition
   ): PetsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`User\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`User\`."""
   allUsers(
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"The method to use when ordering \`User\`.\\"\\"\\"
+    """The method to use when ordering \`User\`."""
     orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
 
-    \\"\\"\\"
+    """
     A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     condition: UserCondition
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
 
-  \\"\\"\\"Reads a single \`Pet\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Pet\` using its globally unique \`ID\`."""
   pet(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Pet\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Pet\`."""
     nodeId: ID!
   ): Pet
 
-  \\"\\"\\"Reads a single \`User\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`User\` using its globally unique \`ID\`."""
   user(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`User\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`User\`."""
     nodeId: ID!
   ): User
 }
 
 type User implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   id: Int!
   name: String!
@@ -3365,56 +3365,56 @@ type User implements Node {
   myCustomArrayOfScalars: [String!]!
 }
 
-\\"\\"\\"
+"""
 A condition to be used against \`User\` object types. All fields are tested for equality and combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UserCondition {
-  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`id\` field."""
   id: Int
 
-  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`name\` field."""
   name: String
 
-  \\"\\"\\"Checks for equality with the object’s \`email\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`email\` field."""
   email: String
 
-  \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`bio\` field."""
   bio: String
 
-  \\"\\"\\"Checks for equality with the object’s \`renamedComplexColumn\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`renamedComplexColumn\` field."""
   renamedComplexColumn: [ComplexInput]
 
-  \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
+  """Checks for equality with the object’s \`createdAt\` field."""
   createdAt: Datetime
 }
 
-\\"\\"\\"A connection to a list of \`User\` values.\\"\\"\\"
+"""A connection to a list of \`User\` values."""
 type UsersConnection {
-  \\"\\"\\"A list of \`User\` objects.\\"\\"\\"
+  """A list of \`User\` objects."""
   nodes: [User]!
 
-  \\"\\"\\"
+  """
   A list of edges which contains the \`User\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UsersEdge!]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`User\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`User\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`User\` edge in the connection.\\"\\"\\"
+"""A \`User\` edge in the connection."""
 type UsersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`User\` at the end of the edge.\\"\\"\\"
+  """The \`User\` at the end of the edge."""
   node: User
 }
 
-\\"\\"\\"Methods to use when ordering \`User\`.\\"\\"\\"
+"""Methods to use when ordering \`User\`."""
 enum UsersOrderBy {
   NATURAL
   ID_ASC
@@ -3432,5 +3432,5 @@ enum UsersOrderBy {
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
-"
+
 `;

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
@@ -2854,3 +2854,583 @@ enum UsersOrderBy {
 }
 
 `;
+
+exports[`allows to retrieve a single scalar value 1`] = `
+"type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`Complex\`\\"\\"\\"
+input ComplexInput {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+scalar Cursor
+
+\\"\\"\\"
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+\\"\\"\\"
+scalar Datetime
+
+\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+interface Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+type PageInfo {
+  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  hasNextPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  hasPreviousPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  startCursor: Cursor
+
+  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  endCursor: Cursor
+}
+
+type Pet implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  id: Int!
+  userId: Int!
+  name: String!
+  type: String!
+}
+
+\\"\\"\\"
+A condition to be used against \`Pet\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PetCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`userId\` field.\\"\\"\\"
+  userId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  name: String
+
+  \\"\\"\\"Checks for equality with the object’s \`type\` field.\\"\\"\\"
+  type: String
+}
+
+\\"\\"\\"A connection to a list of \`Pet\` values.\\"\\"\\"
+type PetsConnection {
+  \\"\\"\\"A list of \`Pet\` objects.\\"\\"\\"
+  nodes: [Pet]!
+
+  \\"\\"\\"
+  A list of edges which contains the \`Pet\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PetsEdge!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Pet\` you could get from the connection.\\"\\"\\"
+  totalCount: Int!
+}
+
+\\"\\"\\"A \`Pet\` edge in the connection.\\"\\"\\"
+type PetsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Pet\` at the end of the edge.\\"\\"\\"
+  node: Pet
+}
+
+\\"\\"\\"Methods to use when ordering \`Pet\`.\\"\\"\\"
+enum PetsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  TYPE_ASC
+  TYPE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query implements Node {
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+
+  \\"\\"\\"
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  node(
+    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    nodeId: ID!
+  ): Node
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Pet\`.\\"\\"\\"
+  allPets(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"The method to use when ordering \`Pet\`.\\"\\"\\"
+    orderBy: [PetsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PetCondition
+  ): PetsConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`User\`.\\"\\"\\"
+  allUsers(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"The method to use when ordering \`User\`.\\"\\"\\"
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: UserCondition
+  ): UsersConnection
+  petById(id: Int!): Pet
+  userById(id: Int!): User
+
+  \\"\\"\\"Reads a single \`Pet\` using its globally unique \`ID\`.\\"\\"\\"
+  pet(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Pet\`.\\"\\"\\"
+    nodeId: ID!
+  ): Pet
+
+  \\"\\"\\"Reads a single \`User\` using its globally unique \`ID\`.\\"\\"\\"
+  user(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`User\`.\\"\\"\\"
+    nodeId: ID!
+  ): User
+}
+
+type User implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  id: Int!
+  name: String!
+  email: String!
+  bio: String
+  renamedComplexColumn: [Complex]
+  createdAt: Datetime!
+  myCustomScalar: Int!
+  myCustomScalarWithFunction: Int!
+  myCustomScalarWithFunctionAndArgument(test: Int!): Int!
+}
+
+\\"\\"\\"
+A condition to be used against \`User\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input UserCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  name: String
+
+  \\"\\"\\"Checks for equality with the object’s \`email\` field.\\"\\"\\"
+  email: String
+
+  \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
+  bio: String
+
+  \\"\\"\\"Checks for equality with the object’s \`renamedComplexColumn\` field.\\"\\"\\"
+  renamedComplexColumn: [ComplexInput]
+
+  \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
+  createdAt: Datetime
+}
+
+\\"\\"\\"A connection to a list of \`User\` values.\\"\\"\\"
+type UsersConnection {
+  \\"\\"\\"A list of \`User\` objects.\\"\\"\\"
+  nodes: [User]!
+
+  \\"\\"\\"
+  A list of edges which contains the \`User\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [UsersEdge!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`User\` you could get from the connection.\\"\\"\\"
+  totalCount: Int!
+}
+
+\\"\\"\\"A \`User\` edge in the connection.\\"\\"\\"
+type UsersEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`User\` at the end of the edge.\\"\\"\\"
+  node: User
+}
+
+\\"\\"\\"Methods to use when ordering \`User\`.\\"\\"\\"
+enum UsersOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  BIO_ASC
+  BIO_DESC
+  RENAMED_COMPLEX_COLUMN_ASC
+  RENAMED_COMPLEX_COLUMN_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+"
+`;
+
+exports[`allows to retrieve array scalar values 1`] = `
+"type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"An input for mutations affecting \`Complex\`\\"\\"\\"
+input ComplexInput {
+  numberInt: Int
+  stringText: String
+}
+
+\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+scalar Cursor
+
+\\"\\"\\"
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+\\"\\"\\"
+scalar Datetime
+
+\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+interface Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+}
+
+\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+type PageInfo {
+  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  hasNextPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  hasPreviousPage: Boolean!
+
+  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  startCursor: Cursor
+
+  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  endCursor: Cursor
+}
+
+type Pet implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  id: Int!
+  userId: Int!
+  name: String!
+  type: String!
+}
+
+\\"\\"\\"
+A condition to be used against \`Pet\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input PetCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`userId\` field.\\"\\"\\"
+  userId: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  name: String
+
+  \\"\\"\\"Checks for equality with the object’s \`type\` field.\\"\\"\\"
+  type: String
+}
+
+\\"\\"\\"A connection to a list of \`Pet\` values.\\"\\"\\"
+type PetsConnection {
+  \\"\\"\\"A list of \`Pet\` objects.\\"\\"\\"
+  nodes: [Pet]!
+
+  \\"\\"\\"
+  A list of edges which contains the \`Pet\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [PetsEdge!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Pet\` you could get from the connection.\\"\\"\\"
+  totalCount: Int!
+}
+
+\\"\\"\\"A \`Pet\` edge in the connection.\\"\\"\\"
+type PetsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Pet\` at the end of the edge.\\"\\"\\"
+  node: Pet
+}
+
+\\"\\"\\"Methods to use when ordering \`Pet\`.\\"\\"\\"
+enum PetsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  TYPE_ASC
+  TYPE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+type Query implements Node {
+  \\"\\"\\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \\"\\"\\"
+  query: Query!
+
+  \\"\\"\\"
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  \\"\\"\\"
+  nodeId: ID!
+
+  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  node(
+    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    nodeId: ID!
+  ): Node
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Pet\`.\\"\\"\\"
+  allPets(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"The method to use when ordering \`Pet\`.\\"\\"\\"
+    orderBy: [PetsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: PetCondition
+  ): PetsConnection
+
+  \\"\\"\\"Reads and enables pagination through a set of \`User\`.\\"\\"\\"
+  allUsers(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"The method to use when ordering \`User\`.\\"\\"\\"
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    \\"\\"\\"
+    A condition to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    condition: UserCondition
+  ): UsersConnection
+  petById(id: Int!): Pet
+  userById(id: Int!): User
+
+  \\"\\"\\"Reads a single \`Pet\` using its globally unique \`ID\`.\\"\\"\\"
+  pet(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Pet\`.\\"\\"\\"
+    nodeId: ID!
+  ): Pet
+
+  \\"\\"\\"Reads a single \`User\` using its globally unique \`ID\`.\\"\\"\\"
+  user(
+    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`User\`.\\"\\"\\"
+    nodeId: ID!
+  ): User
+}
+
+type User implements Node {
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  id: Int!
+  name: String!
+  email: String!
+  bio: String
+  renamedComplexColumn: [Complex]
+  createdAt: Datetime!
+  myCustomArrayOfScalars: [String!]!
+}
+
+\\"\\"\\"
+A condition to be used against \`User\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\\"\\"\\"
+input UserCondition {
+  \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
+  id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`name\` field.\\"\\"\\"
+  name: String
+
+  \\"\\"\\"Checks for equality with the object’s \`email\` field.\\"\\"\\"
+  email: String
+
+  \\"\\"\\"Checks for equality with the object’s \`bio\` field.\\"\\"\\"
+  bio: String
+
+  \\"\\"\\"Checks for equality with the object’s \`renamedComplexColumn\` field.\\"\\"\\"
+  renamedComplexColumn: [ComplexInput]
+
+  \\"\\"\\"Checks for equality with the object’s \`createdAt\` field.\\"\\"\\"
+  createdAt: Datetime
+}
+
+\\"\\"\\"A connection to a list of \`User\` values.\\"\\"\\"
+type UsersConnection {
+  \\"\\"\\"A list of \`User\` objects.\\"\\"\\"
+  nodes: [User]!
+
+  \\"\\"\\"
+  A list of edges which contains the \`User\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [UsersEdge!]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`User\` you could get from the connection.\\"\\"\\"
+  totalCount: Int!
+}
+
+\\"\\"\\"A \`User\` edge in the connection.\\"\\"\\"
+type UsersEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`User\` at the end of the edge.\\"\\"\\"
+  node: User
+}
+
+\\"\\"\\"Methods to use when ordering \`User\`.\\"\\"\\"
+enum UsersOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  BIO_ASC
+  BIO_DESC
+  RENAMED_COMPLEX_COLUMN_ASC
+  RENAMED_COMPLEX_COLUMN_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+"
+`;

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -923,7 +923,10 @@ function getFields<TSource>(
                     pgQuery: (queryBuilder: QueryBuilder) => {
                       queryBuilder.select(
                         typeof directives.pgQuery.fragment === "function"
-                          ? directives.pgQuery.fragment(queryBuilder)
+                          ? directives.pgQuery.fragment(
+                              queryBuilder,
+                              parsedResolveInfoFragment.args
+                            )
                           : directives.pgQuery.fragment,
                         build.getSafeAliasFromAlias(
                           parsedResolveInfoFragment.alias

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -647,7 +647,10 @@ function getFields<TSource>(
     throw new Error("getFields only supports named types");
   }
   const Self: GraphQLNamedType = SelfGeneric as any;
-  const { pgSql: sql } = build;
+  const {
+    pgSql: sql,
+    graphql: { isScalarType, getNamedType },
+  } = build;
   function augmentResolver(
     resolver: AugmentedGraphQLFieldResolver<TSource, any>,
     fieldContext: Context<TSource>,
@@ -746,9 +749,14 @@ function getFields<TSource>(
           scope.pgFieldIntrospection.kind === "class"
             ? scope.pgFieldIntrospection
             : null;
+        const isScalar = isScalarType(getNamedType(type));
 
         const generateImplicitResolverIfPossible = () => {
-          if (directives.pgQuery && table) {
+          if (
+            directives.pgQuery &&
+            ((table && directives.pgQuery.source) ||
+              (isScalar && directives.pgQuery.fragment))
+          ) {
             return (
               data: any,
               _args: any,
@@ -858,53 +866,78 @@ function getFields<TSource>(
               );
             }
           }
-          if (directives.pgQuery && table) {
-            fieldContext.addDataGenerator((parsedResolveInfoFragment: any) => {
-              return {
-                pgQuery: (queryBuilder: QueryBuilder) => {
-                  queryBuilder.select(() => {
-                    const resolveData = fieldContext.getDataFromParsedResolveInfoFragment(
-                      parsedResolveInfoFragment,
-                      namedType
-                    );
-                    const tableAlias = sql.identifier(Symbol());
-                    const query = build.pgQueryFromResolveData(
-                      directives.pgQuery.source,
-                      tableAlias,
-                      resolveData,
-                      {
-                        withPagination: isConnection,
-                        withPaginationAsFields: false,
-                        asJsonAggregate: isListType && !isConnection,
-                        asJson: !isConnection,
-                        addNullCase: !isConnection,
-                      },
-                      (innerQueryBuilder: QueryBuilder) => {
-                        innerQueryBuilder.parentQueryBuilder = queryBuilder;
-                        if (
-                          build.options.subscriptions &&
-                          table.primaryKeyConstraint
-                        ) {
-                          innerQueryBuilder.selectIdentifiers(table);
-                        }
-                        if (
-                          typeof directives.pgQuery.withQueryBuilder ===
-                          "function"
-                        ) {
-                          directives.pgQuery.withQueryBuilder(
-                            innerQueryBuilder,
-                            parsedResolveInfoFragment.args
-                          );
-                        }
-                      },
-                      queryBuilder.context,
-                      queryBuilder.rootValue
-                    );
-                    return sql.fragment`(${query})`;
-                  }, build.getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
-                },
-              };
-            });
+          if (directives.pgQuery) {
+            if (table && directives.pgQuery.source) {
+              fieldContext.addDataGenerator(
+                (parsedResolveInfoFragment: any) => {
+                  return {
+                    pgQuery: (queryBuilder: QueryBuilder) => {
+                      queryBuilder.select(() => {
+                        const resolveData = fieldContext.getDataFromParsedResolveInfoFragment(
+                          parsedResolveInfoFragment,
+                          namedType
+                        );
+                        const tableAlias = sql.identifier(Symbol());
+                        const query = build.pgQueryFromResolveData(
+                          directives.pgQuery.source,
+                          tableAlias,
+                          resolveData,
+                          {
+                            withPagination: isConnection,
+                            withPaginationAsFields: false,
+                            asJsonAggregate: isListType && !isConnection,
+                            asJson: !isConnection,
+                            addNullCase: !isConnection,
+                          },
+                          (innerQueryBuilder: QueryBuilder) => {
+                            innerQueryBuilder.parentQueryBuilder = queryBuilder;
+                            if (
+                              build.options.subscriptions &&
+                              table.primaryKeyConstraint
+                            ) {
+                              innerQueryBuilder.selectIdentifiers(table);
+                            }
+                            if (
+                              typeof directives.pgQuery.withQueryBuilder ===
+                              "function"
+                            ) {
+                              directives.pgQuery.withQueryBuilder(
+                                innerQueryBuilder,
+                                parsedResolveInfoFragment.args
+                              );
+                            }
+                          },
+                          queryBuilder.context,
+                          queryBuilder.rootValue
+                        );
+                        return sql.fragment`(${query})`;
+                      }, build.getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
+                    },
+                  };
+                }
+              );
+            } else if (isScalar && directives.pgQuery.fragment) {
+              fieldContext.addDataGenerator(
+                (parsedResolveInfoFragment: any) => {
+                  return {
+                    pgQuery: (queryBuilder: QueryBuilder) => {
+                      queryBuilder.select(
+                        typeof directives.pgQuery.fragment === "function"
+                          ? directives.pgQuery.fragment(queryBuilder)
+                          : directives.pgQuery.fragment,
+                        build.getSafeAliasFromAlias(
+                          parsedResolveInfoFragment.alias
+                        )
+                      );
+                    },
+                  };
+                }
+              );
+            } else {
+              throw new Error(
+                `@pgQuery(...) directive called with invalid arguments - for a table value, call it with 'source' for a scalar with 'fragment'!`
+              );
+            }
           }
 
           const resolversSpec = rawResolversSpec


### PR DESCRIPTION
We had already chatted about this - this PR allows for scalars to be added as subqueries using the `@pgQuery` directive with the `fragment` argument.

If this is merged, it would be great if you could mention my employer [Mayflower](https://mayflower.de/) in the release notes, as this PR was done on company time. But if this something you don't do, thats fine, too :smiley: 