### PR TITLE
feat(subscriptions): @pgSubscription now supports initial events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,11 @@ install:
   - lerna bootstrap
 
 before_script:
-  - export PATH="/usr/lib/postgresql/$PGVERSION/bin:$PATH"
   - psql -c "ALTER USER travis WITH PASSWORD 'travis';"
   - sudo bash -c "echo -e 'wal_level = logical\nmax_replication_slots = 10\nmax_wal_senders = 10' >> /etc/postgresql/$PGVERSION/main/postgresql.conf"
   - sudo service postgresql restart
   - git clone https://github.com/eulerto/wal2json.git
-  - sudo bash -c "cd wal2json && USE_PGXS=1 make && USE_PGXS=1 make install"
+  - sudo bash -c "cd wal2json && PATH=\"/usr/lib/postgresql/$PGVERSION/bin:\$PATH\" USE_PGXS=1 make && PATH=\"/usr/lib/postgresql/$PGVERSION/bin:\$PATH\" USE_PGXS=1 make install"
   - createdb graphileengine_test
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - lerna bootstrap
 
 before_script:
+  - export PATH="/usr/lib/postgresql/$PGVERSION/bin:$PATH"
   - psql -c "ALTER USER travis WITH PASSWORD 'travis';"
   - sudo bash -c "echo -e 'wal_level = logical\nmax_replication_slots = 10\nmax_wal_senders = 10' >> /etc/postgresql/$PGVERSION/main/postgresql.conf"
   - sudo service postgresql restart

--- a/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
+++ b/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
@@ -102,7 +102,8 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
                 "filter provided to pgSubscription must be a function"
               );
             }
-            asyncIterator = withFilter(() => asyncIterator, filter)(
+            const oldIterator = asyncIterator;
+            asyncIterator = withFilter(() => oldIterator, filter)(
               parent,
               args,
               resolveContext,
@@ -116,8 +117,8 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
                 "initialEvent provided to pgSubscription must be a function"
               );
             }
-
-            return (async function* subscribeWithInitialEvent() {
+            const oldIterator = asyncIterator;
+            asyncIterator = (async function* subscribeWithInitialEvent() {
               const event = await initialEvent(
                 args,
                 resolveContext,
@@ -132,7 +133,7 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
                 yield { ...event, topic };
               }
               for await (const val of {
-                [Symbol.asyncIterator]: () => asyncIterator,
+                [Symbol.asyncIterator]: () => oldIterator,
               }) {
                 yield val;
               }

--- a/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
+++ b/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
@@ -96,21 +96,6 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
             });
           }
 
-          if (filter) {
-            if (typeof filter !== "function") {
-              throw new Error(
-                "filter provided to pgSubscription must be a function"
-              );
-            }
-            const oldIterator = asyncIterator;
-            asyncIterator = withFilter(() => oldIterator, filter)(
-              parent,
-              args,
-              resolveContext,
-              resolveInfo
-            );
-          }
-
           if (initialEvent) {
             if (typeof initialEvent !== "function") {
               throw new Error(
@@ -138,6 +123,21 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
                 yield val;
               }
             })();
+          }
+
+          if (filter) {
+            if (typeof filter !== "function") {
+              throw new Error(
+                "filter provided to pgSubscription must be a function"
+              );
+            }
+            const oldIterator = asyncIterator;
+            asyncIterator = withFilter(() => oldIterator, filter)(
+              parent,
+              args,
+              resolveContext,
+              resolveInfo
+            );
           }
 
           return asyncIterator;

--- a/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
+++ b/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
@@ -125,14 +125,16 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
             })();
           }
 
+          // filter should always be the last adjustment
+          // since we want to feed all current and future
+          // custom emissions to the filter
           if (filter) {
             if (typeof filter !== "function") {
               throw new Error(
                 "filter provided to pgSubscription must be a function"
               );
             }
-            const oldIterator = asyncIterator;
-            asyncIterator = withFilter(() => oldIterator, filter)(
+            return withFilter(() => asyncIterator, filter)(
               parent,
               args,
               resolveContext,

--- a/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
+++ b/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
@@ -1,6 +1,7 @@
 import debugFactory from "debug";
 import { Plugin } from "graphile-build";
 import { PubSub, withFilter } from "graphql-subscriptions";
+import { GraphQLResolveInfo, GraphQLFieldResolver } from "graphql";
 
 const debug = debugFactory("pg-pubsub");
 
@@ -8,21 +9,25 @@ function isPubSub(pubsub: unknown): pubsub is PubSub {
   return !!pubsub;
 }
 
+type PubSubEvent = {
+  [key: string]: any;
+};
+
 function withInitialEvent(
   topic: string,
   initialEvent: (
-    args: { [key: string]: unknown },
-    resolveContext: unknown,
-    resolveInfo: unknown
-  ) => unknown
+    args: { [key: string]: any },
+    resolveContext: any,
+    resolveInfo: GraphQLResolveInfo
+  ) => Promise<PubSubEvent> | PubSubEvent
 ) {
   return async function* subscribeWithInitialEvent(
-    asyncIterator: AsyncIterator<unknown>,
+    asyncIterator: AsyncIterator<PubSubEvent, void>,
     _parent: unknown,
-    args: { [key: string]: unknown },
-    resolveContext: unknown,
-    resolveInfo: unknown
-  ) {
+    args: { [key: string]: any },
+    resolveContext: any,
+    resolveInfo: GraphQLResolveInfo
+  ): AsyncIterator<PubSubEvent, void> {
     const event = await initialEvent(args, resolveContext, resolveInfo);
     if (event != null) {
       if (typeof event !== "object") {
@@ -76,101 +81,101 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
       if (!topicGen) {
         return field;
       }
-      return extend(field, {
-        subscribe: async (
-          parent: unknown,
-          args: { [key: string]: unknown },
-          resolveContext: unknown,
-          resolveInfo: unknown
-        ) => {
-          const topic =
-            typeof topicGen === "function"
-              ? await topicGen(args, resolveContext, resolveInfo)
-              : topicGen;
-          if (!topic) {
-            throw new Error("Cannot subscribe at this time");
-          }
-          if (typeof topic !== "string") {
-            throw new Error("Invalid topic provided to pgSubscription");
-          }
-          const unsubscribeTopic =
-            typeof unsubscribeTopicGen === "function"
-              ? await unsubscribeTopicGen(args, resolveContext, resolveInfo)
-              : unsubscribeTopicGen;
-          let asyncIterator = pubsub.asyncIterator(topic);
-          if (unsubscribeTopic) {
-            // Subscribe to event revoking subscription
-            const unsubscribeTopics: Array<string> = Array.isArray(
-              unsubscribeTopic
-            )
-              ? unsubscribeTopic
-              : [unsubscribeTopic];
-            const unsubscribeIterators = unsubscribeTopics.map(t => {
-              const i = pubsub.asyncIterator(t);
-              i["topic"] = t;
-              return i;
-            });
-            unsubscribeIterators.forEach(unsubscribeIterator => {
-              unsubscribeIterator.next().then(() => {
-                debug(
-                  "Unsubscribe triggered on channel %s",
-                  unsubscribeIterator["topic"]
-                );
-                if (asyncIterator.return) {
-                  asyncIterator.return();
+      const subscribe: GraphQLFieldResolver<any, any> = async (
+        parent,
+        args,
+        resolveContext,
+        resolveInfo
+      ) => {
+        const topic =
+          typeof topicGen === "function"
+            ? await topicGen(args, resolveContext, resolveInfo)
+            : topicGen;
+        if (!topic) {
+          throw new Error("Cannot subscribe at this time");
+        }
+        if (typeof topic !== "string") {
+          throw new Error("Invalid topic provided to pgSubscription");
+        }
+        const unsubscribeTopic =
+          typeof unsubscribeTopicGen === "function"
+            ? await unsubscribeTopicGen(args, resolveContext, resolveInfo)
+            : unsubscribeTopicGen;
+        let asyncIterator = pubsub.asyncIterator<PubSubEvent>(topic);
+        if (unsubscribeTopic) {
+          // Subscribe to event revoking subscription
+          const unsubscribeTopics: Array<string> = Array.isArray(
+            unsubscribeTopic
+          )
+            ? unsubscribeTopic
+            : [unsubscribeTopic];
+          const unsubscribeIterators = unsubscribeTopics.map(t => {
+            const i = pubsub.asyncIterator(t);
+            i["topic"] = t;
+            return i;
+          });
+          unsubscribeIterators.forEach(unsubscribeIterator => {
+            unsubscribeIterator.next().then(() => {
+              debug(
+                "Unsubscribe triggered on channel %s",
+                unsubscribeIterator["topic"]
+              );
+              if (asyncIterator.return) {
+                asyncIterator.return();
+              }
+              unsubscribeIterators.forEach(i => {
+                if (i.return) {
+                  i.return();
                 }
-                unsubscribeIterators.forEach(i => {
-                  if (i.return) {
-                    i.return();
-                  }
-                });
               });
             });
-          }
+          });
+        }
 
-          if (initialEvent) {
-            if (typeof initialEvent !== "function") {
-              throw new Error(
-                "initialEvent provided to pgSubscription must be a function"
-              );
-            }
-            const oldAsyncIterator = asyncIterator;
-            asyncIterator = withInitialEvent(topic, initialEvent)(
-              oldAsyncIterator,
-              parent,
-              args,
-              resolveContext,
-              resolveInfo
+        if (initialEvent) {
+          if (typeof initialEvent !== "function") {
+            throw new Error(
+              "initialEvent provided to pgSubscription must be a function"
             );
           }
+          const oldAsyncIterator = asyncIterator;
+          asyncIterator = withInitialEvent(topic, initialEvent)(
+            oldAsyncIterator,
+            parent,
+            args,
+            resolveContext,
+            resolveInfo
+          );
+        }
 
-          // filter should always be the last adjustment
-          // since we want to feed all current and future
-          // custom emissions to the filter
-          if (filter) {
-            if (typeof filter !== "function") {
-              throw new Error(
-                "filter provided to pgSubscription must be a function"
-              );
-            }
-            const oldAsyncIterator = asyncIterator;
-            asyncIterator = withFilter(() => oldAsyncIterator, filter)(
-              parent,
-              args,
-              resolveContext,
-              resolveInfo
+        // filter should always be the last adjustment
+        // since we want to feed all current and future
+        // custom emissions to the filter
+        if (filter) {
+          if (typeof filter !== "function") {
+            throw new Error(
+              "filter provided to pgSubscription must be a function"
             );
           }
+          const oldAsyncIterator = asyncIterator;
+          asyncIterator = withFilter(() => oldAsyncIterator, filter)(
+            parent,
+            args,
+            resolveContext,
+            resolveInfo
+          );
+        }
 
-          return asyncIterator;
-        },
-        ...(field.resolve
-          ? null
-          : {
-              resolve<T>(event: T): T {
-                return event;
-              },
-            }),
+        return asyncIterator;
+      };
+      const resolve: GraphQLFieldResolver<PubSubEvent, any> = (
+        event
+      ): PubSubEvent => {
+        return event;
+      };
+      return extend(field, {
+        subscribe,
+        ...(field.resolve ? null : { resolve }),
       });
     },
     ["PgSubscriptionResolver"]

--- a/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
+++ b/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
@@ -123,12 +123,14 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
                 resolveContext,
                 resolveInfo
               );
-              if (event === null || typeof event !== "object") {
-                throw new Error(
-                  "initialEvent returning event must be an object"
-                );
+              if (event != null) {
+                if (typeof event !== "object") {
+                  throw new Error(
+                    "initialEvent returning event must be an object"
+                  );
+                }
+                yield { ...event, topic };
               }
-              yield { ...event, topic };
               for await (const val of {
                 [Symbol.asyncIterator]: () => asyncIterator,
               }) {

--- a/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
+++ b/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
@@ -123,7 +123,7 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
                 resolveContext,
                 resolveInfo
               );
-              if (event !== null && typeof event !== "object") {
+              if (event === null || typeof event !== "object") {
                 throw new Error(
                   "initialEvent returning event must be an object"
                 );

--- a/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
+++ b/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
@@ -97,7 +97,7 @@ const PgSubscriptionResolverPlugin: Plugin = function(builder, { pubsub }) {
             typeof unsubscribeTopicGen === "function"
               ? await unsubscribeTopicGen(args, resolveContext, resolveInfo)
               : unsubscribeTopicGen;
-          let asyncIterator = await pubsub.asyncIterator(topic);
+          let asyncIterator = pubsub.asyncIterator(topic);
           if (unsubscribeTopic) {
             // Subscribe to event revoking subscription
             const unsubscribeTopics: Array<string> = Array.isArray(

--- a/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
+++ b/packages/pg-pubsub/src/PgSubscriptionResolverPlugin.ts
@@ -38,9 +38,25 @@ function withInitialEvent(
       yield { ...event, topic };
     }
 
-    // @ts-ignore code is actually fine, but async iterators are currently an ES.next feature
+    /* TODO: when we can upgrade to Node 10.3+ we can replace the below with simply:
     for await (const val of asyncIterator) {
       yield val;
+    }
+    */
+    try {
+      while (true) {
+        const next = await asyncIterator.next();
+        if (next.done) {
+          return next.value;
+        } else {
+          yield next.value;
+        }
+      }
+    } finally {
+      // Terminate the previous iterator
+      if (typeof asyncIterator.return === "function") {
+        asyncIterator.return();
+      }
     }
   };
 }


### PR DESCRIPTION
## Description

Extends the `@pgSubscription` directive with an `initialEvent` argument allowing you to guarantee data freshness by emitting an event which triggers the related resolver as soon as the user subscribes.

## Example
```js
// FileSubscriptionPlugin.js

import { makeExtendSchemaPlugin, gql, embed } from 'graphile-utils';

function buildTopic(args) {
  return `fileChanged:${args.id}`;
}

function buildInitialEvent(args) {
  // the `topic` value will be injected in the returning event
  return { subject: args.id };
}

export const FileSubscriptionPlugin = makeExtendSchemaPlugin(({ pgSql: sql }) => ({
  typeDefs: gql`
    type FileChangedPayload {
      event: String!
      file: File!
    }

    extend type Subscription {
      fileChanged(id: UUID!): FileChangedPayload!
        @pgSubscription(
          topic: ${embed(buildTopic)}
          initialEvent: ${embed(buildInitialEvent)}
        )
    }
  `,
  resolvers: {
    FileChangedPayload: {
      // will be triggered as soon as the user subscribes because of the initialEvent argument
      async file(event, _args, _context, { graphile: { selectGraphQLResultFromTable } }) {
        /**
         * given that the fileChanged id argument is: '456f', the initial event will look like this:
         * ```
         * { topic: 'fileChanged:456f', subject: '456f' }
         * ```
         */

        const rows = await selectGraphQLResultFromTable(
          sql.fragment`public.file`,
          (tableAlias, sqlBuilder) => {
            sqlBuilder.where(sql.fragment`${tableAlias}.id = ${sql.value(event.subject)}`);
          },
        );
        return rows[0];
      },
    },
  },
}));
```