### PR TITLE
fix(types): relax index signature in JSONPgSmartTags

### DIFF
--- a/packages/graphile-utils/src/makePgSmartTagsPlugin.ts
+++ b/packages/graphile-utils/src/makePgSmartTagsPlugin.ts
@@ -220,7 +220,7 @@ export function makePgSmartTagsPlugin(
 export type JSONPgSmartTags = {
   version: 1;
   config: {
-    [kind in PgSmartTagSupportedKinds]: {
+    [kind in PgSmartTagSupportedKinds]?: {
       [identifier: string]: {
         tags?: PgSmartTagTags;
         description?: string;


### PR DESCRIPTION
Just a tiny PR so that instead of this:

```
export const TagsPlugin = makeJSONPgSmartTagsPlugin({
    version: 1,
    config: {
        class: {
            foo: {
                tags: {
                    omit: 'all',
                },
            },
        },
        attribute: {},
        procedure: {},
        constraint: {},
    },
});
```

I can write this:

```
export const TagsPlugin = makeJSONPgSmartTagsPlugin({
    version: 1,
    config: {
        class: {
            foo: {
                tags: {
                    omit: 'all',
                },
            },
        },
    },
});
```