### PR TITLE
fix(types): fix enum tables when used in custom mutations

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.d.ts
@@ -98,6 +98,7 @@ export interface PgType {
   enumDescriptions: string[] | void;
   rangeSubTypeId: string | void;
   tags: { [tag: string]: true | string | Array<string> };
+  isFake?: boolean;
 }
 
 export interface PgAttribute {

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -715,9 +715,11 @@ Original error: ${e.message}
 
                   // Create fake enum type
                   const constraintIdent =
-                    constraint.type === "p" ? "" : `_${constraint.name}`;
+                    (constraint.type === "p" ? "" : `_${constraint.name}`) +
+                    "_fake_enum";
                   const enumTypeArray = {
                     kind: "type",
+                    isFake: true,
                     id: `FAKE_ENUM_${klass.namespaceName}_${klass.name}${constraintIdent}_list`,
                     name: `_${klass.name}${constraintIdent}`,
                     description: null,
@@ -737,10 +739,10 @@ Original error: ${e.message}
                     enumVariants: null,
                     enumDescriptions: null,
                     rangeSubTypeId: null,
-                    isFake: true,
                   };
                   const enumType = {
                     kind: "type",
+                    isFake: true,
                     id: `FAKE_ENUM_${klass.namespaceName}_${klass.name}${constraintIdent}`,
                     name: `${klass.name}${constraintIdent}`,
                     description: klass.description,
@@ -763,7 +765,6 @@ Original error: ${e.message}
                       : null,
                     // TODO: enumDescriptions
                     rangeSubTypeId: null,
-                    isFake: true,
                   };
                   result.type.push(enumType, enumTypeArray);
 

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -109,6 +109,7 @@ export type PgType = {
   enumDescriptions: ?(string[]),
   rangeSubTypeId: ?string,
   tags: { [string]: string },
+  isFake: ?boolean,
 };
 
 export type PgAttribute = {
@@ -736,6 +737,7 @@ Original error: ${e.message}
                     enumVariants: null,
                     enumDescriptions: null,
                     rangeSubTypeId: null,
+                    isFake: true,
                   };
                   const enumType = {
                     kind: "type",
@@ -761,6 +763,7 @@ Original error: ${e.message}
                       : null,
                     // TODO: enumDescriptions
                     rangeSubTypeId: null,
+                    isFake: true,
                   };
                   result.type.push(enumType, enumTypeArray);
 

--- a/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTablesPlugin.js
@@ -323,11 +323,11 @@ export default (function PgTablesPlugin(
                   const v = obj[fieldName];
                   if (inputField && v != null) {
                     const { type, typeModifier } = inputField;
-                    return sql.fragment`${gql2pg(
-                      v,
-                      type,
-                      typeModifier
-                    )}::${sql.identifier(type.namespaceName, type.name)}`;
+                    return sql.fragment`${gql2pg(v, type, typeModifier)}::${
+                      type.isFake
+                        ? sql.identifier("unknown")
+                        : sql.identifier(type.namespaceName, type.name)
+                    }`;
                   } else {
                     return sql.null; // TODO: return default instead.
                   }
@@ -336,10 +336,14 @@ export default (function PgTablesPlugin(
                 return sql.fragment`row(${sql.join(
                   attributes.map(attr2sql),
                   ","
-                )})::${sql.identifier(
-                  tablePgType.namespaceName,
-                  tablePgType.name
-                )}`;
+                )})::${
+                  tablePgType.isFake
+                    ? sql.identifier("unknown")
+                    : sql.identifier(
+                        tablePgType.namespaceName,
+                        tablePgType.name
+                      )
+                }`;
               },
             };
 

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -149,9 +149,11 @@ export default (function PgTypesPlugin(
           return sql.fragment`array[${sql.join(
             val.map(v => gql2pg(v, type.arrayItemType, modifier)),
             ", "
-          )}]::${sql.identifier(type.namespaceName)}.${sql.identifier(
-            type.name
-          )}`;
+          )}]::${
+            type.isFake
+              ? sql.identifier("unknown")
+              : sql.identifier(type.namespaceName, type.name)
+          }`;
         } else {
           return sql.value(val);
         }

--- a/packages/graphile-build-pg/src/plugins/viaTemporaryTable.js
+++ b/packages/graphile-build-pg/src/plugins/viaTemporaryTable.js
@@ -124,10 +124,14 @@ select ${sql.join(
             (outputArgName, idx) =>
               sql.query`(${sqlValuesAlias}.output_value_list)[${sql.literal(
                 idx + 1
-              )}]::${sql.identifier(
-                outputArgTypes[idx].namespaceName,
-                outputArgTypes[idx].name
-              )} as ${sql.identifier(
+              )}]::${
+                outputArgTypes[idx].isFake
+                  ? sql.identifier("unknown")
+                  : sql.identifier(
+                      outputArgTypes[idx].namespaceName,
+                      outputArgTypes[idx].name
+                    )
+              } as ${sql.identifier(
                 // According to https://www.postgresql.org/docs/10/static/sql-createfunction.html,
                 // "If you omit the name for an output argument, the system will choose a default column name."
                 // In PG 9.x and 10, the column names appear to be assigned with a `column` prefix.

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/enum_tables.mutations.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/enum_tables.mutations.graphql
@@ -19,4 +19,8 @@ mutation {
       description
     }
   }
+
+  referencingTableMutation(input: { t: { enum1: A1, enum2: B2, enum3: C4 } }) {
+    integer
+  }
 }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -76,6 +76,9 @@ Object {
         "letter": "C",
       },
     },
+    "referencingTableMutation": Object {
+      "integer": 435,
+    },
   },
 }
 `;

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
@@ -378,6 +378,12 @@ type Mutation {
     """
     input: DeleteReferencingTableByIdInput!
   ): DeleteReferencingTablePayload
+  referencingTableMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ReferencingTableMutationInput!
+  ): ReferencingTableMutationPayload
 
   """
   Updates a single \`LetterDescription\` using its globally unique id and a patch.
@@ -580,6 +586,31 @@ input ReferencingTableInput {
   enum2: EnumTheSecond
   enum3: EnumTheThird
   id: Int
+}
+
+"""All input for the \`referencingTableMutation\` mutation."""
+input ReferencingTableMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  t: ReferencingTableInput
+}
+
+"""The output of our \`referencingTableMutation\` mutation."""
+type ReferencingTableMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  integer: Int
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
 }
 
 """

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -1203,6 +1203,18 @@ create table enum_tables.referencing_table(
   enum_3 char(2) references enum_tables.lots_of_enums(enum_3)
 );
 
+-- Relates to https://github.com/graphile/postgraphile/issues/1365
+create function enum_tables.referencing_table_mutation(t enum_tables.referencing_table)
+returns int as $$
+declare
+  v_out int;
+begin
+  insert into enum_tables.referencing_table (enum_1, enum_2, enum_3) values (t.enum_1, t.enum_2, t.enum_3)
+    returning id into v_out;
+  return v_out;
+end;
+$$ language plpgsql volatile;
+
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

@brendanmckenzie reported graphile/postgraphile#1365 pointing out there's an issue when types that reference enum types are used in custom mutations. This is because we explicitly cast the type of each column, and when we were casting the enum to it's fake name it happened to overlap with the table name, so PostgreSQL thought it was a table reference. Really it should have been a cast to `::text` or whatever type the enum column is.

For now I've solved this by casting to `::unknown` if the type is fake; but we should solve it better in the long run by having the `PgType` have a `sqlFullyQualifiedTypeName` field that we can override for fake types to be the type of the column on the enum (e.g. `pg_catalog.text`).

Fixes graphile/postgraphile#1365

## Performance impact

Negligible.

## Security impact

Fixes a bug.
