### PR TITLE
Use jwt.Secret type in PostgraphileCoreOptions

### DIFF
--- a/packages/postgraphile-core/src/index.ts
+++ b/packages/postgraphile-core/src/index.ts
@@ -20,7 +20,7 @@ import {
   formatSQLForDebugging,
 } from "graphile-build-pg";
 import { Pool, PoolClient } from "pg";
-import { SignOptions } from "jsonwebtoken";
+import { SignOptions, Secret } from "jsonwebtoken";
 
 export {
   Plugin,
@@ -73,7 +73,7 @@ export interface PostGraphileCoreOptions {
   prependPlugins?: Array<Plugin>;
   skipPlugins?: Array<Plugin>;
   jwtPgTypeIdentifier?: string;
-  jwtSecret?: string;
+  jwtSecret?: Secret;
   jwtSignOptions?: SignOptions;
   /**
    * @deprecated UNSUPPORTED! Use an inflector plugin instead.


### PR DESCRIPTION
Not much of a change, but prerequisite for https://github.com/graphile/postgraphile/pull/1167 to typecheck. Also useful in general :-)