### PR TITLE
feat(introspection): Add manual schema reload notification

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -1145,7 +1145,7 @@ export default (async function PgIntrospectionPlugin(
         } else if (payload.type === "manual") {
           this._handleChange();
         } else {
-          throw new Error(`Payload type '${payload.type}' not recognised`);
+          throw new Error(`Payload type '${(payload as any).type}' not recognised`);
         }
       } catch (e) {
         debug(`Error occurred parsing notification payload: ${e}`);

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -1058,6 +1058,8 @@ export default (async function PgIntrospectionPlugin(
           if (affectsOurSchemas) {
             this._handleChange();
           }
+        } else if (payload.type === "manual") {
+          this._handleChange();
         } else {
           throw new Error(`Payload type '${payload.type}' not recognised`);
         }


### PR DESCRIPTION
We're in a situation where we don't have super user access to the database (Cloud SQL) but want postgraphile to reload the schema when it changes, so we manually notify postgraphile when we update it using the following function:

```
  perform pg_notify(
    'postgraphile_watch',
    json_build_object(
      'type',
      'ddl',
      'payload',
      (select json_agg(json_build_object('schema', NULL, 'command', 'ignored by postgraphile')))
    )::text
  );
```
it works fine but feels a bit wrong so I thought I'd make this simple PR to add explicit support for it and allow the simpler: 

```
  perform pg_notify(
    'postgraphile_watch',
    json_build_object(
      'type',
      'manual',
    )::text
  );
```

Does this make sense?