### PR TITLE
fix(pagination): fix bug in cursor pagination for PL/pgSQL SETOF functions

### DIFF
--- a/packages/graphile-build-pg/src/QueryBuilder.js
+++ b/packages/graphile-build-pg/src/QueryBuilder.js
@@ -770,9 +770,14 @@ with ${sql.identifier(flipAlias)} as (
 )
 select *
 from ${sql.identifier(flipAlias)}
-order by (row_number() over (partition by 1)) desc`;
+order by (row_number() over (partition by 1)) desc`; /* We don't need to factor useAsterisk into this row_number() usage */
     }
     if (useAsterisk) {
+      /*
+       * NOTE[useAsterisk/row_number]: since LIMIT/OFFSET is inside this
+       * subquery, row_number() outside of this subquery WON'T include the
+       * offset. We must add it back wherever row_number() is used.
+       */
       fragment = sql.fragment`select ${fields} from (${fragment}) ${this.getTableAlias()}`;
     }
     if (asJsonAggregate) {

--- a/packages/postgraphile-core/__tests__/fixtures/queries/procedure-query.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/procedure-query.graphql
@@ -38,6 +38,8 @@ query {
   tableSetQueryWithOffset10: tableSetQuery(before: "WyJuYXR1cmFsIiwxXQ==", last: 2) { edges { cursor node { name } } pageInfo { startCursor endCursor hasNextPage hasPreviousPage } }
   # Using after and offset together should not throw
   tableSetQueryWithOffset11: tableSetQuery(after: "WyJuYXR1cmFsIiwxXQ==", offset: 1, first: 2) { edges { cursor node { name } } pageInfo { startCursor endCursor hasNextPage hasPreviousPage } }
+  tableSetQueryPlpgsql(first:2) { edges { cursor node { name } } pageInfo { startCursor endCursor hasNextPage hasPreviousPage } }
+  tableSetQueryPlpgsqlOffset2: tableSetQueryPlpgsql(first:2, after: "WyJuYXR1cmFsIiwyXQ==") { edges { cursor node { name } } pageInfo { startCursor endCursor hasNextPage hasPreviousPage } }
   intSetQuery(x: 5, z: 6) { edges { cursor node } totalCount }
   noArgsQuery
   staticBigInteger { edges { node } totalCount }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -5299,6 +5299,50 @@ Object {
         "startCursor": "WyJuYXR1cmFsIiwxXQ==",
       },
     },
+    "tableSetQueryPlpgsql": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwxXQ==",
+          "node": Object {
+            "name": "John Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwyXQ==",
+          "node": Object {
+            "name": "Sara Smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJuYXR1cmFsIiwyXQ==",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "WyJuYXR1cmFsIiwxXQ==",
+      },
+    },
+    "tableSetQueryPlpgsqlOffset2": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwzXQ==",
+          "node": Object {
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiw0XQ==",
+          "node": Object {
+            "name": "Kathryn Ramirez",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJuYXR1cmFsIiw0XQ==",
+        "hasNextPage": true,
+        "hasPreviousPage": true,
+        "startCursor": "WyJuYXR1cmFsIiwzXQ==",
+      },
+    },
     "tableSetQueryWithOffset": Object {
       "edges": Array [
         Object {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -7645,6 +7645,27 @@ type Query implements Node {
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
+
   """Reads a single \`Type\` using its globally unique \`ID\`."""
   type(
     """The globally unique \`ID\` to be used in selecting a single \`Type\`."""
@@ -17702,6 +17723,27 @@ type Query implements Node {
 
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
+  ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
   ): PeopleConnection!
 
   """Reads a single \`Type\` using its globally unique \`ID\`."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
@@ -3769,6 +3769,27 @@ type Query implements Node {
     """
     offset: Int
   ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
@@ -7645,6 +7645,27 @@ type Query implements Node {
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
+
   """Reads a single \`Type\` using its globally unique \`ID\`."""
   type(
     """The globally unique \`ID\` to be used in selecting a single \`Type\`."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
@@ -7835,6 +7835,27 @@ type Query implements Node {
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
+
   """Reads a single \`Type\` using its globally unique \`ID\`."""
   type(
     """The globally unique \`ID\` to be used in selecting a single \`Type\`."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
@@ -7650,6 +7650,27 @@ type Q implements N {
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
+
   """Reads a single \`Type\` using its globally unique \`ID\`."""
   type(
     """The globally unique \`ID\` to be used in selecting a single \`Type\`."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyFunctionsOnly.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyFunctionsOnly.test.js.snap
@@ -2916,6 +2916,27 @@ type Query implements Node {
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
@@ -3821,6 +3821,27 @@ type Query implements Node {
     """
     offset: Int
   ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: Json!, f: FloatRangeInput!): Boolean
 }
 

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
@@ -2673,6 +2673,27 @@ type Query implements Node {
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -8972,6 +8972,27 @@ type Query implements Node {
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
+
   """Reads a single \`Type\` using its globally unique \`ID\`."""
   type(
     """The globally unique \`ID\` to be used in selecting a single \`Type\`."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
@@ -3802,6 +3802,27 @@ type Query implements Node {
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -4091,6 +4091,36 @@ type Query implements Node {
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
   ): [Person!]
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsqlList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [Person!]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 
@@ -7690,6 +7720,15 @@ type Query implements Node {
 
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
+  ): [Person!]
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsqlList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
   ): [Person!]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simplePrint.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simplePrint.test.js.snap
@@ -7532,6 +7532,27 @@ type Query implements Node {
     \\"\\"\\"
     condition: PersonCondition
   ): PeopleConnection!
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Person\`.\\"\\"\\"
+  tableSetQueryPlpgsql(
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+  ): PeopleConnection!
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 
   \\"\\"\\"Reads a single \`DefaultValue\` using its globally unique \`ID\`.\\"\\"\\"

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
@@ -6902,6 +6902,27 @@ type Query {
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
   ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryPlpgsql(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): PeopleConnection!
   typeById(id: Int!): Type
   typeFunction(id: Int): Type
 

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -330,6 +330,7 @@ create function b.compound_type_array_mutation(object c.compound_type) returns c
 create function c.table_query(id int) returns a.post as $$ select * from a.post where id = $1 $$ language sql stable;
 create function c.table_mutation(id int) returns a.post as $$ select * from a.post where id = $1 $$ language sql;
 create function c.table_set_query() returns setof c.person as $$ select * from c.person $$ language sql stable;
+create function c.table_set_query_plpgsql() returns setof c.person as $$ begin return query select * from c.person; end $$ language plpgsql stable;
 comment on function c.table_set_query() is E'@sortable\n@filterable';
 create function c.table_set_mutation() returns setof c.person as $$ select * from c.person order by id asc $$ language sql;
 create function c.int_set_query(x int, y int, z int) returns setof integer as $$ values (1), (2), (3), (4), (x), (y), (z) $$ language sql stable;


### PR DESCRIPTION
Fixes https://github.com/graphile/postgraphile/issues/1171

`useAsterisk` runs certain code in a subquery as an optimisation; so:

```sql
select /* COMPLEX STUFF */
from /* EXPENSIVE THING */
limit 2 offset 2
```

becomes

```sql
select /* COMPLEX STUFF */
from (
  select *
  from /* EXPENSIVE THING */
  limit 2 offset 2
) as __alias__
```

This is great because it means that PostgreSQL can process the rows in the subquery more efficiently, and doesn't have to execute the "COMPLEX STUFF" until it's thrown most of the rows from "EXPENSIVE THING" away. Less computation = faster queries (even though they're a little more complex).

HOWEVER because we've moved the LIMIT/OFFSET to the subquery, any calls to `row_number()` are now different than they were before because they no longer include the OFFSET. In this code, we add it back in. It's kinda hacky, but it's a performance optimisation so we're just going to have to suck it up :wink: 