### PR TITLE
fix(proc): fix output of record/table returning functions

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgRecordReturnTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgRecordReturnTypesPlugin.js
@@ -18,6 +18,7 @@ export default (function PgRecordReturnTypesPlugin(builder) {
         pgGetSelectValueForFieldAndTypeAndModifier: getSelectValueForFieldAndTypeAndModifier,
         getSafeAliasFromResolveInfo,
         getSafeAliasFromAlias,
+        pg2gqlForType,
       } = build;
 
       introspectionResultsByKind.procedure.forEach(proc => {
@@ -129,13 +130,14 @@ export default (function PgRecordReturnTypesPlugin(builder) {
                         },
                       };
                     });
+                    const convertFromPg = pg2gqlForType(outputArgTypes[idx]);
                     return {
                       type: fieldType,
                       resolve(data, _args, _context, resolveInfo) {
                         const safeAlias = getSafeAliasFromResolveInfo(
                           resolveInfo
                         );
-                        return data[safeAlias];
+                        return convertFromPg(data[safeAlias]);
                       },
                     };
                   },

--- a/packages/postgraphile-core/__tests__/fixtures/queries/function-return-types.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/function-return-types.graphql
@@ -157,6 +157,13 @@
   ) {
     ...OutputTwoRowsFragment
   }
+  searchTestSummariesList {
+    id
+    totalDuration {
+      hours
+      minutes
+    }
+  }
 }
 
 fragment OutputTwoRowsFragment on QueryOutputTwoRowsRecord {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1933,6 +1933,22 @@ Object {
       "post": null,
       "txt": "Don't fail me now...999999999999999999",
     },
+    "searchTestSummariesList": Array [
+      Object {
+        "id": 1,
+        "totalDuration": Object {
+          "hours": 2,
+          "minutes": 1,
+        },
+      },
+      Object {
+        "id": 2,
+        "totalDuration": Object {
+          "hours": 3,
+          "minutes": 1,
+        },
+      },
+    ],
   },
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -7577,6 +7577,13 @@ type Query implements Node {
   ): ReservedPatchRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
 
   """Reads a single \`SimilarTable1\` using its globally unique \`ID\`."""
   similarTable1(
@@ -7962,6 +7969,12 @@ type ReturnVoidMutationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 type SimilarTable1 implements Node {
@@ -17657,6 +17670,13 @@ type Query implements Node {
   ): ReservedPatchRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
 
   """Reads a single \`SimilarTable1\` using its globally unique \`ID\`."""
   similarTable1(
@@ -18042,6 +18062,12 @@ type ReturnVoidMutationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 type SimilarTable1 implements Node {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
@@ -3744,6 +3744,27 @@ type Query implements Node {
   query: Query!
   queryOutputTwoRows(leftArmId: Int, postId: Int, txt: String): QueryOutputTwoRowsRecord
   returnTableWithoutGrants: CompoundKey
+
+  """@simpleCollections only"""
+  searchTestSummaries(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): SearchTestSummariesConnection
   tableQuery(id: Int): Post
 
   """
@@ -3798,6 +3819,37 @@ type QueryOutputTwoRowsRecord {
   leftArm: LeftArm
   post: Post
   txt: String
+}
+
+"""A connection to a list of \`SearchTestSummariesRecord\` values."""
+type SearchTestSummariesConnection {
+  """
+  A list of edges which contains the \`SearchTestSummariesRecord\` and cursor to aid in pagination.
+  """
+  edges: [SearchTestSummaryEdge!]!
+
+  """A list of \`SearchTestSummariesRecord\` objects."""
+  nodes: [SearchTestSummariesRecord!]!
+
+  """
+  The count of *all* \`SearchTestSummariesRecord\` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
+}
+
+"""A \`SearchTestSummariesRecord\` edge in the connection."""
+type SearchTestSummaryEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`SearchTestSummariesRecord\` at the end of the edge."""
+  node: SearchTestSummariesRecord!
 }
 
 """All input for the \`tableMutation\` mutation."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
@@ -7577,6 +7577,13 @@ type Query implements Node {
   ): ReservedPatchRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
 
   """Reads a single \`SimilarTable1\` using its globally unique \`ID\`."""
   similarTable1(
@@ -7962,6 +7969,12 @@ type ReturnVoidMutationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 type SimilarTable1 implements Node {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
@@ -7767,6 +7767,13 @@ type Query implements Node {
   ): ReservedPatchRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
 
   """Reads a single \`SimilarTable1\` using its globally unique \`ID\`."""
   similarTable1(
@@ -8152,6 +8159,12 @@ type ReturnVoidMutationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 type SimilarTable1 implements Node {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
@@ -7582,6 +7582,13 @@ type Q implements N {
   ): ReservedPatchRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
 
   """Reads a single \`SimilarTable1\` using its globally unique \`ID\`."""
   similarTable1(
@@ -7967,6 +7974,12 @@ type ReturnVoidMutationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Q
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: I
 }
 
 type SimilarTable1 implements N {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
@@ -3796,6 +3796,27 @@ type Query implements Node {
   query: Query!
   queryOutputTwoRows(leftArmId: Int, postId: Int, txt: String): QueryOutputTwoRowsRecord
   returnTableWithoutGrants: CompoundKey
+
+  """@simpleCollections only"""
+  searchTestSummaries(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+  ): SearchTestSummariesConnection
   tableQuery(id: Int): Post
 
   """
@@ -3850,6 +3871,37 @@ type QueryOutputTwoRowsRecord {
   leftArm: LeftArm
   post: Post
   txt: String
+}
+
+"""A connection to a list of \`SearchTestSummariesRecord\` values."""
+type SearchTestSummariesConnection {
+  """
+  A list of edges which contains the \`SearchTestSummariesRecord\` and cursor to aid in pagination.
+  """
+  edges: [SearchTestSummaryEdge!]!
+
+  """A list of \`SearchTestSummariesRecord\` objects."""
+  nodes: [SearchTestSummariesRecord!]!
+
+  """
+  The count of *all* \`SearchTestSummariesRecord\` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
+}
+
+"""A \`SearchTestSummariesRecord\` edge in the connection."""
+type SearchTestSummaryEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`SearchTestSummariesRecord\` at the end of the edge."""
+  node: SearchTestSummariesRecord!
 }
 
 """All input for the \`tableMutation\` mutation."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
@@ -2643,6 +2643,13 @@ type Query implements Node {
   query: Query!
   queryOutputTwoRows(leftArmId: Int, postId: Int, txt: String): QueryOutputTwoRowsRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
   tableQuery(id: Int): Post
 
   """Reads and enables pagination through a set of \`Person\`."""
@@ -2702,6 +2709,12 @@ type QueryOutputTwoRowsRecord {
   leftArm: LeftArm
   post: Post
   txt: String
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 """All input for the \`tableMutation\` mutation."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -8904,6 +8904,13 @@ type Query implements Node {
   ): ReservedPatchRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
 
   """Reads a single \`SimilarTable1\` using its globally unique \`ID\`."""
   similarTable1(
@@ -9289,6 +9296,12 @@ type ReturnVoidMutationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 type SimilarTable1 implements Node {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
@@ -3772,6 +3772,13 @@ type Query implements Node {
   query: Query!
   queryOutputTwoRows(leftArmId: Int, postId: Int, txt: String): QueryOutputTwoRowsRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
   tableQuery(id: Int): Post
 
   """Reads and enables pagination through a set of \`Person\`."""
@@ -3831,6 +3838,12 @@ type QueryOutputTwoRowsRecord {
   leftArm: LeftArm
   post: Post
   txt: String
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 """All input for the \`tableMutation\` mutation."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -4044,6 +4044,13 @@ type Query implements Node {
   query: Query!
   queryOutputTwoRows(leftArmId: Int, postId: Int, txt: String): QueryOutputTwoRowsRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
   tableQuery(id: Int): Post
 
   """Reads and enables pagination through a set of \`Person\`."""
@@ -4129,6 +4136,12 @@ type QueryOutputTwoRowsRecord {
   leftArm: LeftArm
   post: Post
   txt: String
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 """All input for the \`tableMutation\` mutation."""
@@ -7703,6 +7716,13 @@ type Query implements Node {
   query: Query!
   queryOutputTwoRows(leftArmId: Int, postId: Int, txt: String): QueryOutputTwoRowsRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
   tableQuery(id: Int): Post
 
   """Reads and enables pagination through a set of \`Person\`."""
@@ -7738,6 +7758,12 @@ type QueryOutputTwoRowsRecord {
   leftArm: LeftArm
   post: Post
   txt: String
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 """All input for the \`tableMutation\` mutation."""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simplePrint.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simplePrint.test.js.snap
@@ -7502,6 +7502,13 @@ type Query implements Node {
   noArgsQuery: Int
   queryOutputTwoRows(leftArmId: Int, postId: Int, txt: String): QueryOutputTwoRowsRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
   tableQuery(id: Int): Post
 
   """Reads and enables pagination through a set of \`Person\`."""
@@ -7933,6 +7940,12 @@ type ReturnVoidMutationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 type SimilarTable1 implements Node {

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
@@ -6851,6 +6851,13 @@ type Query {
   reservedInputRecordById(id: Int!): ReservedInputRecord
   reservedPatchRecordById(id: Int!): ReservedPatchRecord
   returnTableWithoutGrants: CompoundKey
+  searchTestSummariesList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+  ): [SearchTestSummariesRecord]
   similarTable1ById(id: Int!): SimilarTable1
   similarTable2ById(id: Int!): SimilarTable2
   staticBigInteger(
@@ -7193,6 +7200,12 @@ type ReturnVoidMutationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
+}
+
+"""The return type of our \`searchTestSummaries\` query."""
+type SearchTestSummariesRecord {
+  id: Int
+  totalDuration: Interval
 }
 
 type SimilarTable1 {

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -775,7 +775,7 @@ CREATE FUNCTION c.search_test_summaries() RETURNS TABLE (
 	) SELECT * FROM foo;
     $$
 LANGUAGE SQL STABLE;
-COMMENT ON FUNCTION c.search_test_summaries IS E'@simpleCollections only';
+COMMENT ON FUNCTION c.search_test_summaries() IS E'@simpleCollections only';
 
 -- Begin tests for smart comments
 

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -763,6 +763,20 @@ begin
 end;
 $$ language plpgsql stable;
 
+-- Issue #666 from graphile-engine
+CREATE FUNCTION c.search_test_summaries() RETURNS TABLE (
+	id integer,
+	total_duration interval
+) AS $$
+	WITH foo(id, total_duration) AS (
+	VALUES
+		(1, '02:01:00'::interval),
+		(2, '03:01:00'::interval)
+	) SELECT * FROM foo;
+    $$
+LANGUAGE SQL STABLE;
+COMMENT ON FUNCTION c.search_test_summaries IS E'@simpleCollections only';
+
 -- Begin tests for smart comments
 
 -- Rename table and columns


### PR DESCRIPTION
Previously the result from PostgreSQL was not passed through `pg2gql` and thus it would only work for simple types, and more complex types (such as interval) were not handled correctly. This solves this issue (3 LOC), and thus fixes #666 