### PR TITLE
fix(utils): only apply condition when specified

### DIFF
--- a/packages/graphile-utils/src/makeAddPgTableConditionPlugin.ts
+++ b/packages/graphile-utils/src/makeAddPgTableConditionPlugin.ts
@@ -107,7 +107,7 @@ export default function makeAddPgTableConditionPlugin(
         }: {
           condition: { [key: string]: any } | null;
         }) {
-          if (!condition) {
+          if (!condition || !(conditionFieldName in condition)) {
             return {};
           }
           const { [conditionFieldName]: conditionValue } = condition;


### PR DESCRIPTION
We need to allow `{allFoos(condition:{myCustomCondition: null}){...}}` to trigger the condition callback (and it's up to that how to handle the null); however if the condition was not specified (e.g. `{allFoos(condition:{}){...}}`) then the callback should not be consulted.

This is technically a breaking change, but this plugin is still marked as experimental, so it only counts as a fix in this case.