### PR TITLE
feat(smart-tags): add support for '@unique' fake constraints

### DIFF
--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/smart_comment_relations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/smart_comment_relations.test.js.snap
@@ -9078,3 +9078,4452 @@ type UpdateStreetPropertyPayload {
 }
 
 `;
+
+exports[`view with fake unique constraint 1`] = `
+type Building implements Node {
+  floors: Int!
+
+  """Reads and enables pagination through a set of \`House\`."""
+  housesByBuildingId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: HouseCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`House\`."""
+    orderBy: [HousesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): HousesConnection!
+  id: Int!
+  isPrimary: Boolean!
+  name: String!
+
+  """Reads a single \`Street\` that is related to this \`Building\`."""
+  namedAfterStreet: Street
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Property\` that is related to this \`Building\`."""
+  propertyByPropertyId: Property
+  propertyId: Int!
+}
+
+"""
+A condition to be used against \`Building\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BuildingCondition {
+  """Checks for equality with the object’s \`floors\` field."""
+  floors: Int
+
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`isPrimary\` field."""
+  isPrimary: Boolean
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`propertyId\` field."""
+  propertyId: Int
+}
+
+"""An input for mutations affecting \`Building\`"""
+input BuildingInput {
+  floors: Int
+  id: Int
+  isPrimary: Boolean
+  name: String!
+  propertyId: Int!
+}
+
+"""
+Represents an update to a \`Building\`. Fields that are set will be updated.
+"""
+input BuildingPatch {
+  floors: Int
+  id: Int
+  isPrimary: Boolean
+  name: String
+  propertyId: Int
+}
+
+"""A connection to a list of \`Building\` values."""
+type BuildingsConnection {
+  """
+  A list of edges which contains the \`Building\` and cursor to aid in pagination.
+  """
+  edges: [BuildingsEdge!]!
+
+  """A list of \`Building\` objects."""
+  nodes: [Building]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Building\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Building\` edge in the connection."""
+type BuildingsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Building\` at the end of the edge."""
+  node: Building
+}
+
+"""Methods to use when ordering \`Building\`."""
+enum BuildingsOrderBy {
+  FLOORS_ASC
+  FLOORS_DESC
+  ID_ASC
+  ID_DESC
+  IS_PRIMARY_ASC
+  IS_PRIMARY_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  PROPERTY_ID_ASC
+  PROPERTY_ID_DESC
+}
+
+"""All input for the create \`Building\` mutation."""
+input CreateBuildingInput {
+  """The \`Building\` to be created by this mutation."""
+  building: BuildingInput!
+
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+}
+
+"""The output of our create \`Building\` mutation."""
+type CreateBuildingPayload {
+  """The \`Building\` that was created by this mutation."""
+  building: Building
+
+  """An edge for our \`Building\`. May be used by Relay 1."""
+  buildingEdge(
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsEdge
+
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single \`Street\` that is related to this \`Building\`."""
+  namedAfterStreet: Street
+
+  """Reads a single \`Property\` that is related to this \`Building\`."""
+  propertyByPropertyId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create \`Offer\` mutation."""
+input CreateOfferInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Offer\` to be created by this mutation."""
+  offer: OfferInput!
+}
+
+"""The output of our create \`Offer\` mutation."""
+type CreateOfferPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Offer\` that was created by this mutation."""
+  offer: Offer
+
+  """An edge for our \`Offer\`. May be used by Relay 1."""
+  offerEdge(
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersEdge
+
+  """Reads a single \`Post\` that is related to this \`Offer\`."""
+  postByPostId: Post
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create \`Post\` mutation."""
+input CreatePostInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Post\` to be created by this mutation."""
+  post: PostInput!
+}
+
+"""The output of our create \`Post\` mutation."""
+type CreatePostPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Post\` that was created by this mutation."""
+  post: Post
+
+  """An edge for our \`Post\`. May be used by Relay 1."""
+  postEdge(
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [NATURAL]
+  ): PostsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create \`Property\` mutation."""
+input CreatePropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Property\` to be created by this mutation."""
+  property: PropertyInput!
+}
+
+"""The output of our create \`Property\` mutation."""
+type CreatePropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Property\` that was created by this mutation."""
+  property: Property
+
+  """An edge for our \`Property\`. May be used by Relay 1."""
+  propertyEdge(
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`Property\`."""
+  streetByStreetId: Street
+}
+
+"""All input for the create \`Street\` mutation."""
+input CreateStreetInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Street\` to be created by this mutation."""
+  street: StreetInput!
+}
+
+"""The output of our create \`Street\` mutation."""
+type CreateStreetPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The \`Street\` that was created by this mutation."""
+  street: Street
+
+  """An edge for our \`Street\`. May be used by Relay 1."""
+  streetEdge(
+    """The method to use when ordering \`Street\`."""
+    orderBy: [StreetsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetsEdge
+}
+
+"""All input for the create \`StreetProperty\` mutation."""
+input CreateStreetPropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`StreetProperty\` to be created by this mutation."""
+  streetProperty: StreetPropertyInput!
+}
+
+"""The output of our create \`StreetProperty\` mutation."""
+type CreateStreetPropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single \`Property\` that is related to this \`StreetProperty\`."""
+  propertyByPropId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`StreetProperty\`."""
+  streetByStrId: Street
+
+  """The \`StreetProperty\` that was created by this mutation."""
+  streetProperty: StreetProperty
+
+  """An edge for our \`StreetProperty\`. May be used by Relay 1."""
+  streetPropertyEdge(
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesEdge
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the \`deleteBuildingById\` mutation."""
+input DeleteBuildingByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteBuilding\` mutation."""
+input DeleteBuildingInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Building\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Building\` mutation."""
+type DeleteBuildingPayload {
+  """The \`Building\` that was deleted by this mutation."""
+  building: Building
+
+  """An edge for our \`Building\`. May be used by Relay 1."""
+  buildingEdge(
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsEdge
+
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedBuildingId: ID
+
+  """Reads a single \`Street\` that is related to this \`Building\`."""
+  namedAfterStreet: Street
+
+  """Reads a single \`Property\` that is related to this \`Building\`."""
+  propertyByPropertyId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`deleteOfferById\` mutation."""
+input DeleteOfferByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteOffer\` mutation."""
+input DeleteOfferInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Offer\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Offer\` mutation."""
+type DeleteOfferPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedOfferViewId: ID
+
+  """The \`Offer\` that was deleted by this mutation."""
+  offer: Offer
+
+  """An edge for our \`Offer\`. May be used by Relay 1."""
+  offerEdge(
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersEdge
+
+  """Reads a single \`Post\` that is related to this \`Offer\`."""
+  postByPostId: Post
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`deletePostById\` mutation."""
+input DeletePostByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: String!
+}
+
+"""The output of our delete \`Post\` mutation."""
+type DeletePostPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedPostViewId: ID
+
+  """The \`Post\` that was deleted by this mutation."""
+  post: Post
+
+  """An edge for our \`Post\`. May be used by Relay 1."""
+  postEdge(
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [NATURAL]
+  ): PostsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`deletePropertyById\` mutation."""
+input DeletePropertyByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteProperty\` mutation."""
+input DeletePropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Property\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Property\` mutation."""
+type DeletePropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedPropertyId: ID
+
+  """The \`Property\` that was deleted by this mutation."""
+  property: Property
+
+  """An edge for our \`Property\`. May be used by Relay 1."""
+  propertyEdge(
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`Property\`."""
+  streetByStreetId: Street
+}
+
+"""All input for the \`deleteStreetById\` mutation."""
+input DeleteStreetByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteStreet\` mutation."""
+input DeleteStreetInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Street\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Street\` mutation."""
+type DeleteStreetPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedStreetId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The \`Street\` that was deleted by this mutation."""
+  street: Street
+
+  """An edge for our \`Street\`. May be used by Relay 1."""
+  streetEdge(
+    """The method to use when ordering \`Street\`."""
+    orderBy: [StreetsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetsEdge
+}
+
+"""All input for the \`deleteStreetPropertyByStrIdAndPropId\` mutation."""
+input DeleteStreetPropertyByStrIdAndPropIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  propId: Int!
+  strId: Int!
+}
+
+"""All input for the \`deleteStreetProperty\` mutation."""
+input DeleteStreetPropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`StreetProperty\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`StreetProperty\` mutation."""
+type DeleteStreetPropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedStreetPropertyId: ID
+
+  """Reads a single \`Property\` that is related to this \`StreetProperty\`."""
+  propertyByPropId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`StreetProperty\`."""
+  streetByStrId: Street
+
+  """The \`StreetProperty\` that was deleted by this mutation."""
+  streetProperty: StreetProperty
+
+  """An edge for our \`StreetProperty\`. May be used by Relay 1."""
+  streetPropertyEdge(
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesEdge
+}
+
+type House implements Node {
+  """Reads a single \`Building\` that is related to this \`House\`."""
+  buildingByBuildingId: Building
+  buildingId: Int
+  buildingName: String
+  floors: Int
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Property\` that is related to this \`House\`."""
+  propertyByPropertyId: Property
+  propertyId: Int!
+  propertyNameOrNumber: String!
+
+  """Reads a single \`Street\` that is related to this \`House\`."""
+  streetByStreetId: Street
+  streetId: Int!
+  streetName: String!
+
+  """Reads a single \`StreetProperty\` that is related to this \`House\`."""
+  streetPropertyByStreetIdAndPropertyId: StreetProperty
+}
+
+"""
+A condition to be used against \`House\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input HouseCondition {
+  """Checks for equality with the object’s \`buildingId\` field."""
+  buildingId: Int
+
+  """Checks for equality with the object’s \`buildingName\` field."""
+  buildingName: String
+
+  """Checks for equality with the object’s \`floors\` field."""
+  floors: Int
+
+  """Checks for equality with the object’s \`propertyId\` field."""
+  propertyId: Int
+
+  """Checks for equality with the object’s \`propertyNameOrNumber\` field."""
+  propertyNameOrNumber: String
+
+  """Checks for equality with the object’s \`streetId\` field."""
+  streetId: Int
+
+  """Checks for equality with the object’s \`streetName\` field."""
+  streetName: String
+}
+
+"""A connection to a list of \`House\` values."""
+type HousesConnection {
+  """
+  A list of edges which contains the \`House\` and cursor to aid in pagination.
+  """
+  edges: [HousesEdge!]!
+
+  """A list of \`House\` objects."""
+  nodes: [House]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`House\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`House\` edge in the connection."""
+type HousesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`House\` at the end of the edge."""
+  node: House
+}
+
+"""Methods to use when ordering \`House\`."""
+enum HousesOrderBy {
+  BUILDING_ID_ASC
+  BUILDING_ID_DESC
+  BUILDING_NAME_ASC
+  BUILDING_NAME_DESC
+  FLOORS_ASC
+  FLOORS_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  PROPERTY_ID_ASC
+  PROPERTY_ID_DESC
+  PROPERTY_NAME_OR_NUMBER_ASC
+  PROPERTY_NAME_OR_NUMBER_DESC
+  STREET_ID_ASC
+  STREET_ID_DESC
+  STREET_NAME_ASC
+  STREET_NAME_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single \`Building\`."""
+  createBuilding(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateBuildingInput!
+  ): CreateBuildingPayload
+
+  """Creates a single \`Offer\`."""
+  createOffer(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateOfferInput!
+  ): CreateOfferPayload
+
+  """Creates a single \`Post\`."""
+  createPost(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreatePostInput!
+  ): CreatePostPayload
+
+  """Creates a single \`Property\`."""
+  createProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreatePropertyInput!
+  ): CreatePropertyPayload
+
+  """Creates a single \`Street\`."""
+  createStreet(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateStreetInput!
+  ): CreateStreetPayload
+
+  """Creates a single \`StreetProperty\`."""
+  createStreetProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateStreetPropertyInput!
+  ): CreateStreetPropertyPayload
+
+  """Deletes a single \`Building\` using its globally unique id."""
+  deleteBuilding(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteBuildingInput!
+  ): DeleteBuildingPayload
+
+  """Deletes a single \`Building\` using a unique key."""
+  deleteBuildingById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteBuildingByIdInput!
+  ): DeleteBuildingPayload
+
+  """Deletes a single \`Offer\` using its globally unique id."""
+  deleteOffer(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOfferInput!
+  ): DeleteOfferPayload
+
+  """Deletes a single \`Offer\` using a unique key."""
+  deleteOfferById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOfferByIdInput!
+  ): DeleteOfferPayload
+
+  """Deletes a single \`Post\` using a unique key."""
+  deletePostById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePostByIdInput!
+  ): DeletePostPayload
+
+  """Deletes a single \`Property\` using its globally unique id."""
+  deleteProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePropertyInput!
+  ): DeletePropertyPayload
+
+  """Deletes a single \`Property\` using a unique key."""
+  deletePropertyById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePropertyByIdInput!
+  ): DeletePropertyPayload
+
+  """Deletes a single \`Street\` using its globally unique id."""
+  deleteStreet(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStreetInput!
+  ): DeleteStreetPayload
+
+  """Deletes a single \`Street\` using a unique key."""
+  deleteStreetById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStreetByIdInput!
+  ): DeleteStreetPayload
+
+  """Deletes a single \`StreetProperty\` using its globally unique id."""
+  deleteStreetProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStreetPropertyInput!
+  ): DeleteStreetPropertyPayload
+
+  """Deletes a single \`StreetProperty\` using a unique key."""
+  deleteStreetPropertyByStrIdAndPropId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStreetPropertyByStrIdAndPropIdInput!
+  ): DeleteStreetPropertyPayload
+
+  """Updates a single \`Building\` using its globally unique id and a patch."""
+  updateBuilding(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateBuildingInput!
+  ): UpdateBuildingPayload
+
+  """Updates a single \`Building\` using a unique key and a patch."""
+  updateBuildingById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateBuildingByIdInput!
+  ): UpdateBuildingPayload
+
+  """Updates a single \`Offer\` using its globally unique id and a patch."""
+  updateOffer(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOfferInput!
+  ): UpdateOfferPayload
+
+  """Updates a single \`Offer\` using a unique key and a patch."""
+  updateOfferById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOfferByIdInput!
+  ): UpdateOfferPayload
+
+  """Updates a single \`Post\` using a unique key and a patch."""
+  updatePostById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePostByIdInput!
+  ): UpdatePostPayload
+
+  """Updates a single \`Property\` using its globally unique id and a patch."""
+  updateProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePropertyInput!
+  ): UpdatePropertyPayload
+
+  """Updates a single \`Property\` using a unique key and a patch."""
+  updatePropertyById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePropertyByIdInput!
+  ): UpdatePropertyPayload
+
+  """Updates a single \`Street\` using its globally unique id and a patch."""
+  updateStreet(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStreetInput!
+  ): UpdateStreetPayload
+
+  """Updates a single \`Street\` using a unique key and a patch."""
+  updateStreetById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStreetByIdInput!
+  ): UpdateStreetPayload
+
+  """
+  Updates a single \`StreetProperty\` using its globally unique id and a patch.
+  """
+  updateStreetProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStreetPropertyInput!
+  ): UpdateStreetPropertyPayload
+
+  """Updates a single \`StreetProperty\` using a unique key and a patch."""
+  updateStreetPropertyByStrIdAndPropId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStreetPropertyByStrIdAndPropIdInput!
+  ): UpdateStreetPropertyPayload
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+type Offer implements Node {
+  id: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Post\` that is related to this \`Offer\`."""
+  postByPostId: Post
+  postId: String
+}
+
+"""
+A condition to be used against \`Offer\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input OfferCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`postId\` field."""
+  postId: String
+}
+
+"""An input for mutations affecting \`Offer\`"""
+input OfferInput {
+  id: Int!
+  postId: String
+}
+
+"""
+Represents an update to a \`Offer\`. Fields that are set will be updated.
+"""
+input OfferPatch {
+  id: Int
+  postId: String
+}
+
+"""A connection to a list of \`Offer\` values."""
+type OffersConnection {
+  """
+  A list of edges which contains the \`Offer\` and cursor to aid in pagination.
+  """
+  edges: [OffersEdge!]!
+
+  """A list of \`Offer\` objects."""
+  nodes: [Offer]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Offer\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Offer\` edge in the connection."""
+type OffersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Offer\` at the end of the edge."""
+  node: Offer
+}
+
+"""Methods to use when ordering \`Offer\`."""
+enum OffersOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  POST_ID_ASC
+  POST_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+type Post {
+  id: String
+
+  """Reads and enables pagination through a set of \`Offer\`."""
+  offersByPostId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OfferCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersConnection!
+}
+
+"""
+A condition to be used against \`Post\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PostCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: String
+}
+
+"""An input for mutations affecting \`Post\`"""
+input PostInput {
+  id: String
+}
+
+"""Represents an update to a \`Post\`. Fields that are set will be updated."""
+input PostPatch {
+  id: String
+}
+
+"""A connection to a list of \`Post\` values."""
+type PostsConnection {
+  """
+  A list of edges which contains the \`Post\` and cursor to aid in pagination.
+  """
+  edges: [PostsEdge!]!
+
+  """A list of \`Post\` objects."""
+  nodes: [Post]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Post\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Post\` edge in the connection."""
+type PostsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Post\` at the end of the edge."""
+  node: Post
+}
+
+"""Methods to use when ordering \`Post\`."""
+enum PostsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+}
+
+"""A connection to a list of \`Property\` values."""
+type PropertiesConnection {
+  """
+  A list of edges which contains the \`Property\` and cursor to aid in pagination.
+  """
+  edges: [PropertiesEdge!]!
+
+  """A list of \`Property\` objects."""
+  nodes: [Property]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Property\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Property\` edge in the connection."""
+type PropertiesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Property\` at the end of the edge."""
+  node: Property
+}
+
+"""Methods to use when ordering \`Property\`."""
+enum PropertiesOrderBy {
+  ID_ASC
+  ID_DESC
+  NAME_OR_NUMBER_ASC
+  NAME_OR_NUMBER_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  STREET_ID_ASC
+  STREET_ID_DESC
+}
+
+type Property implements Node {
+  """Reads and enables pagination through a set of \`Building\`."""
+  buildingsByPropertyId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BuildingCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsConnection!
+
+  """Reads and enables pagination through a set of \`House\`."""
+  housesByPropertyId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: HouseCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`House\`."""
+    orderBy: [HousesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): HousesConnection!
+  id: Int!
+  nameOrNumber: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Street\` that is related to this \`Property\`."""
+  streetByStreetId: Street
+  streetId: Int!
+
+  """Reads and enables pagination through a set of \`StreetProperty\`."""
+  streetPropertiesByPropId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StreetPropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesConnection!
+}
+
+"""
+A condition to be used against \`Property\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input PropertyCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`nameOrNumber\` field."""
+  nameOrNumber: String
+
+  """Checks for equality with the object’s \`streetId\` field."""
+  streetId: Int
+}
+
+"""An input for mutations affecting \`Property\`"""
+input PropertyInput {
+  id: Int
+  nameOrNumber: String!
+  streetId: Int!
+}
+
+"""
+Represents an update to a \`Property\`. Fields that are set will be updated.
+"""
+input PropertyPatch {
+  id: Int
+  nameOrNumber: String
+  streetId: Int
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """Reads and enables pagination through a set of \`Building\`."""
+  allBuildings(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BuildingCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsConnection
+
+  """Reads and enables pagination through a set of \`House\`."""
+  allHouses(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: HouseCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`House\`."""
+    orderBy: [HousesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): HousesConnection
+
+  """Reads and enables pagination through a set of \`Offer\`."""
+  allOffers(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OfferCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersConnection
+
+  """Reads and enables pagination through a set of \`Post\`."""
+  allPosts(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PostCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [NATURAL]
+  ): PostsConnection
+
+  """Reads and enables pagination through a set of \`Property\`."""
+  allProperties(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesConnection
+
+  """Reads and enables pagination through a set of \`StreetProperty\`."""
+  allStreetProperties(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StreetPropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesConnection
+
+  """Reads and enables pagination through a set of \`Street\`."""
+  allStreets(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StreetCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Street\`."""
+    orderBy: [StreetsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetsConnection
+
+  """Reads a single \`Building\` using its globally unique \`ID\`."""
+  building(
+    """The globally unique \`ID\` to be used in selecting a single \`Building\`."""
+    nodeId: ID!
+  ): Building
+  buildingById(id: Int!): Building
+
+  """Reads a single \`House\` using its globally unique \`ID\`."""
+  house(
+    """The globally unique \`ID\` to be used in selecting a single \`House\`."""
+    nodeId: ID!
+  ): House
+  houseByStreetIdAndPropertyId(propertyId: Int!, streetId: Int!): House
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Offer\` using its globally unique \`ID\`."""
+  offer(
+    """The globally unique \`ID\` to be used in selecting a single \`Offer\`."""
+    nodeId: ID!
+  ): Offer
+  offerById(id: Int!): Offer
+  postById(id: String!): Post
+
+  """Reads a single \`Property\` using its globally unique \`ID\`."""
+  property(
+    """The globally unique \`ID\` to be used in selecting a single \`Property\`."""
+    nodeId: ID!
+  ): Property
+  propertyById(id: Int!): Property
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """Reads a single \`Street\` using its globally unique \`ID\`."""
+  street(
+    """The globally unique \`ID\` to be used in selecting a single \`Street\`."""
+    nodeId: ID!
+  ): Street
+  streetById(id: Int!): Street
+
+  """Reads a single \`StreetProperty\` using its globally unique \`ID\`."""
+  streetProperty(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`StreetProperty\`.
+    """
+    nodeId: ID!
+  ): StreetProperty
+  streetPropertyByStrIdAndPropId(propId: Int!, strId: Int!): StreetProperty
+}
+
+type Street implements Node {
+  """Reads and enables pagination through a set of \`Building\`."""
+  buildingsNamedAfterStreet(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BuildingCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsConnection!
+
+  """Reads and enables pagination through a set of \`House\`."""
+  housesByStreetId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: HouseCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`House\`."""
+    orderBy: [HousesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): HousesConnection!
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Property\`."""
+  propertiesByStreetId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesConnection!
+
+  """Reads and enables pagination through a set of \`StreetProperty\`."""
+  streetPropertiesByStrId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StreetPropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesConnection!
+}
+
+"""
+A condition to be used against \`Street\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input StreetCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+}
+
+"""An input for mutations affecting \`Street\`"""
+input StreetInput {
+  id: Int
+  name: String!
+}
+
+"""
+Represents an update to a \`Street\`. Fields that are set will be updated.
+"""
+input StreetPatch {
+  id: Int
+  name: String
+}
+
+"""A connection to a list of \`StreetProperty\` values."""
+type StreetPropertiesConnection {
+  """
+  A list of edges which contains the \`StreetProperty\` and cursor to aid in pagination.
+  """
+  edges: [StreetPropertiesEdge!]!
+
+  """A list of \`StreetProperty\` objects."""
+  nodes: [StreetProperty]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`StreetProperty\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`StreetProperty\` edge in the connection."""
+type StreetPropertiesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`StreetProperty\` at the end of the edge."""
+  node: StreetProperty
+}
+
+"""Methods to use when ordering \`StreetProperty\`."""
+enum StreetPropertiesOrderBy {
+  CURRENT_OWNER_ASC
+  CURRENT_OWNER_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  PROP_ID_ASC
+  PROP_ID_DESC
+  STR_ID_ASC
+  STR_ID_DESC
+}
+
+type StreetProperty implements Node {
+  currentOwner: String
+
+  """Reads a single \`House\` that is related to this \`StreetProperty\`."""
+  houseByStreetIdAndPropertyId: House
+
+  """Reads and enables pagination through a set of \`House\`."""
+  housesByStreetIdAndPropertyId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: HouseCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`House\`."""
+    orderBy: [HousesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): HousesConnection! @deprecated(reason: "Please use houseByStreetIdAndPropertyId instead")
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Property\` that is related to this \`StreetProperty\`."""
+  propertyByPropId: Property
+  propId: Int!
+
+  """Reads a single \`Street\` that is related to this \`StreetProperty\`."""
+  streetByStrId: Street
+  strId: Int!
+}
+
+"""
+A condition to be used against \`StreetProperty\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input StreetPropertyCondition {
+  """Checks for equality with the object’s \`currentOwner\` field."""
+  currentOwner: String
+
+  """Checks for equality with the object’s \`propId\` field."""
+  propId: Int
+
+  """Checks for equality with the object’s \`strId\` field."""
+  strId: Int
+}
+
+"""An input for mutations affecting \`StreetProperty\`"""
+input StreetPropertyInput {
+  currentOwner: String
+  propId: Int!
+  strId: Int!
+}
+
+"""
+Represents an update to a \`StreetProperty\`. Fields that are set will be updated.
+"""
+input StreetPropertyPatch {
+  currentOwner: String
+  propId: Int
+  strId: Int
+}
+
+"""A connection to a list of \`Street\` values."""
+type StreetsConnection {
+  """
+  A list of edges which contains the \`Street\` and cursor to aid in pagination.
+  """
+  edges: [StreetsEdge!]!
+
+  """A list of \`Street\` objects."""
+  nodes: [Street]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Street\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Street\` edge in the connection."""
+type StreetsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Street\` at the end of the edge."""
+  node: Street
+}
+
+"""Methods to use when ordering \`Street\`."""
+enum StreetsOrderBy {
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""All input for the \`updateBuildingById\` mutation."""
+input UpdateBuildingByIdInput {
+  """
+  An object where the defined keys will be set on the \`Building\` being updated.
+  """
+  buildingPatch: BuildingPatch!
+
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`updateBuilding\` mutation."""
+input UpdateBuildingInput {
+  """
+  An object where the defined keys will be set on the \`Building\` being updated.
+  """
+  buildingPatch: BuildingPatch!
+
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Building\` to be updated.
+  """
+  nodeId: ID!
+}
+
+"""The output of our update \`Building\` mutation."""
+type UpdateBuildingPayload {
+  """The \`Building\` that was updated by this mutation."""
+  building: Building
+
+  """An edge for our \`Building\`. May be used by Relay 1."""
+  buildingEdge(
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsEdge
+
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single \`Street\` that is related to this \`Building\`."""
+  namedAfterStreet: Street
+
+  """Reads a single \`Property\` that is related to this \`Building\`."""
+  propertyByPropertyId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`updateOfferById\` mutation."""
+input UpdateOfferByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`Offer\` being updated.
+  """
+  offerPatch: OfferPatch!
+}
+
+"""All input for the \`updateOffer\` mutation."""
+input UpdateOfferInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Offer\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Offer\` being updated.
+  """
+  offerPatch: OfferPatch!
+}
+
+"""The output of our update \`Offer\` mutation."""
+type UpdateOfferPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Offer\` that was updated by this mutation."""
+  offer: Offer
+
+  """An edge for our \`Offer\`. May be used by Relay 1."""
+  offerEdge(
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersEdge
+
+  """Reads a single \`Post\` that is related to this \`Offer\`."""
+  postByPostId: Post
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`updatePostById\` mutation."""
+input UpdatePostByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: String!
+
+  """
+  An object where the defined keys will be set on the \`Post\` being updated.
+  """
+  postPatch: PostPatch!
+}
+
+"""The output of our update \`Post\` mutation."""
+type UpdatePostPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Post\` that was updated by this mutation."""
+  post: Post
+
+  """An edge for our \`Post\`. May be used by Relay 1."""
+  postEdge(
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [NATURAL]
+  ): PostsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`updatePropertyById\` mutation."""
+input UpdatePropertyByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`Property\` being updated.
+  """
+  propertyPatch: PropertyPatch!
+}
+
+"""All input for the \`updateProperty\` mutation."""
+input UpdatePropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Property\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Property\` being updated.
+  """
+  propertyPatch: PropertyPatch!
+}
+
+"""The output of our update \`Property\` mutation."""
+type UpdatePropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Property\` that was updated by this mutation."""
+  property: Property
+
+  """An edge for our \`Property\`. May be used by Relay 1."""
+  propertyEdge(
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`Property\`."""
+  streetByStreetId: Street
+}
+
+"""All input for the \`updateStreetById\` mutation."""
+input UpdateStreetByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`Street\` being updated.
+  """
+  streetPatch: StreetPatch!
+}
+
+"""All input for the \`updateStreet\` mutation."""
+input UpdateStreetInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Street\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Street\` being updated.
+  """
+  streetPatch: StreetPatch!
+}
+
+"""The output of our update \`Street\` mutation."""
+type UpdateStreetPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The \`Street\` that was updated by this mutation."""
+  street: Street
+
+  """An edge for our \`Street\`. May be used by Relay 1."""
+  streetEdge(
+    """The method to use when ordering \`Street\`."""
+    orderBy: [StreetsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetsEdge
+}
+
+"""All input for the \`updateStreetPropertyByStrIdAndPropId\` mutation."""
+input UpdateStreetPropertyByStrIdAndPropIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  propId: Int!
+
+  """
+  An object where the defined keys will be set on the \`StreetProperty\` being updated.
+  """
+  streetPropertyPatch: StreetPropertyPatch!
+  strId: Int!
+}
+
+"""All input for the \`updateStreetProperty\` mutation."""
+input UpdateStreetPropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`StreetProperty\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`StreetProperty\` being updated.
+  """
+  streetPropertyPatch: StreetPropertyPatch!
+}
+
+"""The output of our update \`StreetProperty\` mutation."""
+type UpdateStreetPropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single \`Property\` that is related to this \`StreetProperty\`."""
+  propertyByPropId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`StreetProperty\`."""
+  streetByStrId: Street
+
+  """The \`StreetProperty\` that was updated by this mutation."""
+  streetProperty: StreetProperty
+
+  """An edge for our \`StreetProperty\`. May be used by Relay 1."""
+  streetPropertyEdge(
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesEdge
+}
+
+`;
+
+exports[`view with fake unique constraints and primary key 1`] = `
+type Building implements Node {
+  floors: Int!
+  id: Int!
+  isPrimary: Boolean!
+  name: String!
+
+  """Reads a single \`Street\` that is related to this \`Building\`."""
+  namedAfterStreet: Street
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Property\` that is related to this \`Building\`."""
+  propertyByPropertyId: Property
+  propertyId: Int!
+}
+
+"""
+A condition to be used against \`Building\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BuildingCondition {
+  """Checks for equality with the object’s \`floors\` field."""
+  floors: Int
+
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`isPrimary\` field."""
+  isPrimary: Boolean
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`propertyId\` field."""
+  propertyId: Int
+}
+
+"""An input for mutations affecting \`Building\`"""
+input BuildingInput {
+  floors: Int
+  id: Int
+  isPrimary: Boolean
+  name: String!
+  propertyId: Int!
+}
+
+"""
+Represents an update to a \`Building\`. Fields that are set will be updated.
+"""
+input BuildingPatch {
+  floors: Int
+  id: Int
+  isPrimary: Boolean
+  name: String
+  propertyId: Int
+}
+
+"""A connection to a list of \`Building\` values."""
+type BuildingsConnection {
+  """
+  A list of edges which contains the \`Building\` and cursor to aid in pagination.
+  """
+  edges: [BuildingsEdge!]!
+
+  """A list of \`Building\` objects."""
+  nodes: [Building]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Building\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Building\` edge in the connection."""
+type BuildingsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Building\` at the end of the edge."""
+  node: Building
+}
+
+"""Methods to use when ordering \`Building\`."""
+enum BuildingsOrderBy {
+  FLOORS_ASC
+  FLOORS_DESC
+  ID_ASC
+  ID_DESC
+  IS_PRIMARY_ASC
+  IS_PRIMARY_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  PROPERTY_ID_ASC
+  PROPERTY_ID_DESC
+}
+
+"""All input for the create \`Building\` mutation."""
+input CreateBuildingInput {
+  """The \`Building\` to be created by this mutation."""
+  building: BuildingInput!
+
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+}
+
+"""The output of our create \`Building\` mutation."""
+type CreateBuildingPayload {
+  """The \`Building\` that was created by this mutation."""
+  building: Building
+
+  """An edge for our \`Building\`. May be used by Relay 1."""
+  buildingEdge(
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsEdge
+
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single \`Street\` that is related to this \`Building\`."""
+  namedAfterStreet: Street
+
+  """Reads a single \`Property\` that is related to this \`Building\`."""
+  propertyByPropertyId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create \`Offer\` mutation."""
+input CreateOfferInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Offer\` to be created by this mutation."""
+  offer: OfferInput!
+}
+
+"""The output of our create \`Offer\` mutation."""
+type CreateOfferPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Offer\` that was created by this mutation."""
+  offer: Offer
+
+  """An edge for our \`Offer\`. May be used by Relay 1."""
+  offerEdge(
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersEdge
+
+  """Reads a single \`Post\` that is related to this \`Offer\`."""
+  postByPostId: Post
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create \`Post\` mutation."""
+input CreatePostInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Post\` to be created by this mutation."""
+  post: PostInput!
+}
+
+"""The output of our create \`Post\` mutation."""
+type CreatePostPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Post\` that was created by this mutation."""
+  post: Post
+
+  """An edge for our \`Post\`. May be used by Relay 1."""
+  postEdge(
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create \`Property\` mutation."""
+input CreatePropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Property\` to be created by this mutation."""
+  property: PropertyInput!
+}
+
+"""The output of our create \`Property\` mutation."""
+type CreatePropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Property\` that was created by this mutation."""
+  property: Property
+
+  """An edge for our \`Property\`. May be used by Relay 1."""
+  propertyEdge(
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`Property\`."""
+  streetByStreetId: Street
+}
+
+"""All input for the create \`Street\` mutation."""
+input CreateStreetInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Street\` to be created by this mutation."""
+  street: StreetInput!
+}
+
+"""The output of our create \`Street\` mutation."""
+type CreateStreetPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The \`Street\` that was created by this mutation."""
+  street: Street
+
+  """An edge for our \`Street\`. May be used by Relay 1."""
+  streetEdge(
+    """The method to use when ordering \`Street\`."""
+    orderBy: [StreetsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetsEdge
+}
+
+"""All input for the create \`StreetProperty\` mutation."""
+input CreateStreetPropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`StreetProperty\` to be created by this mutation."""
+  streetProperty: StreetPropertyInput!
+}
+
+"""The output of our create \`StreetProperty\` mutation."""
+type CreateStreetPropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single \`Property\` that is related to this \`StreetProperty\`."""
+  propertyByPropId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`StreetProperty\`."""
+  streetByStrId: Street
+
+  """The \`StreetProperty\` that was created by this mutation."""
+  streetProperty: StreetProperty
+
+  """An edge for our \`StreetProperty\`. May be used by Relay 1."""
+  streetPropertyEdge(
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesEdge
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the \`deleteBuildingById\` mutation."""
+input DeleteBuildingByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteBuilding\` mutation."""
+input DeleteBuildingInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Building\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Building\` mutation."""
+type DeleteBuildingPayload {
+  """The \`Building\` that was deleted by this mutation."""
+  building: Building
+
+  """An edge for our \`Building\`. May be used by Relay 1."""
+  buildingEdge(
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsEdge
+
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedBuildingId: ID
+
+  """Reads a single \`Street\` that is related to this \`Building\`."""
+  namedAfterStreet: Street
+
+  """Reads a single \`Property\` that is related to this \`Building\`."""
+  propertyByPropertyId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`deleteOfferById\` mutation."""
+input DeleteOfferByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteOffer\` mutation."""
+input DeleteOfferInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Offer\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Offer\` mutation."""
+type DeleteOfferPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedOfferViewId: ID
+
+  """The \`Offer\` that was deleted by this mutation."""
+  offer: Offer
+
+  """An edge for our \`Offer\`. May be used by Relay 1."""
+  offerEdge(
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersEdge
+
+  """Reads a single \`Post\` that is related to this \`Offer\`."""
+  postByPostId: Post
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`deletePostById\` mutation."""
+input DeletePostByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: String!
+}
+
+"""All input for the \`deletePost\` mutation."""
+input DeletePostInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Post\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Post\` mutation."""
+type DeletePostPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedPostViewId: ID
+
+  """The \`Post\` that was deleted by this mutation."""
+  post: Post
+
+  """An edge for our \`Post\`. May be used by Relay 1."""
+  postEdge(
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`deletePropertyById\` mutation."""
+input DeletePropertyByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteProperty\` mutation."""
+input DeletePropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Property\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Property\` mutation."""
+type DeletePropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedPropertyId: ID
+
+  """The \`Property\` that was deleted by this mutation."""
+  property: Property
+
+  """An edge for our \`Property\`. May be used by Relay 1."""
+  propertyEdge(
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`Property\`."""
+  streetByStreetId: Street
+}
+
+"""All input for the \`deleteStreetById\` mutation."""
+input DeleteStreetByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteStreet\` mutation."""
+input DeleteStreetInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Street\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Street\` mutation."""
+type DeleteStreetPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedStreetId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The \`Street\` that was deleted by this mutation."""
+  street: Street
+
+  """An edge for our \`Street\`. May be used by Relay 1."""
+  streetEdge(
+    """The method to use when ordering \`Street\`."""
+    orderBy: [StreetsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetsEdge
+}
+
+"""All input for the \`deleteStreetPropertyByStrIdAndPropId\` mutation."""
+input DeleteStreetPropertyByStrIdAndPropIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  propId: Int!
+  strId: Int!
+}
+
+"""All input for the \`deleteStreetProperty\` mutation."""
+input DeleteStreetPropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`StreetProperty\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`StreetProperty\` mutation."""
+type DeleteStreetPropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedStreetPropertyId: ID
+
+  """Reads a single \`Property\` that is related to this \`StreetProperty\`."""
+  propertyByPropId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`StreetProperty\`."""
+  streetByStrId: Street
+
+  """The \`StreetProperty\` that was deleted by this mutation."""
+  streetProperty: StreetProperty
+
+  """An edge for our \`StreetProperty\`. May be used by Relay 1."""
+  streetPropertyEdge(
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesEdge
+}
+
+type House implements Node {
+  buildingId: Int
+  buildingName: String!
+  floors: Int
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  propertyId: Int!
+  propertyNameOrNumber: String!
+  streetId: Int!
+  streetName: String!
+}
+
+"""
+A condition to be used against \`House\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input HouseCondition {
+  """Checks for equality with the object’s \`buildingId\` field."""
+  buildingId: Int
+
+  """Checks for equality with the object’s \`buildingName\` field."""
+  buildingName: String
+
+  """Checks for equality with the object’s \`floors\` field."""
+  floors: Int
+
+  """Checks for equality with the object’s \`propertyId\` field."""
+  propertyId: Int
+
+  """Checks for equality with the object’s \`propertyNameOrNumber\` field."""
+  propertyNameOrNumber: String
+
+  """Checks for equality with the object’s \`streetId\` field."""
+  streetId: Int
+
+  """Checks for equality with the object’s \`streetName\` field."""
+  streetName: String
+}
+
+"""A connection to a list of \`House\` values."""
+type HousesConnection {
+  """
+  A list of edges which contains the \`House\` and cursor to aid in pagination.
+  """
+  edges: [HousesEdge!]!
+
+  """A list of \`House\` objects."""
+  nodes: [House]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`House\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`House\` edge in the connection."""
+type HousesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`House\` at the end of the edge."""
+  node: House
+}
+
+"""Methods to use when ordering \`House\`."""
+enum HousesOrderBy {
+  BUILDING_ID_ASC
+  BUILDING_ID_DESC
+  BUILDING_NAME_ASC
+  BUILDING_NAME_DESC
+  FLOORS_ASC
+  FLOORS_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  PROPERTY_ID_ASC
+  PROPERTY_ID_DESC
+  PROPERTY_NAME_OR_NUMBER_ASC
+  PROPERTY_NAME_OR_NUMBER_DESC
+  STREET_ID_ASC
+  STREET_ID_DESC
+  STREET_NAME_ASC
+  STREET_NAME_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single \`Building\`."""
+  createBuilding(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateBuildingInput!
+  ): CreateBuildingPayload
+
+  """Creates a single \`Offer\`."""
+  createOffer(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateOfferInput!
+  ): CreateOfferPayload
+
+  """Creates a single \`Post\`."""
+  createPost(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreatePostInput!
+  ): CreatePostPayload
+
+  """Creates a single \`Property\`."""
+  createProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreatePropertyInput!
+  ): CreatePropertyPayload
+
+  """Creates a single \`Street\`."""
+  createStreet(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateStreetInput!
+  ): CreateStreetPayload
+
+  """Creates a single \`StreetProperty\`."""
+  createStreetProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateStreetPropertyInput!
+  ): CreateStreetPropertyPayload
+
+  """Deletes a single \`Building\` using its globally unique id."""
+  deleteBuilding(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteBuildingInput!
+  ): DeleteBuildingPayload
+
+  """Deletes a single \`Building\` using a unique key."""
+  deleteBuildingById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteBuildingByIdInput!
+  ): DeleteBuildingPayload
+
+  """Deletes a single \`Offer\` using its globally unique id."""
+  deleteOffer(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOfferInput!
+  ): DeleteOfferPayload
+
+  """Deletes a single \`Offer\` using a unique key."""
+  deleteOfferById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOfferByIdInput!
+  ): DeleteOfferPayload
+
+  """Deletes a single \`Post\` using its globally unique id."""
+  deletePost(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePostInput!
+  ): DeletePostPayload
+
+  """Deletes a single \`Post\` using a unique key."""
+  deletePostById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePostByIdInput!
+  ): DeletePostPayload
+
+  """Deletes a single \`Property\` using its globally unique id."""
+  deleteProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePropertyInput!
+  ): DeletePropertyPayload
+
+  """Deletes a single \`Property\` using a unique key."""
+  deletePropertyById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePropertyByIdInput!
+  ): DeletePropertyPayload
+
+  """Deletes a single \`Street\` using its globally unique id."""
+  deleteStreet(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStreetInput!
+  ): DeleteStreetPayload
+
+  """Deletes a single \`Street\` using a unique key."""
+  deleteStreetById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStreetByIdInput!
+  ): DeleteStreetPayload
+
+  """Deletes a single \`StreetProperty\` using its globally unique id."""
+  deleteStreetProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStreetPropertyInput!
+  ): DeleteStreetPropertyPayload
+
+  """Deletes a single \`StreetProperty\` using a unique key."""
+  deleteStreetPropertyByStrIdAndPropId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStreetPropertyByStrIdAndPropIdInput!
+  ): DeleteStreetPropertyPayload
+
+  """Updates a single \`Building\` using its globally unique id and a patch."""
+  updateBuilding(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateBuildingInput!
+  ): UpdateBuildingPayload
+
+  """Updates a single \`Building\` using a unique key and a patch."""
+  updateBuildingById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateBuildingByIdInput!
+  ): UpdateBuildingPayload
+
+  """Updates a single \`Offer\` using its globally unique id and a patch."""
+  updateOffer(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOfferInput!
+  ): UpdateOfferPayload
+
+  """Updates a single \`Offer\` using a unique key and a patch."""
+  updateOfferById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOfferByIdInput!
+  ): UpdateOfferPayload
+
+  """Updates a single \`Post\` using its globally unique id and a patch."""
+  updatePost(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePostInput!
+  ): UpdatePostPayload
+
+  """Updates a single \`Post\` using a unique key and a patch."""
+  updatePostById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePostByIdInput!
+  ): UpdatePostPayload
+
+  """Updates a single \`Property\` using its globally unique id and a patch."""
+  updateProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePropertyInput!
+  ): UpdatePropertyPayload
+
+  """Updates a single \`Property\` using a unique key and a patch."""
+  updatePropertyById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePropertyByIdInput!
+  ): UpdatePropertyPayload
+
+  """Updates a single \`Street\` using its globally unique id and a patch."""
+  updateStreet(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStreetInput!
+  ): UpdateStreetPayload
+
+  """Updates a single \`Street\` using a unique key and a patch."""
+  updateStreetById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStreetByIdInput!
+  ): UpdateStreetPayload
+
+  """
+  Updates a single \`StreetProperty\` using its globally unique id and a patch.
+  """
+  updateStreetProperty(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStreetPropertyInput!
+  ): UpdateStreetPropertyPayload
+
+  """Updates a single \`StreetProperty\` using a unique key and a patch."""
+  updateStreetPropertyByStrIdAndPropId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStreetPropertyByStrIdAndPropIdInput!
+  ): UpdateStreetPropertyPayload
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+type Offer implements Node {
+  id: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Post\` that is related to this \`Offer\`."""
+  postByPostId: Post
+  postId: String
+}
+
+"""
+A condition to be used against \`Offer\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input OfferCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`postId\` field."""
+  postId: String
+}
+
+"""An input for mutations affecting \`Offer\`"""
+input OfferInput {
+  id: Int!
+  postId: String
+}
+
+"""
+Represents an update to a \`Offer\`. Fields that are set will be updated.
+"""
+input OfferPatch {
+  id: Int
+  postId: String
+}
+
+"""A connection to a list of \`Offer\` values."""
+type OffersConnection {
+  """
+  A list of edges which contains the \`Offer\` and cursor to aid in pagination.
+  """
+  edges: [OffersEdge!]!
+
+  """A list of \`Offer\` objects."""
+  nodes: [Offer]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Offer\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Offer\` edge in the connection."""
+type OffersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Offer\` at the end of the edge."""
+  node: Offer
+}
+
+"""Methods to use when ordering \`Offer\`."""
+enum OffersOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  POST_ID_ASC
+  POST_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+type Post implements Node {
+  id: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Offer\`."""
+  offersByPostId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OfferCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersConnection!
+}
+
+"""
+A condition to be used against \`Post\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PostCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: String
+}
+
+"""An input for mutations affecting \`Post\`"""
+input PostInput {
+  id: String!
+}
+
+"""Represents an update to a \`Post\`. Fields that are set will be updated."""
+input PostPatch {
+  id: String
+}
+
+"""A connection to a list of \`Post\` values."""
+type PostsConnection {
+  """
+  A list of edges which contains the \`Post\` and cursor to aid in pagination.
+  """
+  edges: [PostsEdge!]!
+
+  """A list of \`Post\` objects."""
+  nodes: [Post]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Post\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Post\` edge in the connection."""
+type PostsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Post\` at the end of the edge."""
+  node: Post
+}
+
+"""Methods to use when ordering \`Post\`."""
+enum PostsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""A connection to a list of \`Property\` values."""
+type PropertiesConnection {
+  """
+  A list of edges which contains the \`Property\` and cursor to aid in pagination.
+  """
+  edges: [PropertiesEdge!]!
+
+  """A list of \`Property\` objects."""
+  nodes: [Property]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Property\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Property\` edge in the connection."""
+type PropertiesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Property\` at the end of the edge."""
+  node: Property
+}
+
+"""Methods to use when ordering \`Property\`."""
+enum PropertiesOrderBy {
+  ID_ASC
+  ID_DESC
+  NAME_OR_NUMBER_ASC
+  NAME_OR_NUMBER_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  STREET_ID_ASC
+  STREET_ID_DESC
+}
+
+type Property implements Node {
+  """Reads and enables pagination through a set of \`Building\`."""
+  buildingsByPropertyId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BuildingCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsConnection!
+  id: Int!
+  nameOrNumber: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Street\` that is related to this \`Property\`."""
+  streetByStreetId: Street
+  streetId: Int!
+
+  """Reads and enables pagination through a set of \`StreetProperty\`."""
+  streetPropertiesByPropId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StreetPropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesConnection!
+}
+
+"""
+A condition to be used against \`Property\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input PropertyCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`nameOrNumber\` field."""
+  nameOrNumber: String
+
+  """Checks for equality with the object’s \`streetId\` field."""
+  streetId: Int
+}
+
+"""An input for mutations affecting \`Property\`"""
+input PropertyInput {
+  id: Int
+  nameOrNumber: String!
+  streetId: Int!
+}
+
+"""
+Represents an update to a \`Property\`. Fields that are set will be updated.
+"""
+input PropertyPatch {
+  id: Int
+  nameOrNumber: String
+  streetId: Int
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """Reads and enables pagination through a set of \`Building\`."""
+  allBuildings(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BuildingCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsConnection
+
+  """Reads and enables pagination through a set of \`House\`."""
+  allHouses(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: HouseCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`House\`."""
+    orderBy: [HousesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): HousesConnection
+
+  """Reads and enables pagination through a set of \`Offer\`."""
+  allOffers(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OfferCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersConnection
+
+  """Reads and enables pagination through a set of \`Post\`."""
+  allPosts(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PostCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsConnection
+
+  """Reads and enables pagination through a set of \`Property\`."""
+  allProperties(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesConnection
+
+  """Reads and enables pagination through a set of \`StreetProperty\`."""
+  allStreetProperties(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StreetPropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesConnection
+
+  """Reads and enables pagination through a set of \`Street\`."""
+  allStreets(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StreetCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Street\`."""
+    orderBy: [StreetsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetsConnection
+
+  """Reads a single \`Building\` using its globally unique \`ID\`."""
+  building(
+    """The globally unique \`ID\` to be used in selecting a single \`Building\`."""
+    nodeId: ID!
+  ): Building
+  buildingById(id: Int!): Building
+
+  """Reads a single \`House\` using its globally unique \`ID\`."""
+  house(
+    """The globally unique \`ID\` to be used in selecting a single \`House\`."""
+    nodeId: ID!
+  ): House
+  houseByStreetIdAndPropertyId(propertyId: Int!, streetId: Int!): House
+  houseByStreetIdAndPropertyNameOrNumber(propertyNameOrNumber: String!, streetId: Int!): House
+  houseByStreetNameAndBuildingName(buildingName: String!, streetName: String!): House
+  houseByStreetNameAndPropertyId(propertyId: Int!, streetName: String!): House
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Offer\` using its globally unique \`ID\`."""
+  offer(
+    """The globally unique \`ID\` to be used in selecting a single \`Offer\`."""
+    nodeId: ID!
+  ): Offer
+  offerById(id: Int!): Offer
+
+  """Reads a single \`Post\` using its globally unique \`ID\`."""
+  post(
+    """The globally unique \`ID\` to be used in selecting a single \`Post\`."""
+    nodeId: ID!
+  ): Post
+  postById(id: String!): Post
+
+  """Reads a single \`Property\` using its globally unique \`ID\`."""
+  property(
+    """The globally unique \`ID\` to be used in selecting a single \`Property\`."""
+    nodeId: ID!
+  ): Property
+  propertyById(id: Int!): Property
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """Reads a single \`Street\` using its globally unique \`ID\`."""
+  street(
+    """The globally unique \`ID\` to be used in selecting a single \`Street\`."""
+    nodeId: ID!
+  ): Street
+  streetById(id: Int!): Street
+
+  """Reads a single \`StreetProperty\` using its globally unique \`ID\`."""
+  streetProperty(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`StreetProperty\`.
+    """
+    nodeId: ID!
+  ): StreetProperty
+  streetPropertyByStrIdAndPropId(propId: Int!, strId: Int!): StreetProperty
+}
+
+type Street implements Node {
+  """Reads and enables pagination through a set of \`Building\`."""
+  buildingsNamedAfterStreet(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BuildingCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsConnection!
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Property\`."""
+  propertiesByStreetId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesConnection!
+
+  """Reads and enables pagination through a set of \`StreetProperty\`."""
+  streetPropertiesByStrId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StreetPropertyCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesConnection!
+}
+
+"""
+A condition to be used against \`Street\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input StreetCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+}
+
+"""An input for mutations affecting \`Street\`"""
+input StreetInput {
+  id: Int
+  name: String!
+}
+
+"""
+Represents an update to a \`Street\`. Fields that are set will be updated.
+"""
+input StreetPatch {
+  id: Int
+  name: String
+}
+
+"""A connection to a list of \`StreetProperty\` values."""
+type StreetPropertiesConnection {
+  """
+  A list of edges which contains the \`StreetProperty\` and cursor to aid in pagination.
+  """
+  edges: [StreetPropertiesEdge!]!
+
+  """A list of \`StreetProperty\` objects."""
+  nodes: [StreetProperty]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`StreetProperty\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`StreetProperty\` edge in the connection."""
+type StreetPropertiesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`StreetProperty\` at the end of the edge."""
+  node: StreetProperty
+}
+
+"""Methods to use when ordering \`StreetProperty\`."""
+enum StreetPropertiesOrderBy {
+  CURRENT_OWNER_ASC
+  CURRENT_OWNER_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  PROP_ID_ASC
+  PROP_ID_DESC
+  STR_ID_ASC
+  STR_ID_DESC
+}
+
+type StreetProperty implements Node {
+  currentOwner: String
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Property\` that is related to this \`StreetProperty\`."""
+  propertyByPropId: Property
+  propId: Int!
+
+  """Reads a single \`Street\` that is related to this \`StreetProperty\`."""
+  streetByStrId: Street
+  strId: Int!
+}
+
+"""
+A condition to be used against \`StreetProperty\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input StreetPropertyCondition {
+  """Checks for equality with the object’s \`currentOwner\` field."""
+  currentOwner: String
+
+  """Checks for equality with the object’s \`propId\` field."""
+  propId: Int
+
+  """Checks for equality with the object’s \`strId\` field."""
+  strId: Int
+}
+
+"""An input for mutations affecting \`StreetProperty\`"""
+input StreetPropertyInput {
+  currentOwner: String
+  propId: Int!
+  strId: Int!
+}
+
+"""
+Represents an update to a \`StreetProperty\`. Fields that are set will be updated.
+"""
+input StreetPropertyPatch {
+  currentOwner: String
+  propId: Int
+  strId: Int
+}
+
+"""A connection to a list of \`Street\` values."""
+type StreetsConnection {
+  """
+  A list of edges which contains the \`Street\` and cursor to aid in pagination.
+  """
+  edges: [StreetsEdge!]!
+
+  """A list of \`Street\` objects."""
+  nodes: [Street]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Street\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Street\` edge in the connection."""
+type StreetsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Street\` at the end of the edge."""
+  node: Street
+}
+
+"""Methods to use when ordering \`Street\`."""
+enum StreetsOrderBy {
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""All input for the \`updateBuildingById\` mutation."""
+input UpdateBuildingByIdInput {
+  """
+  An object where the defined keys will be set on the \`Building\` being updated.
+  """
+  buildingPatch: BuildingPatch!
+
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`updateBuilding\` mutation."""
+input UpdateBuildingInput {
+  """
+  An object where the defined keys will be set on the \`Building\` being updated.
+  """
+  buildingPatch: BuildingPatch!
+
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Building\` to be updated.
+  """
+  nodeId: ID!
+}
+
+"""The output of our update \`Building\` mutation."""
+type UpdateBuildingPayload {
+  """The \`Building\` that was updated by this mutation."""
+  building: Building
+
+  """An edge for our \`Building\`. May be used by Relay 1."""
+  buildingEdge(
+    """The method to use when ordering \`Building\`."""
+    orderBy: [BuildingsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BuildingsEdge
+
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single \`Street\` that is related to this \`Building\`."""
+  namedAfterStreet: Street
+
+  """Reads a single \`Property\` that is related to this \`Building\`."""
+  propertyByPropertyId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`updateOfferById\` mutation."""
+input UpdateOfferByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`Offer\` being updated.
+  """
+  offerPatch: OfferPatch!
+}
+
+"""All input for the \`updateOffer\` mutation."""
+input UpdateOfferInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Offer\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Offer\` being updated.
+  """
+  offerPatch: OfferPatch!
+}
+
+"""The output of our update \`Offer\` mutation."""
+type UpdateOfferPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Offer\` that was updated by this mutation."""
+  offer: Offer
+
+  """An edge for our \`Offer\`. May be used by Relay 1."""
+  offerEdge(
+    """The method to use when ordering \`Offer\`."""
+    orderBy: [OffersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OffersEdge
+
+  """Reads a single \`Post\` that is related to this \`Offer\`."""
+  postByPostId: Post
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`updatePostById\` mutation."""
+input UpdatePostByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: String!
+
+  """
+  An object where the defined keys will be set on the \`Post\` being updated.
+  """
+  postPatch: PostPatch!
+}
+
+"""All input for the \`updatePost\` mutation."""
+input UpdatePostInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Post\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Post\` being updated.
+  """
+  postPatch: PostPatch!
+}
+
+"""The output of our update \`Post\` mutation."""
+type UpdatePostPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Post\` that was updated by this mutation."""
+  post: Post
+
+  """An edge for our \`Post\`. May be used by Relay 1."""
+  postEdge(
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`updatePropertyById\` mutation."""
+input UpdatePropertyByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`Property\` being updated.
+  """
+  propertyPatch: PropertyPatch!
+}
+
+"""All input for the \`updateProperty\` mutation."""
+input UpdatePropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Property\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Property\` being updated.
+  """
+  propertyPatch: PropertyPatch!
+}
+
+"""The output of our update \`Property\` mutation."""
+type UpdatePropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Property\` that was updated by this mutation."""
+  property: Property
+
+  """An edge for our \`Property\`. May be used by Relay 1."""
+  propertyEdge(
+    """The method to use when ordering \`Property\`."""
+    orderBy: [PropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PropertiesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`Property\`."""
+  streetByStreetId: Street
+}
+
+"""All input for the \`updateStreetById\` mutation."""
+input UpdateStreetByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`Street\` being updated.
+  """
+  streetPatch: StreetPatch!
+}
+
+"""All input for the \`updateStreet\` mutation."""
+input UpdateStreetInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Street\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Street\` being updated.
+  """
+  streetPatch: StreetPatch!
+}
+
+"""The output of our update \`Street\` mutation."""
+type UpdateStreetPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The \`Street\` that was updated by this mutation."""
+  street: Street
+
+  """An edge for our \`Street\`. May be used by Relay 1."""
+  streetEdge(
+    """The method to use when ordering \`Street\`."""
+    orderBy: [StreetsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetsEdge
+}
+
+"""All input for the \`updateStreetPropertyByStrIdAndPropId\` mutation."""
+input UpdateStreetPropertyByStrIdAndPropIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  propId: Int!
+
+  """
+  An object where the defined keys will be set on the \`StreetProperty\` being updated.
+  """
+  streetPropertyPatch: StreetPropertyPatch!
+  strId: Int!
+}
+
+"""All input for the \`updateStreetProperty\` mutation."""
+input UpdateStreetPropertyInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`StreetProperty\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`StreetProperty\` being updated.
+  """
+  streetPropertyPatch: StreetPropertyPatch!
+}
+
+"""The output of our update \`StreetProperty\` mutation."""
+type UpdateStreetPropertyPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single \`Property\` that is related to this \`StreetProperty\`."""
+  propertyByPropId: Property
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Street\` that is related to this \`StreetProperty\`."""
+  streetByStrId: Street
+
+  """The \`StreetProperty\` that was updated by this mutation."""
+  streetProperty: StreetProperty
+
+  """An edge for our \`StreetProperty\`. May be used by Relay 1."""
+  streetPropertyEdge(
+    """The method to use when ordering \`StreetProperty\`."""
+    orderBy: [StreetPropertiesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StreetPropertiesEdge
+}
+
+`;

--- a/packages/postgraphile-core/__tests__/integration/schema/smart_comment_relations.test.js
+++ b/packages/postgraphile-core/__tests__/integration/schema/smart_comment_relations.test.js
@@ -95,6 +95,63 @@ comment on view smart_comment_relations.offer_view is E'@name offers
       const fields = Offer.getFields();
       expect(fields.nodeId).toBeTruthy();
       expect(fields.postByPostId).toBeTruthy();
+      const Query = schema.getType("Query");
+      const queryFields = Query.getFields();
+      // `@uniqueKey` does not add root level fields; use `@unique` for that.
+      expect(queryFields.postById).toBeFalsy();
+    }
+  )
+);
+
+test(
+  "view with fake unique constraint",
+  core.test(
+    ["smart_comment_relations"],
+    {},
+    pgClient =>
+      pgClient.query(
+        `
+comment on view smart_comment_relations.post_view is E'@name posts
+@unique id'; -- NOT primary key!
+
+comment on view smart_comment_relations.offer_view is E'@name offers
+@primaryKey id
+@foreignKey (post_id) references post_view(id)';`
+      ),
+    schema => {
+      const Offer = schema.getType("Offer");
+      const fields = Offer.getFields();
+      expect(fields.nodeId).toBeTruthy();
+      expect(fields.postByPostId).toBeTruthy();
+      const Query = schema.getType("Query");
+      const queryFields = Query.getFields();
+      expect(queryFields.postById).toBeTruthy();
+    }
+  )
+);
+
+test(
+  "view with fake unique constraints and primary key",
+  core.test(
+    ["smart_comment_relations"],
+    {},
+    pgClient =>
+      pgClient.query(
+        `
+comment on view smart_comment_relations.houses is E'@name houses
+@primaryKey street_id,property_id
+@unique street_name,property_id
+@unique street_id,property_name_or_number
+@unique street_name,building_name';`
+      ),
+    schema => {
+      const Query = schema.getType("Query");
+      const queryFields = Query.getFields();
+      expect(queryFields.houseByStreetIdAndPropertyId).toBeTruthy();
+      expect(queryFields.houseByStreetNameAndPropertyId).toBeTruthy();
+      expect(queryFields.houseByStreetIdAndPropertyNameOrNumber).toBeTruthy();
+      expect(queryFields.houseByStreetNameAndBuildingName).toBeTruthy();
+      expect(queryFields.nonsense).toBeFalsy();
     }
   )
 );


### PR DESCRIPTION
## Description

The existing `@uniqueKey` smart tag is a bit rubbish. Now we have infrastructure for `@primaryKey` and `@foreignKey` fake constraints, it makes sense to add `@unique` fake constraints too. This PR does that.

Fixes https://github.com/graphile/graphile-engine/issues/664

## Performance impact

Negligible.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
