### PR TITLE
feat(QueryBuilder): new methods for managing QB children

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.d.ts
+++ b/packages/graphile-build-pg/src/QueryBuilder.d.ts
@@ -93,6 +93,13 @@ export default class QueryBuilder {
     addNotDistinctFromNullCase?: boolean;
     useAsterisk?: boolean;
   }): SQL;
+  public buildChild(): QueryBuilder;
+  public buildNamedChildFrom(
+    name: string,
+    from: SQLGen,
+    field: SQLGen
+  ): QueryBuilder;
+  public getNamedChild(name: string): QueryBuilder | undefined;
 
   // ----------------------------------------
 

--- a/packages/graphile-build-pg/src/QueryBuilder.d.ts
+++ b/packages/graphile-build-pg/src/QueryBuilder.d.ts
@@ -94,13 +94,13 @@ export default class QueryBuilder {
     useAsterisk?: boolean;
   }): SQL;
   public buildChild(): QueryBuilder;
-  public buildNamedChildFrom(
-    name: string,
+  public buildNamedChildSelecting(
+    name: RawAlias,
     from: SQLGen,
     field: SQLGen,
-    alias: SQLAlias
+    alias?: SQLAlias
   ): QueryBuilder;
-  public getNamedChild(name: string): QueryBuilder | undefined;
+  public getNamedChild(name: RawAlias): QueryBuilder | undefined;
 
   // ----------------------------------------
 

--- a/packages/graphile-build-pg/src/QueryBuilder.d.ts
+++ b/packages/graphile-build-pg/src/QueryBuilder.d.ts
@@ -97,7 +97,7 @@ export default class QueryBuilder {
   public buildNamedChildSelecting(
     name: RawAlias,
     from: SQLGen,
-    field: SQLGen,
+    selectExpression: SQLGen,
     alias?: SQLAlias
   ): QueryBuilder;
   public getNamedChild(name: RawAlias): QueryBuilder | undefined;

--- a/packages/graphile-build-pg/src/QueryBuilder.d.ts
+++ b/packages/graphile-build-pg/src/QueryBuilder.d.ts
@@ -97,7 +97,8 @@ export default class QueryBuilder {
   public buildNamedChildFrom(
     name: string,
     from: SQLGen,
-    field: SQLGen
+    field: SQLGen,
+    alias: SQLAlias
   ): QueryBuilder;
   public getNamedChild(name: string): QueryBuilder | undefined;
 

--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -126,7 +126,7 @@ class QueryBuilder {
   lockContext: {
     queryBuilder: QueryBuilder,
   };
-  children: Map<string, QueryBuilder>;
+  _children: Map<string, QueryBuilder>;
 
   constructor(
     options: QueryBuilderOptions = {},
@@ -217,7 +217,7 @@ class QueryBuilder {
       last: null,
       cursorComparator: null,
     };
-    this.children = new Map();
+    this._children = new Map();
     this.beforeLock("select", () => {
       this.lock("selectCursor");
       if (this.compiledData.selectCursor) {
@@ -883,18 +883,18 @@ order by (row_number() over (partition by 1)) desc`;
     return child;
   }
   buildNamedChildFrom(name: string, from: SQLGen, field: SQLGen) {
-    if (this.children.has(name)) {
+    if (this._children.has(name)) {
       throw new Error(`QueryBuilder already has a child named ${name}`);
     }
     const child = this.buildChild();
     child.from(from);
-    child.select(field, "_");
+    child.select(field, "value");
     child.lock("select");
-    this.children.set(name, child);
+    this._children.set(name, child);
     return child;
   }
   getNamedChild(name: string) {
-    return this.children.get(name);
+    return this._children.get(name);
   }
 }
 

--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -73,6 +73,7 @@ class QueryBuilder {
   context: GraphQLContext;
   rootValue: any; // eslint-disable-line flowtype/no-weak-types
   supportsJSONB: boolean;
+  isSingleFieldSelector: boolean;
   locks: {
     [string]: false | true | string,
   };
@@ -688,10 +689,10 @@ ${sql.join(
       useAsterisk?: boolean,
     } = {}
   ) {
-    if (this.isSingleFieldSelectorThingie) {
+    if (this.isSingleFieldSelector) {
       if (Object.keys(options).length > 0) {
         throw new Error(
-          "Can't use QueryBuilder.build(options) in isSingleFieldSelectorThingie"
+          "Can't use QueryBuilder.build(options) in isSingleFieldSelector"
         );
       }
       options = {
@@ -922,7 +923,7 @@ order by (row_number() over (partition by 1)) desc`;
       throw new Error(`QueryBuilder already has a child named ${name}`);
     }
     const child = this.buildChild();
-    child.isSingleFieldSelectorThingie = true;
+    child.isSingleFieldSelector = true;
     child.from(from, alias);
     child.select(field, "value");
     child.lock("select");

--- a/packages/postgraphile-core/__tests__/fixtures/queries/named_query_builder.toys.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/named_query_builder.toys.graphql
@@ -1,0 +1,17 @@
+{
+  t1: toyById(id: 1) {
+    categories {
+      name
+    }
+  }
+  t2: toyById(id: 1) {
+    categories(approved: true) {
+      name
+    }
+  }
+  t3: toyById(id: 1) {
+    categories(approved: false) {
+      name
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/integration/ToyCategoriesPlugin.js
+++ b/packages/postgraphile-core/__tests__/integration/ToyCategoriesPlugin.js
@@ -104,7 +104,7 @@ module.exports = builder => {
                 "toyCategoriesSubquery"
               );
               toyCategoriesQueryBuilder.where(
-                sql.fragment`${toyCategoriesQueryBuilder.getTableAlias()}.approved = ${sql.literal(
+                sql.fragment`${toyCategoriesQueryBuilder.getTableAlias()}.approved = ${sql.value(
                   approved
                 )}`
               );

--- a/packages/postgraphile-core/__tests__/integration/ToyCategoriesPlugin.js
+++ b/packages/postgraphile-core/__tests__/integration/ToyCategoriesPlugin.js
@@ -1,0 +1,118 @@
+module.exports = builder => {
+  // This hook adds the 'Toy.categories' field
+  builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
+    const {
+      getTypeByName,
+      graphql: { GraphQLList },
+    } = build;
+    const { Self, fieldWithHooks } = context;
+
+    if (Self.name !== "Toy") {
+      return fields;
+    }
+
+    return build.extend(fields, {
+      categories: fieldWithHooks(
+        "categories",
+        ({ addDataGenerator, getDataFromParsedResolveInfoFragment }) => {
+          addDataGenerator(parsedResolveInfoFragment => {
+            return {
+              pgQuery: queryBuilder => {
+                queryBuilder.select(() => {
+                  const resolveData = getDataFromParsedResolveInfoFragment(
+                    parsedResolveInfoFragment,
+                    gqlForeignTableType
+                  );
+                  const foreignTableAlias = sql.identifier(Symbol());
+                  const query = queryFromResolveData(
+                    sql.fragment`named_query_builder.categories`,
+                    foreignTableAlias,
+                    resolveData,
+                    {
+                      useAsterisk: false,
+                      asJson: true,
+                    },
+                    innerQueryBuilder => {
+                      innerQueryBuilder.parentQueryBuilder = queryBuilder;
+
+                      const innerInnerQueryBuilder = innerQueryBuilder.buildNamedChildFrom(
+                        "toyCategoriesSubquery",
+                        sql.fragment`named_query_builder.toy_categories`,
+                        "category_id"
+                      );
+                      innerQueryBuilder.where(
+                        () =>
+                          sql.fragment`${innerQueryBuilder.getTableAlias()}.id IN (${innerInnerQueryBuilder.build()})`
+                      );
+                    },
+                    queryBuilder.context,
+                    queryBuilder.rootValue
+                  );
+                  return sql.fragment`(${query})`;
+                }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));
+              },
+            };
+          });
+          const Category = getTypeByName("Category");
+          return {
+            type: new GraphQLList(Category),
+            resolve: (data, _args, resolveContext, resolveInfo) => {
+              if (!data) return null;
+              const safeAlias = getSafeAliasFromResolveInfo(resolveInfo);
+              return data[safeAlias];
+            },
+          };
+        },
+        {
+          /* w/e */
+        }
+      ),
+    });
+  });
+
+  // NOTE: this could be in a completely different plugin
+  // This hook adds the `approved: Boolean` argument to Toy.categories
+  builder.hook(
+    "GraphQLObjectType:fields:field:args",
+    (args, build, context) => {
+      const {
+        graphql: { GraphQLBoolean },
+      } = build;
+      const {
+        Self,
+        scope: { fieldName },
+        addArgDataGenerator,
+      } = context;
+      if (Self.name !== "Toy" || fieldName !== "categories") {
+        return args;
+      }
+
+      addArgDataGenerator(({ approved }) => {
+        return {
+          pgQuery: queryBuilder => {
+            if (approved != null) {
+              const toyCategoriesQueryBuilder = queryBuilder.getNamedChild(
+                "toyCategoriesSubquery"
+              );
+              toyCategoriesQueryBuilder.where(
+                sql.fragment`${toyCategoriesQueryBuilder.getTableAlias()}.approved = ${sql.value(
+                  approved
+                )}`
+              );
+            }
+          },
+        };
+      });
+
+      return build.extend(
+        args,
+        {
+          approved: {
+            type: GraphQLBoolean,
+          },
+        },
+        "Test"
+      );
+    }
+  );
+};

--- a/packages/postgraphile-core/__tests__/integration/ToyCategoriesPlugin.js
+++ b/packages/postgraphile-core/__tests__/integration/ToyCategoriesPlugin.js
@@ -40,7 +40,7 @@ module.exports = builder => {
                     innerQueryBuilder => {
                       innerQueryBuilder.parentQueryBuilder = queryBuilder;
                       const alias = Symbol("toyCategoriesSubquery");
-                      const innerInnerQueryBuilder = innerQueryBuilder.buildNamedChildFrom(
+                      const innerInnerQueryBuilder = innerQueryBuilder.buildNamedChildSelecting(
                         "toyCategoriesSubquery",
                         sql.identifier("named_query_builder", "toy_categories"),
                         sql.identifier(alias, "category_id"),

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -2004,6 +2004,37 @@ Object {
 }
 `;
 
+exports[`named_query_builder.toys.graphql 1`] = `
+Object {
+  "data": Object {
+    "t1": Object {
+      "categories": Array [
+        Object {
+          "name": "Dinosaurs",
+        },
+        Object {
+          "name": "Military",
+        },
+      ],
+    },
+    "t2": Object {
+      "categories": Array [
+        Object {
+          "name": "Dinosaurs",
+        },
+      ],
+    },
+    "t3": Object {
+      "categories": Array [
+        Object {
+          "name": "Military",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`network_types.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/queries.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries.test.js
@@ -6,6 +6,7 @@ const { resolve: resolvePath } = require("path");
 const { printSchema } = require("graphql/utilities");
 const debug = require("debug")("graphile-build:schema");
 const { makeExtendSchemaPlugin, gql } = require("graphile-utils");
+const ToyCategoriesPlugin = require("./ToyCategoriesPlugin");
 
 function readFile(filename, encoding) {
   return new Promise((resolve, reject) => {
@@ -57,6 +58,7 @@ beforeAll(() => {
       largeBigint,
       useCustomNetworkScalars,
       pg10UseCustomNetworkScalars,
+      namedQueryBuilder,
     ] = await Promise.all([
       createPostGraphileSchema(pgClient, ["a", "b", "c"], {
         subscriptions: true,
@@ -119,6 +121,10 @@ beforeAll(() => {
             },
           })
         : null,
+      createPostGraphileSchema(pgClient, ["named_query_builder"], {
+        subscriptions: true,
+        appendPlugins: [ToyCategoriesPlugin],
+      }),
     ]);
     // Now for RBAC-enabled tests
     await pgClient.query("set role postgraphile_test_authenticator");
@@ -142,6 +148,7 @@ beforeAll(() => {
       largeBigint,
       useCustomNetworkScalars,
       pg10UseCustomNetworkScalars,
+      namedQueryBuilder,
     };
   });
 
@@ -212,6 +219,8 @@ beforeAll(() => {
               gqlSchema = gqlSchemas.smartCommentRelations;
             } else if (fileName.startsWith("large_bigint")) {
               gqlSchema = gqlSchemas.largeBigint;
+            } else if (fileName.startsWith("named_query_builder")) {
+              gqlSchema = gqlSchemas.namedQueryBuilder;
             } else {
               gqlSchema = gqlSchemas.normal;
             }

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -231,3 +231,22 @@ insert into network_types.network values
   (6, '2001:4f8:3:ba:2e0:81ff:fe22:d1f1', '2001:4f8:3:ba:2e0:81ff:fe22:d1f1/128', '08002b010203');
 
 alter sequence network_types.network_id_seq restart with 7;
+
+
+insert into named_query_builder.categories (id, name) values
+  (1, 'Dinosaurs'),
+  (2, 'Science'),
+  (3, 'Military');
+insert into named_query_builder.toys (id, name) values
+  (1, 'Rex'),
+  (2, 'Toy Soldiers'),
+  (3, 'Dino-Rocket Launcher'),
+  (4, 'History of Dinosaurs book');
+insert into named_query_builder.toy_categories(toy_id, category_id, approved) values
+  (1, 1, true),
+  (2, 3, true),
+  (3, 1, true),
+  (3, 3, true),
+  (4, 1, true),
+  (4, 2, true),
+  (1, 3, false);

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -1,5 +1,5 @@
 -- WARNING: this database is shared with graphile-utils, don't run the tests in parallel!
-drop schema if exists a, b, c, d, inheritence, smart_comment_relations, ranges, index_expressions, simple_collections, live_test, large_bigint, network_types cascade;
+drop schema if exists a, b, c, d, inheritence, smart_comment_relations, ranges, index_expressions, simple_collections, live_test, large_bigint, network_types, named_query_builder cascade;
 drop extension if exists tablefunc;
 drop extension if exists intarray;
 drop extension if exists hstore;
@@ -1070,4 +1070,24 @@ create table network_types.network (
   inet inet,
   cidr cidr,
   macaddr macaddr
+);
+
+/******************************************************************************/
+
+create schema named_query_builder;
+
+create table named_query_builder.toys (
+  id serial primary key,
+  name text not null
+);
+
+create table named_query_builder.categories (
+  id serial primary key,
+  name text not null
+);
+
+create table named_query_builder.toy_categories (
+  toy_id int not null references named_query_builder.toys,
+  category_id int not null references named_query_builder.categories,
+  approved boolean not null
 );


### PR DESCRIPTION
This adds three new public methods to the `QueryBuilder` class: `buildChild`, `buildNamedChildFrom`, and `getNamedChild`. These new methods will enable new capabilities for PostGraphile plugins. @benjie and I discussed this via Discord a few days ago, so I know he approves of these new methods.

I do have a few qustions:
* Should we also add a `buildNamedChild` method, which is like `buildNamedChildFrom` but does not call the `select`, `from`, or `lock` methods? It seems like an obvious extension of this API, but I'm not sure if it's actually useful/necessary. It might be better to wait until we find a use-case before building it.
* Should I add automated tests for this change? I don't see any automated tests for the `QueryBuilder` class at all.