### PR TITLE
feat(pg): add partial index detection to introspection

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -152,6 +152,7 @@ export interface PgIndex {
   indexType: string;
   isUnique: boolean;
   isPrimary: boolean;
+  isPartial: boolean;
   attributeNums: Array<number>;
   attributePropertiesAsc: Array<boolean> | void;
   attributePropertiesNullsFirst: Array<boolean> | void;

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -182,6 +182,7 @@ export type PgIndex = {
   isReplicaIdentity: boolean,
   isValid: boolean,
   */
+  isPartial: boolean,
   attributeNums: Array<number>,
   attributePropertiesAsc: ?Array<boolean>,
   attributePropertiesNullsFirst: ?Array<boolean>,

--- a/packages/graphile-build-pg/src/plugins/introspectionQuery.js
+++ b/packages/graphile-build-pg/src/plugins/introspectionQuery.js
@@ -375,6 +375,7 @@ with
       idx.indimmediate as "isImmediate", -- enforce uniqueness immediately on insert
       idx.indisreplident as "isReplicaIdentity",
       idx.indisvalid as "isValid", -- if false, don't use for queries
+      idx.indpred is not null as "isPartial", -- if true, index is not on on rows.
       idx.indkey as "attributeNums",
       am.amname as "indexType",
       ${


### PR DESCRIPTION
The PgIndex type currently do not have a way to know if the index is a partial index or not, making it hard to decide and use the index inside plugin. The `indpred` field that existed in postgresql index since 7.1+  shows the predicate of the index, describe the "where clause" of the index. If it is not null, it is an expression of "what part of all records should be in this index". If this field is NULL, it means the index is not partial. 

Also added field to Flow type and ts type. 