### PR TITLE
feat: add support for "enum tables"

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -93,6 +93,9 @@ export interface PgType {
   domainBaseTypeId: string | void;
   domainBaseType: PgType | void;
   domainTypeModifier: number | void;
+  domainHasDefault: boolean;
+  enumVariants: string[] | void;
+  rangeSubTypeId: string | void;
   tags: { [tag: string]: true | string | Array<string> };
 }
 

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -95,6 +95,7 @@ export interface PgType {
   domainTypeModifier: number | void;
   domainHasDefault: boolean;
   enumVariants: string[] | void;
+  enumDescriptions: string[] | void;
   rangeSubTypeId: string | void;
   tags: { [tag: string]: true | string | Array<string> };
 }

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -564,9 +564,8 @@ export default (async function PgIntrospectionPlugin(
                   c => c.classId === klass.id && c.type === "p"
                 );
                 if (!pk) {
-                  throw new Error(
-                    `Enum table "${klass.namespaceName}"."${klass.name}" has no primary key`
-                  );
+                  // Must be from another schema
+                  return;
                 }
 
                 // Assert primary key is exactly one column

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -693,10 +693,15 @@ export default (async function PgIntrospectionPlugin(
                 });
 
                 // Prevent the table being recognised as a table
+                // eslint-disable-next-line require-atomic-updates
                 klass.tags.omit = true;
+                // eslint-disable-next-line require-atomic-updates
                 klass.isSelectable = false;
+                // eslint-disable-next-line require-atomic-updates
                 klass.isInsertable = false;
+                // eslint-disable-next-line require-atomic-updates
                 klass.isUpdatable = false;
+                // eslint-disable-next-line require-atomic-updates
                 klass.isDeletable = false;
               }
             })

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -68,6 +68,9 @@ export default (function PgTablesPlugin(
       const Cursor = getTypeByName("Cursor");
 
       introspectionResultsByKind.class.forEach(table => {
+        if (table.tags.enum) {
+          return;
+        }
         const tablePgType = table.type;
         if (!tablePgType) {
           throw new Error("Could not determine the type for this table");

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -570,8 +570,11 @@ export default (function PgTypesPlugin(
             {
               name: inflection.enumType(type),
               description: type.description,
-              values: type.enumVariants.reduce((memo, value) => {
+              values: type.enumVariants.reduce((memo, value, i) => {
                 memo[inflection.enumName(value)] = {
+                  description: type.enumDescriptions
+                    ? type.enumDescriptions[i]
+                    : null,
                   value: value,
                 };
                 return memo;

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/enum_tables.mutations.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/enum_tables.mutations.graphql
@@ -1,0 +1,22 @@
+mutation {
+  deleteLetterDescriptionByLetter(input: { letter: C }) {
+    letterDescription {
+      id
+      letter
+    }
+  }
+  createLetterDescription(
+    input: {
+      letterDescription: {
+        letter: C
+        description: "One does like to see the letter C"
+      }
+    }
+  ) {
+    letterDescription {
+      id
+      letter
+      description
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/fixtures/queries/enum_tables.queries.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/enum_tables.queries.graphql
@@ -1,0 +1,28 @@
+{
+  all: allLetterDescriptions {
+    nodes {
+      id
+      letter
+      description
+    }
+  }
+  reverse: allLetterDescriptions(orderBy: [LETTER_DESC]) {
+    nodes {
+      id
+      letter
+      description
+    }
+  }
+  b: letterDescriptionByLetter(letter: B) {
+    id
+    letter
+    description
+  }
+  letterC: allLetterDescriptions(condition: { letter: C }) {
+    nodes {
+      id
+      letter
+      description
+    }
+  }
+}

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -60,6 +60,26 @@ Object {
 }
 `;
 
+exports[`enum_tables.mutations.graphql 1`] = `
+Object {
+  "data": Object {
+    "createLetterDescription": Object {
+      "letterDescription": Object {
+        "description": "One does like to see the letter C",
+        "id": 105,
+        "letter": "C",
+      },
+    },
+    "deleteLetterDescriptionByLetter": Object {
+      "letterDescription": Object {
+        "id": 103,
+        "letter": "C",
+      },
+    },
+  },
+}
+`;
+
 exports[`inheritence.createUserFile.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1579,36 +1579,36 @@ Object {
       "nodes": Array [
         Object {
           "description": "The first letter in the alphabet",
-          "id": 1,
+          "id": 101,
           "letter": "A",
         },
         Object {
           "description": "Following closely behind the first letter, this is a popular choice",
-          "id": 2,
+          "id": 102,
           "letter": "B",
         },
         Object {
           "description": "Pronounced like 'sea'",
-          "id": 3,
+          "id": 103,
           "letter": "C",
         },
         Object {
           "description": "The first letter omitted from the 'ABC' phrase",
-          "id": 4,
+          "id": 104,
           "letter": "D",
         },
       ],
     },
     "b": Object {
       "description": "Following closely behind the first letter, this is a popular choice",
-      "id": 2,
+      "id": 102,
       "letter": "B",
     },
     "letterC": Object {
       "nodes": Array [
         Object {
           "description": "Pronounced like 'sea'",
-          "id": 3,
+          "id": 103,
           "letter": "C",
         },
       ],
@@ -1617,22 +1617,22 @@ Object {
       "nodes": Array [
         Object {
           "description": "The first letter omitted from the 'ABC' phrase",
-          "id": 4,
+          "id": 104,
           "letter": "D",
         },
         Object {
           "description": "Pronounced like 'sea'",
-          "id": 3,
+          "id": 103,
           "letter": "C",
         },
         Object {
           "description": "Following closely behind the first letter, this is a popular choice",
-          "id": 2,
+          "id": 102,
           "letter": "B",
         },
         Object {
           "description": "The first letter in the alphabet",
-          "id": 1,
+          "id": 101,
           "letter": "A",
         },
       ],

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1572,6 +1572,75 @@ Object {
 }
 `;
 
+exports[`enum_tables.queries.graphql 1`] = `
+Object {
+  "data": Object {
+    "all": Object {
+      "nodes": Array [
+        Object {
+          "description": "The first letter in the alphabet",
+          "id": 1,
+          "letter": "A",
+        },
+        Object {
+          "description": "Following closely behind the first letter, this is a popular choice",
+          "id": 2,
+          "letter": "B",
+        },
+        Object {
+          "description": "Pronounced like 'sea'",
+          "id": 3,
+          "letter": "C",
+        },
+        Object {
+          "description": "The first letter omitted from the 'ABC' phrase",
+          "id": 4,
+          "letter": "D",
+        },
+      ],
+    },
+    "b": Object {
+      "description": "Following closely behind the first letter, this is a popular choice",
+      "id": 2,
+      "letter": "B",
+    },
+    "letterC": Object {
+      "nodes": Array [
+        Object {
+          "description": "Pronounced like 'sea'",
+          "id": 3,
+          "letter": "C",
+        },
+      ],
+    },
+    "reverse": Object {
+      "nodes": Array [
+        Object {
+          "description": "The first letter omitted from the 'ABC' phrase",
+          "id": 4,
+          "letter": "D",
+        },
+        Object {
+          "description": "Pronounced like 'sea'",
+          "id": 3,
+          "letter": "C",
+        },
+        Object {
+          "description": "Following closely behind the first letter, this is a popular choice",
+          "id": 2,
+          "letter": "B",
+        },
+        Object {
+          "description": "The first letter in the alphabet",
+          "id": 1,
+          "letter": "A",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`function-return-types.graphql 1`] = `
 Object {
   "data": Object {

--- a/packages/postgraphile-core/__tests__/integration/mutations.test.js
+++ b/packages/postgraphile-core/__tests__/integration/mutations.test.js
@@ -41,6 +41,7 @@ beforeAll(() => {
       pg10Schema,
       useCustomNetworkScalarsSchema,
       pg10UseCustomNetworkScalarsSchema,
+      enumTables,
     ] = await Promise.all([
       createPostGraphileSchema(pgClient, ["a", "b", "c"]),
       createPostGraphileSchema(pgClient, ["d"]),
@@ -60,6 +61,7 @@ beforeAll(() => {
             },
           })
         : null,
+      createPostGraphileSchema(pgClient, ["enum_tables"]),
     ]);
     // Now for RBAC-enabled tests
     await pgClient.query("set role postgraphile_test_authenticator");
@@ -74,6 +76,7 @@ beforeAll(() => {
       useCustomNetworkScalarsSchema,
       pg10UseCustomNetworkScalarsSchema,
       rbacSchema,
+      enumTables,
     };
   });
 
@@ -93,6 +96,7 @@ beforeAll(() => {
       useCustomNetworkScalarsSchema,
       pg10UseCustomNetworkScalarsSchema,
       rbacSchema,
+      enumTables,
     } = await gqlSchemaPromise;
     // Get a new Postgres client and run the mutation.
     return await withPgClient(async pgClient => {
@@ -115,6 +119,8 @@ beforeAll(() => {
         schemaToUse = dSchema;
       } else if (fileName.startsWith("inheritence.")) {
         schemaToUse = inheritenceSchema;
+      } else if (fileName.startsWith("enum_tables.")) {
+        schemaToUse = enumTables;
       } else if (fileName.startsWith("pg10.")) {
         if (serverVersionNum < 100000) {
           // eslint-disable-next-line

--- a/packages/postgraphile-core/__tests__/integration/queries.test.js
+++ b/packages/postgraphile-core/__tests__/integration/queries.test.js
@@ -59,6 +59,7 @@ beforeAll(() => {
       useCustomNetworkScalars,
       pg10UseCustomNetworkScalars,
       namedQueryBuilder,
+      enumTables,
     ] = await Promise.all([
       createPostGraphileSchema(pgClient, ["a", "b", "c"], {
         subscriptions: true,
@@ -125,6 +126,9 @@ beforeAll(() => {
         subscriptions: true,
         appendPlugins: [ToyCategoriesPlugin],
       }),
+      createPostGraphileSchema(pgClient, ["enum_tables"], {
+        subscriptions: true,
+      }),
     ]);
     // Now for RBAC-enabled tests
     await pgClient.query("set role postgraphile_test_authenticator");
@@ -149,6 +153,7 @@ beforeAll(() => {
       useCustomNetworkScalars,
       pg10UseCustomNetworkScalars,
       namedQueryBuilder,
+      enumTables,
     };
   });
 
@@ -221,6 +226,8 @@ beforeAll(() => {
               gqlSchema = gqlSchemas.largeBigint;
             } else if (fileName.startsWith("named_query_builder")) {
               gqlSchema = gqlSchemas.namedQueryBuilder;
+            } else if (fileName.startsWith("enum_tables.")) {
+              gqlSchema = gqlSchemas.enumTables;
             } else {
               gqlSchema = gqlSchemas.normal;
             }

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
@@ -2,9 +2,16 @@
 
 exports[`prints a schema for enum_tables 1`] = `
 enum Abcd {
+  """The letter A"""
   A
+
+  """The letter B"""
   B
+
+  """The letter C"""
   C
+
+  """The letter D"""
   D
 }
 

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
@@ -1,0 +1,407 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints a schema for enum_tables 1`] = `
+enum Abcd {
+  A
+  B
+  C
+  D
+}
+
+"""All input for the create \`LetterDescription\` mutation."""
+input CreateLetterDescriptionInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`LetterDescription\` to be created by this mutation."""
+  letterDescription: LetterDescriptionInput!
+}
+
+"""The output of our create \`LetterDescription\` mutation."""
+type CreateLetterDescriptionPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`LetterDescription\` that was created by this mutation."""
+  letterDescription: LetterDescription
+
+  """An edge for our \`LetterDescription\`. May be used by Relay 1."""
+  letterDescriptionEdge(
+    """The method to use when ordering \`LetterDescription\`."""
+    orderBy: [LetterDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LetterDescriptionsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the \`deleteLetterDescriptionById\` mutation."""
+input DeleteLetterDescriptionByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteLetterDescriptionByLetter\` mutation."""
+input DeleteLetterDescriptionByLetterInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  letter: Abcd!
+}
+
+"""All input for the \`deleteLetterDescription\` mutation."""
+input DeleteLetterDescriptionInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`LetterDescription\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`LetterDescription\` mutation."""
+type DeleteLetterDescriptionPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedLetterDescriptionId: ID
+
+  """The \`LetterDescription\` that was deleted by this mutation."""
+  letterDescription: LetterDescription
+
+  """An edge for our \`LetterDescription\`. May be used by Relay 1."""
+  letterDescriptionEdge(
+    """The method to use when ordering \`LetterDescription\`."""
+    orderBy: [LetterDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LetterDescriptionsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+type LetterDescription implements Node {
+  description: String
+  id: Int!
+  letter: Abcd!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""
+A condition to be used against \`LetterDescription\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input LetterDescriptionCondition {
+  """Checks for equality with the object’s \`description\` field."""
+  description: String
+
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`letter\` field."""
+  letter: Abcd
+}
+
+"""An input for mutations affecting \`LetterDescription\`"""
+input LetterDescriptionInput {
+  description: String
+  id: Int
+  letter: Abcd!
+}
+
+"""
+Represents an update to a \`LetterDescription\`. Fields that are set will be updated.
+"""
+input LetterDescriptionPatch {
+  description: String
+  id: Int
+  letter: Abcd
+}
+
+"""A connection to a list of \`LetterDescription\` values."""
+type LetterDescriptionsConnection {
+  """
+  A list of edges which contains the \`LetterDescription\` and cursor to aid in pagination.
+  """
+  edges: [LetterDescriptionsEdge!]!
+
+  """A list of \`LetterDescription\` objects."""
+  nodes: [LetterDescription]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* \`LetterDescription\` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""A \`LetterDescription\` edge in the connection."""
+type LetterDescriptionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`LetterDescription\` at the end of the edge."""
+  node: LetterDescription
+}
+
+"""Methods to use when ordering \`LetterDescription\`."""
+enum LetterDescriptionsOrderBy {
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  ID_ASC
+  ID_DESC
+  LETTER_ASC
+  LETTER_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single \`LetterDescription\`."""
+  createLetterDescription(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateLetterDescriptionInput!
+  ): CreateLetterDescriptionPayload
+
+  """Deletes a single \`LetterDescription\` using its globally unique id."""
+  deleteLetterDescription(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLetterDescriptionInput!
+  ): DeleteLetterDescriptionPayload
+
+  """Deletes a single \`LetterDescription\` using a unique key."""
+  deleteLetterDescriptionById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLetterDescriptionByIdInput!
+  ): DeleteLetterDescriptionPayload
+
+  """Deletes a single \`LetterDescription\` using a unique key."""
+  deleteLetterDescriptionByLetter(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLetterDescriptionByLetterInput!
+  ): DeleteLetterDescriptionPayload
+
+  """
+  Updates a single \`LetterDescription\` using its globally unique id and a patch.
+  """
+  updateLetterDescription(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLetterDescriptionInput!
+  ): UpdateLetterDescriptionPayload
+
+  """Updates a single \`LetterDescription\` using a unique key and a patch."""
+  updateLetterDescriptionById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLetterDescriptionByIdInput!
+  ): UpdateLetterDescriptionPayload
+
+  """Updates a single \`LetterDescription\` using a unique key and a patch."""
+  updateLetterDescriptionByLetter(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLetterDescriptionByLetterInput!
+  ): UpdateLetterDescriptionPayload
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """Reads and enables pagination through a set of \`LetterDescription\`."""
+  allLetterDescriptions(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: LetterDescriptionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`LetterDescription\`."""
+    orderBy: [LetterDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LetterDescriptionsConnection
+
+  """Reads a single \`LetterDescription\` using its globally unique \`ID\`."""
+  letterDescription(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`LetterDescription\`.
+    """
+    nodeId: ID!
+  ): LetterDescription
+  letterDescriptionById(id: Int!): LetterDescription
+  letterDescriptionByLetter(letter: Abcd!): LetterDescription
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+}
+
+"""All input for the \`updateLetterDescriptionById\` mutation."""
+input UpdateLetterDescriptionByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`LetterDescription\` being updated.
+  """
+  letterDescriptionPatch: LetterDescriptionPatch!
+}
+
+"""All input for the \`updateLetterDescriptionByLetter\` mutation."""
+input UpdateLetterDescriptionByLetterInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  letter: Abcd!
+
+  """
+  An object where the defined keys will be set on the \`LetterDescription\` being updated.
+  """
+  letterDescriptionPatch: LetterDescriptionPatch!
+}
+
+"""All input for the \`updateLetterDescription\` mutation."""
+input UpdateLetterDescriptionInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the \`LetterDescription\` being updated.
+  """
+  letterDescriptionPatch: LetterDescriptionPatch!
+
+  """
+  The globally unique \`ID\` which will identify a single \`LetterDescription\` to be updated.
+  """
+  nodeId: ID!
+}
+
+"""The output of our update \`LetterDescription\` mutation."""
+type UpdateLetterDescriptionPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`LetterDescription\` that was updated by this mutation."""
+  letterDescription: LetterDescription
+
+  """An edge for our \`LetterDescription\`. May be used by Relay 1."""
+  letterDescriptionEdge(
+    """The method to use when ordering \`LetterDescription\`."""
+    orderBy: [LetterDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LetterDescriptionsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+`;

--- a/packages/postgraphile-core/__tests__/integration/schema/enum_tables.test.js
+++ b/packages/postgraphile-core/__tests__/integration/schema/enum_tables.test.js
@@ -1,0 +1,3 @@
+const core = require("./core");
+
+test("prints a schema for enum_tables", core.test(["enum_tables"], {}));

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -252,6 +252,7 @@ insert into named_query_builder.toy_categories(toy_id, category_id, approved) va
   (1, 3, false);
 
 --------------------------------------------------------------------------------
+alter sequence enum_tables.letter_descriptions_id_seq restart with 101;
 insert into enum_tables.letter_descriptions(letter, description) values
   ('A', 'The first letter in the alphabet'),
   ('B', 'Following closely behind the first letter, this is a popular choice'),

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -250,3 +250,10 @@ insert into named_query_builder.toy_categories(toy_id, category_id, approved) va
   (4, 1, true),
   (4, 2, true),
   (1, 3, false);
+
+--------------------------------------------------------------------------------
+insert into enum_tables.letter_descriptions(letter, description) values
+  ('A', 'The first letter in the alphabet'),
+  ('B', 'Following closely behind the first letter, this is a popular choice'),
+  ('C', 'Pronounced like ''sea'''),
+  ('D', 'The first letter omitted from the ''ABC'' phrase');

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -1111,11 +1111,15 @@ create table named_query_builder.toy_categories (
 --------------------------------------------------------------------------------
 
 create schema enum_tables;
-create table enum_tables.abcd (letter text primary key);
+create table enum_tables.abcd (letter text primary key, description text);
+comment on column enum_tables.abcd.description is E'@enumDescription';
 -- Enum table needs values added as part of the migration, not as part of the
 -- data.
-insert into enum_tables.abcd (letter)
-  values ('A'), ('B'), ('C'), ('D');
+insert into enum_tables.abcd (letter, description) values
+  ('A', 'The letter A'),
+  ('B', 'The letter B'),
+  ('C', 'The letter C'),
+  ('D', 'The letter D');
 comment on table enum_tables.abcd is E'@enum';
 
 create table enum_tables.letter_descriptions(

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -1,5 +1,20 @@
 -- WARNING: this database is shared with graphile-utils, don't run the tests in parallel!
-drop schema if exists a, b, c, d, inheritence, smart_comment_relations, ranges, index_expressions, simple_collections, live_test, large_bigint, network_types, named_query_builder cascade;
+drop schema if exists
+  a,
+  b,
+  c,
+  d,
+  inheritence,
+  smart_comment_relations,
+  ranges,
+  index_expressions,
+  simple_collections,
+  live_test,
+  large_bigint,
+  network_types,
+  named_query_builder,
+  enum_tables
+cascade;
 drop extension if exists tablefunc;
 drop extension if exists intarray;
 drop extension if exists hstore;
@@ -1091,4 +1106,20 @@ create table named_query_builder.toy_categories (
   toy_id int not null references named_query_builder.toys,
   category_id int not null references named_query_builder.categories,
   approved boolean not null
+);
+
+--------------------------------------------------------------------------------
+
+create schema enum_tables;
+create table enum_tables.abcd (letter text primary key);
+-- Enum table needs values added as part of the migration, not as part of the
+-- data.
+insert into enum_tables.abcd (letter)
+  values ('A'), ('B'), ('C'), ('D');
+comment on table enum_tables.abcd is E'@enum';
+
+create table enum_tables.letter_descriptions(
+  id serial primary key,
+  letter text not null references enum_tables.abcd unique,
+  description text
 );


### PR DESCRIPTION
PostgreSQL enums cannot be added to inside of transactions, and cannot have values removed. This makes them very cumbersome to use. For years I've been recommending to use "enum tables" instead, where you write your enum values to a table and reference them via foreign key, but I never got around to adding support for this pattern to PostGraphile... until now!

An enum table must have a text (or varchar or char) primary key, and may have other columns. It must have the `@enum` smart comment, and this **must** be done via a smart comment (and not a smart tag file or plugin) due to the way in which PostGraphile v4's introspection engine works. 

Example:

```sql
create table abcd (
  letter text primary key,
  description text
);
comment on table abcd is E'@enum';
insert into abcd (letter, description) values
  ('A', 'The letter A'),
  ('B', 'The letter B'),
  ('C', 'The letter C'),
  ('D', 'The letter D');
```

If one of the columns is named 'description' or has the smart comment (NOT smart tag) `@enumDescription` then its contents will be used as the description of the enum value in GraphiQL.

The enum table will not show up in your GraphQL schema, it's automatically omitted. (Don't bypass this with a smart tags plugin, bad things will occur.) To use a value from another table, use a foreign key constraint:

```sql
create table letter_descriptions(
  id serial primary key,
  letter text not null references abcd,
  description text
);
```

PostGraphile will represent this field as if it were an enum rather than text. This works for queries, mutations, conditions and ordering.

NOTE: we currently don't have an official way to mark function input/output parameters as enum-table enums, so they will remain as text.

NOTE: `--watch` won't monitor for new enum values being added.