### PR TITLE
fix: load makeAddPgTableConditionPlugins before PgConnectionArgOrderBy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@ examples
 dist
 CHANGELOG.md
 package.json
+lerna.json

--- a/packages/graphile-utils/src/makeAddPgTableConditionPlugin.ts
+++ b/packages/graphile-utils/src/makeAddPgTableConditionPlugin.ts
@@ -130,7 +130,13 @@ export default function makeAddPgTableConditionPlugin(
         });
 
         return args;
-      }
+      },
+      [],
+      // Make sure we're loaded before PgConnectionArgOrderBy, otherwise
+      // ordering added by conditions will be overridden by the default
+      // ordering.
+      ["PgConnectionArgOrderBy"],
+      []
     );
   };
   plugin.displayName = displayName;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7847,11 +7847,11 @@ posix-character-classes@^0.1.0:
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 postgraphile@^4.4.0, postgraphile@^4.4.4:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/postgraphile/-/postgraphile-4.8.0.tgz#222992e8aed62023c88f790a9d33ae6c7fd33243"
-  integrity sha512-NSETJhg5smqiu8mbr6AqATVypPb5WMVq95i7smlaE+XIzOT+bbJz4bAuB+Gvp399tOwFOwUyfOZxQvq5jxJg+A==
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/postgraphile/-/postgraphile-4.9.0.tgz#71bca224833f702803169802ce9b79e36b739be1"
+  integrity sha512-ltsYwzcNmR/VZX2gKgVt7hCT1h+JB81Hcn7xLKvvFyjh6CKAia4fYKUh84dq67nQTzj6tZrJVtbGYQ0NIApLBw==
   dependencies:
-    "@graphile/lru" "4.8.0-rc.0"
+    "@graphile/lru" "4.9.0"
     "@types/json5" "^0.0.30"
     "@types/jsonwebtoken" "^8.3.2"
     "@types/koa" "^2.0.44"
@@ -7862,7 +7862,7 @@ postgraphile@^4.4.0, postgraphile@^4.4.4:
     commander "^2.19.0"
     debug "^4.1.1"
     finalhandler "^1.0.6"
-    graphile-utils "^4.8.0"
+    graphile-utils "^4.9.0"
     graphql "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.2"
     http-errors "^1.5.1"
     iterall "^1.0.2"
@@ -7871,10 +7871,10 @@ postgraphile@^4.4.0, postgraphile@^4.4.4:
     parseurl "^1.3.2"
     pg ">=6.1.0 <9"
     pg-connection-string "^2.0.0"
-    pg-sql2 "4.8.0"
-    postgraphile-core "4.8.0"
+    pg-sql2 "4.9.0"
+    postgraphile-core "4.9.0"
     subscriptions-transport-ws "^0.9.15"
-    tslib "^1.5.0"
+    tslib "^2.0.1"
     ws "^6.1.3"
 
 postgres-array@~2.0.0:
@@ -9377,7 +9377,7 @@ ts-node@9.0.0, ts-node@^9.0.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tslib@^1.10.0, tslib@^1.5.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==


### PR DESCRIPTION
This allows plugins like the following to influence the order of the result without having to manually specify plugin order via `--prepend-plugins`

```js
const { makeAddPgTableConditionPlugin } = require("graphile-utils");

module.exports = makeAddPgTableConditionPlugin(
  "app_public",
  "quiz",
  "entryCountMin",
  build => ({
    type: build.graphql.GraphQLInt,
  }),
  (value, { queryBuilder, sql, sqlTableAlias }) => {
    if (value == null) {
      return;
    }

    // Order the result set by the number of entries the quiz has
    queryBuilder.orderBy(
      sql.fragment`(select count(*) from app_public.quiz_entry where quiz_entry.quiz_id = ${sqlTableAlias}.id)`,
      false,
      false
    );

    // Filter to only quizzes that have at least `value` entries.
    return sql.fragment`(select count(*) from app_public.quiz_entry where quiz_entry.quiz_id = ${sqlTableAlias}.id) >= ${sql.value(
      value
    )}`;
  }
);
```