### PR TITLE
fix(introspection): don't query roles when ignoring RBAC

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -468,6 +468,7 @@ export default (async function PgIntrospectionPlugin(
     pgThrowOnMissingSchema = false,
     pgIncludeExtensionResources = false,
     pgLegacyFunctionsOnly = false,
+    pgIgnoreRBAC = true,
     pgSkipInstallingWatchFixtures = false,
     pgOwnerConnectionString,
   }
@@ -493,6 +494,7 @@ export default (async function PgIntrospectionPlugin(
           );
           const introspectionQuery = makeIntrospectionQuery(serverVersionNum, {
             pgLegacyFunctionsOnly,
+            pgIgnoreRBAC,
           });
           const { rows } = await pgClient.query(introspectionQuery, [
             schemas,


### PR DESCRIPTION
This fix is to make the introspection query not iterate over every role in the database on startup when `--no-ignore-rbac` is not present. (We are the crazy people with 4000+ roles and the 16 minute start times)

We patched our local copy of Postgraphile by just removing the `union all` below, but we wanted to make sure this didn't get broken by future versions and wanted to contribute back.

I'm new to typescript and I think I followed everything correctly.  Everything built and appeared to start up correctly with and without the `--no-ignore-rbac` parameter.
