### PR TITLE
RFC: phase-dependent typings for Builder

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -195,3 +195,10 @@ export default function PgIntrospectionPlugin(
   builder: SchemaBuilder,
   options: Options
 ): Promise<void> | void;
+
+import "graphile-build";
+declare module "graphile-build" {
+  interface BuildPropertiesIntroducedIn_build {
+    pgIntrospectionResultsByKind: PgIntrospectionResultsByKind;
+  }
+}

--- a/packages/graphile-build-pg/src/plugins/pgBasicsPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/pgBasicsPlugin.d.ts
@@ -1,0 +1,182 @@
+import {
+  PgClass,
+  PgNamespace,
+  PgAttribute,
+  PgType,
+  PgConstraint,
+  PgExtension,
+  PgIndex,
+  PgProc,
+} from "graphile-build-pg";
+import {
+  GraphQLSchema,
+  GraphQLSchemaConfig,
+  GraphQLObjectTypeConfig,
+  GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLInputObjectTypeConfig,
+  GraphQLEnumTypeConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLFieldConfigMap,
+  GraphQLFieldConfig,
+  GraphQLEnumValueConfigMap,
+  GraphQLEnumValueConfig,
+  GraphQLInputFieldConfigMap,
+  GraphQLInputFieldConfig,
+  GraphQLUnionTypeConfig,
+  GraphQLNamedType,
+} from "graphql";
+
+import "graphile-build";
+declare module "graphile-build" {
+  interface BuildPropertiesIntroducedIn_build {
+    graphileBuildPgVersion: any;
+    pgSql: typeof import("pg-sql2");
+    pgStrictFunctions: any;
+    pgColumnFilter: any;
+    pgQueryFromResolveData: any;
+    pgAddStartEndCursor: any;
+    pgOmit: any;
+    pgMakeProcField: any;
+    pgParseIdentifier: any;
+    pgViaTemporaryTable: any;
+    describePgEntity: any;
+    pgField: any;
+    sqlCommentByAddingTags: any;
+    pgPrepareAndRun: any;
+  }
+
+  type Keys = Array<{
+    column: string;
+    table: string;
+    schema?: string;
+  }>;
+
+  interface Inflection {
+    conditionType(typeName: string): string;
+    inputType(typeName: string): string;
+    rangeBoundType(typeName: string): string;
+    rangeType(typeName: string): string;
+    patchType(typeName: string): string;
+    baseInputType(typeName: string): string;
+    patchField(itemName: string): string;
+    orderByType(typeName: string): string;
+    edge(typeName: string): string;
+    connection(typeName: string): string;
+    _functionName(proc: PgProc): string;
+    _typeName(type: PgType): string;
+    _tableName(table: PgClass): string;
+    _singularizedTableName(table: PgClass): string;
+    _columnName(attr: PgAttribute, _options?: { skipRowId?: boolean }): string;
+    enumType(type: PgType): string;
+    argument(name: string | undefined, index: number): string;
+    orderByEnum(columnName: unknown, ascending: unknown): string;
+    orderByColumnEnum(attr: PgAttribute, ascending: boolean): string;
+    orderByComputedColumnEnum(
+      pseudoColumnName: string,
+      proc: PgProc,
+      table: PgClass,
+      ascending: boolean
+    ): string;
+    domainType(type: PgType): string;
+    enumName(inValue: string): string;
+    tableNode(table: PgClass): string;
+    tableFieldName(table: PgClass): string;
+    allRows(table: PgClass): string;
+    allRowsSimple(table: PgClass): string;
+    functionMutationName(proc: PgProc): string;
+    functionMutationResultFieldName(
+      proc: PgProc,
+      gqlType: unknown,
+      plural: boolean,
+      outputArgNames: Array<string>
+    ): string;
+    functionQueryName(proc: PgProc): string;
+    functionQueryNameList(proc: PgProc): string;
+    functionPayloadType(proc: PgProc): string;
+    functionInputType(proc: PgProc): string;
+    functionOutputFieldName(
+      proc: PgProc,
+      outputArgName: string,
+      index: number
+    ): string;
+    tableType(table: PgClass): string;
+    column(attr: PgAttribute): string;
+    computedColumn(
+      pseudoColumnName: string,
+      proc: PgProc,
+      _table: PgClass
+    ): string;
+    computedColumnList(
+      pseudoColumnName: string,
+      proc: PgProc,
+      _table: PgClass
+    ): string;
+    singleRelationByKeys(
+      detailedKeys: Keys,
+      table: PgClass,
+      _foreignTable: PgClass,
+      constraint: PgConstraint
+    ): string;
+    singleRelationByKeysBackwards(
+      detailedKeys: Keys,
+      table: PgClass,
+      _foreignTable: PgClass,
+      constraint: PgConstraint
+    ): string;
+    manyRelationByKeys(
+      detailedKeys: Keys,
+      table: PgClass,
+      _foreignTable: PgClass,
+      constraint: PgConstraint
+    ): string;
+    manyRelationByKeysSimple(
+      detailedKeys: Keys,
+      table: PgClass,
+      _foreignTable: PgClass,
+      constraint: PgConstraint
+    ): string;
+    rowByUniqueKeys(
+      detailedKeys: Keys,
+      table: PgClass,
+      constraint: PgConstraint
+    ): string;
+    updateByKeys(
+      detailedKeys: Keys,
+      table: PgClass,
+      constraint: PgConstraint
+    ): string;
+    deleteByKeys(
+      detailedKeys: Keys,
+      table: PgClass,
+      constraint: PgConstraint
+    ): string;
+    updateByKeysInputType(
+      detailedKeys: Keys,
+      table: PgClass,
+      constraint: PgConstraint
+    ): string;
+    deleteByKeysInputType(
+      detailedKeys: Keys,
+      table: PgClass,
+      constraint: PgConstraint
+    ): string;
+    updateNode(table: PgClass): string;
+    deleteNode(table: PgClass): string;
+    deletedNodeId(table: PgClass): string;
+    updateNodeInputType(table: PgClass): string;
+    deleteNodeInputType(table: PgClass): string;
+    edgeField(table: PgClass): string;
+    recordFunctionReturnType(proc: PgProc): string;
+    recordFunctionConnection(proc: PgProc): string;
+    recordFunctionEdge(proc: PgProc): string;
+    scalarFunctionConnection(proc: PgProc): string;
+    scalarFunctionEdge(proc: PgProc): string;
+    createField(table: PgClass): string;
+    createInputType(table: PgClass): string;
+    createPayloadType(table: PgClass): string;
+    updatePayloadType(table: PgClass): string;
+    deletePayloadType(table: PgClass): string;
+    [key: string]: (...args: any[]) => string;
+  }
+}

--- a/packages/graphile-build/src/SchemaBuilder.d.ts
+++ b/packages/graphile-build/src/SchemaBuilder.d.ts
@@ -14,6 +14,7 @@ import {
   GraphQLInputFieldConfigMap,
   GraphQLInputFieldConfig,
   GraphQLUnionTypeConfig,
+  GraphQLNamedType,
 } from "graphql";
 import { EventEmitter } from "events";
 
@@ -38,12 +39,9 @@ export type DataForType = {
 
 export type InitObject = never;
 
-export interface Build {
-  [str: string]: any;
-}
-export interface Inflection {
-  [str: string]: any;
-}
+import { Build, Inflection } from "./makeNewBuild";
+export { Build, Inflection };
+
 export interface Scope<Type> {
   [str: string]: any;
 }
@@ -52,8 +50,8 @@ export interface Context<Type> {
   [str: string]: any;
 }
 
-export interface Hook<Type> {
-  (input: Type, build: Build, context: Context<Type>): Type;
+export interface Hook<Type, Builder> {
+  (input: Type, build: Builder, context: Context<Type>): Type;
   displayName?: string;
   provides?: Array<string>;
   before?: Array<string>;
@@ -63,126 +61,150 @@ export interface Hook<Type> {
 export default class SchemaBuilder extends EventEmitter {
   hook(
     hookName: "build",
-    fn: Hook<Build>,
+    fn: Hook<Build, BuildFor_build>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "inflection",
-    fn: Hook<Inflection>,
+    fn: Hook<Inflection, BuildFor_inflection>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "init",
-    fn: Hook<InitObject>,
+    fn: Hook<InitObject, BuildFor_init>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLSchema",
-    fn: Hook<GraphQLSchemaConfig>,
+    fn: Hook<GraphQLSchemaConfig, BuildFor_GraphQLSchema>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook<TSource, TContext>(
     hookName: "GraphQLObjectType",
-    fn: Hook<GraphQLObjectTypeConfig<TSource, TContext>>,
+    fn: Hook<
+      GraphQLObjectTypeConfig<TSource, TContext>,
+      BuildFor_GraphQLObjectType
+    >,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLObjectType:interfaces",
-    fn: Hook<Array<GraphQLInterfaceType>>,
+    fn: Hook<
+      Array<GraphQLInterfaceType>,
+      BuildFor_GraphQLObjectType_interfaces
+    >,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook<TSource, TContext>(
     hookName: "GraphQLObjectType:fields",
-    fn: Hook<GraphQLFieldConfigMap<TSource, TContext>>,
+    fn: Hook<
+      GraphQLFieldConfigMap<TSource, TContext>,
+      BuildFor_GraphQLObjectType_fields
+    >,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook<TSource, TContext>(
     hookName: "GraphQLObjectType:fields:field",
-    fn: Hook<GraphQLFieldConfig<TSource, TContext>>,
+    fn: Hook<
+      GraphQLFieldConfig<TSource, TContext>,
+      BuildFor_GraphQLObjectType_fields_field
+    >,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLObjectType:fields:field:args",
-    fn: Hook<GraphQLFieldConfigArgumentMap>,
+    fn: Hook<
+      GraphQLFieldConfigArgumentMap,
+      BuildFor_GraphQLObjectType_fields_field_args
+    >,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLInputObjectType",
-    fn: Hook<GraphQLInputObjectTypeConfig>,
+    fn: Hook<GraphQLInputObjectTypeConfig, BuildFor_GraphQLInputObjectType>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLInputObjectType:fields",
-    fn: Hook<GraphQLInputFieldConfigMap>,
+    fn: Hook<
+      GraphQLInputFieldConfigMap,
+      BuildFor_GraphQLInputObjectType_fields
+    >,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLInputObjectType:fields:field",
-    fn: Hook<GraphQLInputFieldConfig>,
+    fn: Hook<
+      GraphQLInputFieldConfig,
+      BuildFor_GraphQLInputObjectType_fields_field
+    >,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLEnumType",
-    fn: Hook<GraphQLEnumTypeConfig>,
+    fn: Hook<GraphQLEnumTypeConfig, BuildFor_GraphQLEnumType>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLEnumType:values",
-    fn: Hook<GraphQLEnumValueConfigMap>,
+    fn: Hook<GraphQLEnumValueConfigMap, BuildFor_GraphQLEnumType_values>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLEnumType:values:value",
-    fn: Hook<GraphQLEnumValueConfig>,
+    fn: Hook<GraphQLEnumValueConfig, BuildFor_GraphQLEnumType_values_value>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook<TSource, TContext>(
     hookName: "GraphQLUnionType",
-    fn: Hook<GraphQLUnionTypeConfig<TSource, TContext>>,
+    fn: Hook<
+      GraphQLUnionTypeConfig<TSource, TContext>,
+      BuildFor_GraphQLUnionType
+    >,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "GraphQLUnionType:types",
-    fn: Hook<Array<GraphQLObjectType>>,
+    fn: Hook<Array<GraphQLObjectType>, BuildFor_GraphQLUnionType_types>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
   ): void;
   hook(
     hookName: "finalize",
-    fn: Hook<GraphQLSchema>,
+    fn: Hook<GraphQLSchema, BuildFor_finalize>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>
@@ -306,3 +328,130 @@ export default class SchemaBuilder extends EventEmitter {
 
   unwatchSchema(): Promise<void>;
 }
+
+export interface BuildPropertiesIntroducedIn_build {}
+export interface BuildPropertiesIntroducedIn_inflection {}
+export interface BuildPropertiesIntroducedIn_init {}
+export interface BuildPropertiesIntroducedIn_GraphQLSchema {}
+export interface BuildPropertiesIntroducedIn_GraphQLObjectType {}
+export interface BuildPropertiesIntroducedIn_GraphQLObjectType_interfaces {}
+export interface BuildPropertiesIntroducedIn_GraphQLObjectType_fields {}
+export interface BuildPropertiesIntroducedIn_GraphQLObjectType_fields_field {}
+export interface BuildPropertiesIntroducedIn_GraphQLObjectType_fields_field_args {}
+export interface BuildPropertiesIntroducedIn_GraphQLInputObjectType {}
+export interface BuildPropertiesIntroducedIn_GraphQLInputObjectType_fields {}
+export interface BuildPropertiesIntroducedIn_GraphQLInputObjectType_fields_field {}
+export interface BuildPropertiesIntroducedIn_GraphQLEnumType {}
+export interface BuildPropertiesIntroducedIn_GraphQLEnumType_values {}
+export interface BuildPropertiesIntroducedIn_GraphQLEnumType_values_value {}
+export interface BuildPropertiesIntroducedIn_GraphQLUnionType {}
+export interface BuildPropertiesIntroducedIn_GraphQLUnionType_types {}
+export interface BuildPropertiesIntroducedIn_finalize {}
+
+interface BuildPropertiesIntroducedBefore_build extends Build {}
+interface BuildPropertiesIntroducedBefore_inflection
+  extends BuildPropertiesIntroducedBefore_build,
+    BuildPropertiesIntroducedIn_build {}
+interface BuildPropertiesIntroducedBefore_init
+  extends BuildPropertiesIntroducedBefore_inflection,
+    BuildPropertiesIntroducedIn_inflection {}
+interface BuildPropertiesIntroducedBefore_GraphQLSchema
+  extends BuildPropertiesIntroducedBefore_init,
+    BuildPropertiesIntroducedIn_init {}
+interface BuildPropertiesIntroducedBefore_GraphQLObjectType
+  extends BuildPropertiesIntroducedBefore_GraphQLSchema,
+    BuildPropertiesIntroducedIn_GraphQLSchema {}
+interface BuildPropertiesIntroducedBefore_GraphQLObjectType_interfaces
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType,
+    BuildPropertiesIntroducedIn_GraphQLObjectType {}
+interface BuildPropertiesIntroducedBefore_GraphQLObjectType_fields
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType_interfaces,
+    BuildPropertiesIntroducedIn_GraphQLObjectType_interfaces {}
+interface BuildPropertiesIntroducedBefore_GraphQLObjectType_fields_field
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType_fields,
+    BuildPropertiesIntroducedIn_GraphQLObjectType_fields {}
+interface BuildPropertiesIntroducedBefore_GraphQLObjectType_fields_field_args
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType_fields_field,
+    BuildPropertiesIntroducedIn_GraphQLObjectType_fields_field {}
+interface BuildPropertiesIntroducedBefore_GraphQLInputObjectType
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType_fields_field_args,
+    BuildPropertiesIntroducedIn_GraphQLObjectType_fields_field_args {}
+interface BuildPropertiesIntroducedBefore_GraphQLInputObjectType_fields
+  extends BuildPropertiesIntroducedBefore_GraphQLInputObjectType,
+    BuildPropertiesIntroducedIn_GraphQLInputObjectType {}
+interface BuildPropertiesIntroducedBefore_GraphQLInputObjectType_fields_field
+  extends BuildPropertiesIntroducedBefore_GraphQLInputObjectType_fields,
+    BuildPropertiesIntroducedIn_GraphQLInputObjectType_fields {}
+interface BuildPropertiesIntroducedBefore_GraphQLEnumType
+  extends BuildPropertiesIntroducedBefore_GraphQLInputObjectType_fields_field,
+    BuildPropertiesIntroducedIn_GraphQLInputObjectType_fields_field {}
+interface BuildPropertiesIntroducedBefore_GraphQLEnumType_values
+  extends BuildPropertiesIntroducedBefore_GraphQLEnumType,
+    BuildPropertiesIntroducedIn_GraphQLEnumType {}
+interface BuildPropertiesIntroducedBefore_GraphQLEnumType_values_value
+  extends BuildPropertiesIntroducedBefore_GraphQLEnumType_values,
+    BuildPropertiesIntroducedIn_GraphQLEnumType_values {}
+interface BuildPropertiesIntroducedBefore_GraphQLUnionType
+  extends BuildPropertiesIntroducedBefore_GraphQLEnumType_values_value,
+    BuildPropertiesIntroducedIn_GraphQLEnumType_values_value {}
+interface BuildPropertiesIntroducedBefore_GraphQLUnionType_types
+  extends BuildPropertiesIntroducedBefore_GraphQLUnionType,
+    BuildPropertiesIntroducedIn_GraphQLUnionType {}
+interface BuildPropertiesIntroducedBefore_finalize
+  extends BuildPropertiesIntroducedBefore_GraphQLUnionType_types,
+    BuildPropertiesIntroducedIn_GraphQLUnionType_types {}
+
+interface BuildFor_build
+  extends BuildPropertiesIntroducedBefore_build,
+    Partial<BuildPropertiesIntroducedIn_build> {}
+interface BuildFor_inflection
+  extends BuildPropertiesIntroducedBefore_inflection,
+    Partial<BuildPropertiesIntroducedIn_inflection> {}
+interface BuildFor_init
+  extends BuildPropertiesIntroducedBefore_init,
+    Partial<BuildPropertiesIntroducedIn_init> {}
+interface BuildFor_GraphQLSchema
+  extends BuildPropertiesIntroducedBefore_GraphQLSchema,
+    Partial<BuildPropertiesIntroducedIn_GraphQLSchema> {}
+interface BuildFor_GraphQLObjectType
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType,
+    Partial<BuildPropertiesIntroducedIn_GraphQLObjectType> {}
+interface BuildFor_GraphQLObjectType_interfaces
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType_interfaces,
+    Partial<BuildPropertiesIntroducedIn_GraphQLObjectType_interfaces> {}
+interface BuildFor_GraphQLObjectType_fields
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType_fields,
+    Partial<BuildPropertiesIntroducedIn_GraphQLObjectType_fields> {}
+interface BuildFor_GraphQLObjectType_fields_field
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType_fields_field,
+    Partial<BuildPropertiesIntroducedIn_GraphQLObjectType_fields_field> {}
+interface BuildFor_GraphQLObjectType_fields_field_args
+  extends BuildPropertiesIntroducedBefore_GraphQLObjectType_fields_field_args,
+    Partial<BuildPropertiesIntroducedIn_GraphQLObjectType_fields_field_args> {}
+interface BuildFor_GraphQLInputObjectType
+  extends BuildPropertiesIntroducedBefore_GraphQLInputObjectType,
+    Partial<BuildPropertiesIntroducedIn_GraphQLInputObjectType> {}
+interface BuildFor_GraphQLInputObjectType_fields
+  extends BuildPropertiesIntroducedBefore_GraphQLInputObjectType_fields,
+    Partial<BuildPropertiesIntroducedIn_GraphQLInputObjectType_fields> {}
+interface BuildFor_GraphQLInputObjectType_fields_field
+  extends BuildPropertiesIntroducedBefore_GraphQLInputObjectType_fields_field,
+    Partial<BuildPropertiesIntroducedIn_GraphQLInputObjectType_fields_field> {}
+interface BuildFor_GraphQLEnumType
+  extends BuildPropertiesIntroducedBefore_GraphQLEnumType,
+    Partial<BuildPropertiesIntroducedIn_GraphQLEnumType> {}
+interface BuildFor_GraphQLEnumType_values
+  extends BuildPropertiesIntroducedBefore_GraphQLEnumType_values,
+    Partial<BuildPropertiesIntroducedIn_GraphQLEnumType_values> {}
+interface BuildFor_GraphQLEnumType_values_value
+  extends BuildPropertiesIntroducedBefore_GraphQLEnumType_values_value,
+    Partial<BuildPropertiesIntroducedIn_GraphQLEnumType_values_value> {}
+interface BuildFor_GraphQLUnionType
+  extends BuildPropertiesIntroducedBefore_GraphQLUnionType,
+    Partial<BuildPropertiesIntroducedIn_GraphQLUnionType> {}
+interface BuildFor_GraphQLUnionType_types
+  extends BuildPropertiesIntroducedBefore_GraphQLUnionType_types,
+    Partial<BuildPropertiesIntroducedIn_GraphQLUnionType_types> {}
+interface BuildFor_finalize
+  extends BuildPropertiesIntroducedBefore_finalize,
+    Partial<BuildPropertiesIntroducedIn_finalize> {}

--- a/packages/graphile-build/src/index.d.ts
+++ b/packages/graphile-build/src/index.d.ts
@@ -21,7 +21,6 @@ import SchemaBuilder, {
 } from "./SchemaBuilder";
 
 export {
-  mixed,
   Options,
   Plugin,
   TriggerChangeType,
@@ -29,12 +28,31 @@ export {
   SchemaListener,
   DataForType,
   InitObject,
-  Build,
-  Inflection,
   Scope,
   Context,
   Hook,
+  BuildPropertiesIntroducedIn_build,
+  BuildPropertiesIntroducedIn_inflection,
+  BuildPropertiesIntroducedIn_init,
+  BuildPropertiesIntroducedIn_GraphQLSchema,
+  BuildPropertiesIntroducedIn_GraphQLObjectType,
+  BuildPropertiesIntroducedIn_GraphQLObjectType_interfaces,
+  BuildPropertiesIntroducedIn_GraphQLObjectType_fields,
+  BuildPropertiesIntroducedIn_GraphQLObjectType_fields_field,
+  BuildPropertiesIntroducedIn_GraphQLObjectType_fields_field_args,
+  BuildPropertiesIntroducedIn_GraphQLInputObjectType,
+  BuildPropertiesIntroducedIn_GraphQLInputObjectType_fields,
+  BuildPropertiesIntroducedIn_GraphQLInputObjectType_fields_field,
+  BuildPropertiesIntroducedIn_GraphQLEnumType,
+  BuildPropertiesIntroducedIn_GraphQLEnumType_values,
+  BuildPropertiesIntroducedIn_GraphQLEnumType_values_value,
+  BuildPropertiesIntroducedIn_GraphQLUnionType,
+  BuildPropertiesIntroducedIn_GraphQLUnionType_types,
+  BuildPropertiesIntroducedIn_finalize,
 } from "./SchemaBuilder";
+
+export { Build, Inflection } from "./makeNewBuild";
+
 export { LiveSource, LiveProvider, LiveMonitor, LiveCoordinator } from "./Live";
 export { SchemaBuilder };
 

--- a/packages/graphile-build/src/makeNewBuild.d.ts
+++ b/packages/graphile-build/src/makeNewBuild.d.ts
@@ -1,0 +1,69 @@
+import {
+  PgProc,
+  PgType,
+  PgClass,
+  PgAttribute,
+  PgConstraint,
+} from "graphile-build-pg";
+import { GraphQLNamedType } from "graphql";
+
+export interface Build {
+  options: any;
+  graphileBuildVersion: any;
+  versions: any;
+  hasVersion(
+    packageName: string,
+    range: string,
+    options?: { includePrerelease?: boolean }
+  ): boolean;
+  graphql: typeof import("graphql");
+  parseResolveInfo: any;
+  simplifyParsedResolveInfoFragmentWithType: any;
+  getSafeAliasFromAlias: any;
+  /** @deprecated */
+  getAliasFromResolveInfo: any;
+  getSafeAliasFromResolveInfo: any;
+  resolveAlias(data: any, _args: any, _context: any, resolveInfo: any): any;
+  addType(type: GraphQLNamedType, origin?: string): void;
+  getTypeByName(typeName: any): any;
+  extend: any;
+  newWithHooks(
+    Type: any,
+    spec: any,
+    inScope: any,
+    performNonEmptyFieldsCheck?: any
+  ): any;
+  /** @deprecated */
+  fieldDataGeneratorsByType: any;
+  fieldDataGeneratorsByFieldNameByType: any;
+  fieldArgDataGeneratorsByFieldNameByType: any;
+
+  inflection: Inflection;
+
+  swallowError: any;
+  /** @deprecated EXPERIMENTAL, API might change! */
+
+  resolveNode: any;
+  status: {
+    currentHookName: any;
+    currentHookEvent: any;
+  };
+  liveCoordinator: any;
+  scopeByType: Map<any, any>;
+  [str: string]: any;
+}
+
+export interface Inflection {
+  pluralize(...args: any[]): string;
+  singularize(...args: any[]): string;
+  upperCamelCase(...args: any[]): string;
+  camelCase(...args: any[]): string;
+  constantCase(...args: any[]): string;
+  // Built-in names (allows you to override these in the output schema)
+  builtin(...args: any[]): string;
+  // When converting a query field to a subscription (live query) field, this allows you to rename it
+  live(...args: any[]): string;
+  // Try and make something a valid GraphQL 'Name'
+  coerceToGraphQLName(name: string): string;
+  [key: string]: (...args: any[]) => string;
+}

--- a/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
+++ b/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
@@ -51,7 +51,7 @@ export default function makeChangeNullabilityPlugin(
           : nullableType === field.type
           ? new GraphQLNonNull(field.type)
           : field.type, // Optimisation if it's already non-null
-      };
+      } as any;
     }
     builder.hook("GraphQLInputObjectType:fields:field", changeNullability);
     builder.hook("GraphQLObjectType:fields:field", changeNullability);

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -32,6 +32,17 @@ import {
   StringValueNode,
   TypeNode,
   ValueNode,
+
+  // graphql object types
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLDirective,
 } from "graphql";
 import { GraphileEmbed } from "./gql";
 import { InputObjectTypeExtensionNode } from "graphql/language/ast";
@@ -81,8 +92,20 @@ export interface ExtensionDefinition {
   resolvers?: Resolvers;
 }
 
+type GraphQLConstructorType =
+  | typeof GraphQLScalarType
+  | typeof GraphQLObjectType
+  | typeof GraphQLInterfaceType
+  | typeof GraphQLUnionType
+  | typeof GraphQLEnumType
+  | typeof GraphQLInputObjectType
+  | typeof GraphQLList
+  | typeof GraphQLNonNull
+  | typeof GraphQLDirective
+  | Resolvers;
+
 interface NewTypeDef {
-  type: GraphQLType;
+  type: GraphQLConstructorType;
   definition: any;
 }
 
@@ -174,7 +197,7 @@ export default function makeExtendSchemaPlugin(
                 )}'`
               );
             }
-            addType(gqlScalarType);
+            addType(gqlScalarType as any /* ??? */);
           } else {
             // Create a string type
             newTypes.push({


### PR DESCRIPTION
So, I already have some collection of ad-hoc typings for Builder, and I thought of doing something useful with them.

This would expose different interfaces like `BuildPropertiesIntroducedIn_GraphQLObjectType` that can be extended from plugin's type definitions. 
These extended types will be available in (in this case) the `GraphQLObjectType` phase as Partial (because these typing can't track if they've already been set within the phase, and fully in all following phases.

I also added such type augmentations for `PgIntrospectionPlugin` and `pgBasicsPlugin`, as these are the one that have most impact on my code.

As a first result, this uncovered some errors in the typings of `makeExtendSchemaPlugin` as the graphql types there were referenced as instance types, not their respective constructors/classes.


This has a LOT of `any` in it right now, but that already is better than the current state of affairs, as it at least describes the existence of keys. Where I could easily add types, I did so.

But at the moment, I'd rather wait for your input, if something like this is a direction you'd like to be going instead of charging further ahead ;)