### PR TITLE
feat(utils): `@pgQuery.source` can be function

### DIFF
--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -872,6 +872,9 @@ function getFields<TSource>(
                 (parsedResolveInfoFragment: any) => {
                   return {
                     pgQuery: (queryBuilder: QueryBuilder) => {
+                      const source = typeof directives.pgQuery.source === 'function'
+                        ? directives.pgQuery.source({ parentQueryBuilder: queryBuilder })
+                        : directives.pgQuery.source;
                       queryBuilder.select(() => {
                         const resolveData = fieldContext.getDataFromParsedResolveInfoFragment(
                           parsedResolveInfoFragment,
@@ -879,7 +882,7 @@ function getFields<TSource>(
                         );
                         const tableAlias = sql.identifier(Symbol());
                         const query = build.pgQueryFromResolveData(
-                          directives.pgQuery.source,
+                          source,
                           tableAlias,
                           resolveData,
                           {

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -872,9 +872,13 @@ function getFields<TSource>(
                 (parsedResolveInfoFragment: any) => {
                   return {
                     pgQuery: (queryBuilder: QueryBuilder) => {
-                      const source = typeof directives.pgQuery.source === 'function'
-                        ? directives.pgQuery.source({ parentQueryBuilder: queryBuilder })
-                        : directives.pgQuery.source;
+                      const source =
+                        typeof directives.pgQuery.source === "function"
+                          ? directives.pgQuery.source(
+                              queryBuilder,
+                              parsedResolveInfoFragment.args
+                            )
+                          : directives.pgQuery.source;
                       queryBuilder.select(() => {
                         const resolveData = fieldContext.getDataFromParsedResolveInfoFragment(
                           parsedResolveInfoFragment,


### PR DESCRIPTION
E.g. if we need to enable a subquery that references the parent query builder's alias.

```graphql
foo: ItemConnection @pgQuery(
  source: ${embed(
    ({ parentQueryBuilder }) => sql.fragment`(
  select items.*
  from mindtree_public.items
  inner join lateral unnest(${parentQueryBuilder.getTableAlias()}."starredTopicIds") with ordinality as star(id, idx) on (star.id = items.id)
  where items.type = 'TOPIC'
  order by idx asc
)`
  )}
  withQueryBuilder: ${...}
)
```

NOTE: we should also allow blocking the default value for the `orderBy` argument which is added automatically (I think?) - e.g. in this case it's important the default order is `NATURAL` since the result set is already ordered (but the order value does not leak).