### PR TITLE
chore: fix development flow for jest-serializer-graphql-schema

### DIFF
--- a/packages/graphile-build-pg/package.json
+++ b/packages/graphile-build-pg/package.json
@@ -55,7 +55,8 @@
     "@babel/cli": "^7.0.0",
     "eslint_d": "^8.0.0",
     "flow-copy-source": "^1.2.0",
-    "jest": "^24.8.0"
+    "jest": "^24.8.0",
+    "jest-serializer-graphql-schema": "4.4.5"
   },
   "files": [
     "node8plus",

--- a/packages/graphile-build/package.json
+++ b/packages/graphile-build/package.json
@@ -47,7 +47,8 @@
     "@babel/cli": "^7.0.0",
     "eslint_d": "^8.0.0",
     "flow-copy-source": "^1.2.0",
-    "jest": "^24.8.0"
+    "jest": "^24.8.0",
+    "jest-serializer-graphql-schema": "4.4.5"
   },
   "peerDependencies": {
     "graphql": ">=0.9 <0.14 || ^14.0.2"

--- a/packages/graphile-utils/package.json
+++ b/packages/graphile-utils/package.json
@@ -40,6 +40,7 @@
     "graphile-build": "4.4.5",
     "graphile-build-pg": "4.4.5",
     "jest": "^24.8.0",
+    "jest-serializer-graphql-schema": "4.4.5",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   },

--- a/packages/jest-serializer-graphql-schema/package.json
+++ b/packages/jest-serializer-graphql-schema/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepack": "tsc",
+    "watch": "tsc --watch",
     "test": "jest"
   },
   "repository": {

--- a/packages/jest-serializer-graphql-schema/package.json
+++ b/packages/jest-serializer-graphql-schema/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/graphile/graphile-engine/tree/master/packages/jest-serializer-graphql-schema#readme",
   "peerDependencies": {
-    "graphql": "^14.5.8"
+    "graphql": "^14.0.2"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.2",

--- a/packages/pg-pubsub/package.json
+++ b/packages/pg-pubsub/package.json
@@ -44,6 +44,7 @@
     "@types/jest": "^24.0.12",
     "graphql": ">=0.6 <15",
     "jest": "24.9.0",
+    "jest-serializer-graphql-schema": "4.4.5",
     "mock-req": "^0.2.0",
     "mock-res": "^0.5.0",
     "pg": "^7.10.0",

--- a/packages/postgraphile-core/package.json
+++ b/packages/postgraphile-core/package.json
@@ -27,6 +27,7 @@
     "@types/pg": "^7.4.14",
     "debug": "^4.1.1",
     "jest": "^24.8.0",
+    "jest-serializer-graphql-schema": "4.4.5",
     "jest-silent-reporter": "^0.1.2",
     "jsonwebtoken": "^8.5.1",
     "pg-connection-string": "^2.1.0",


### PR DESCRIPTION
- Fixed `yarn watch`
- Fixed new peerdep warning
- Added devDependencies on the new module