### PR TITLE
fix(types): minor TypeScript fixes

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.d.ts
+++ b/packages/graphile-build-pg/src/QueryBuilder.d.ts
@@ -42,8 +42,8 @@ export default class QueryBuilder {
   public setOrderIsUnique(): void;
   public orderBy(
     exprGen: SQLGen,
-    ascending: boolean,
-    nullsFirst: boolean | null
+    ascending?: boolean,
+    nullsFirst?: boolean | null
   ): void;
   public limit(limitGen: NumberGen): void;
   public offset(offsetGen: NumberGen): void;

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -78,7 +78,7 @@ export interface Resolvers<TSource = any, TContext = any> {
 
 export interface ExtensionDefinition {
   typeDefs: DocumentNode;
-  resolvers: Resolvers;
+  resolvers?: Resolvers;
 }
 
 interface NewTypeDef {


### PR DESCRIPTION
Two tweaks:

- `ExtensionDefinition.resolvers` should be optional, as seen [in the docs here](https://www.graphile.org/postgraphile/make-extend-schema-plugin/#using-the-pgquery-directive-for-non-root-queries-and-better-performance), and verified that this change is OK to make [at the call site here](https://github.com/graphile/graphile-engine/blob/1689f6691a0716d41d256de3499c9da40407348f/packages/graphile-utils/src/makeExtendSchemaPlugin.ts#L109) as there is a default empty object

- `QueryBuidler.orderBy` should have `ascending` and `nullsFirst` as optional, as seen also [in the docs here](https://www.graphile.org/postgraphile/make-extend-schema-plugin/#using-the-pgquery-directive-for-non-root-queries-and-better-performance), and verified that this change is OK to make [at the call site here](https://github.com/graphile/graphile-engine/blob/1689f6691a0716d41d256de3499c9da40407348f/packages/graphile-build-pg/src/QueryBuilder.js#L710-L721)