### PR TITLE
fix(tags): fix non-null for multiple @unique tags

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -358,7 +358,7 @@ function smartCommentConstraints(introspectionResults) {
     }
     if (klass.tags.unique) {
       if (Array.isArray(klass.tags.unique)) {
-        klass.tags.unique.forEach(key => addKey(key, true));
+        klass.tags.unique.forEach(key => addKey(key));
       } else {
         addKey(klass.tags.unique);
       }

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/smart_comment_relations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/smart_comment_relations.test.js.snap
@@ -11980,7 +11980,7 @@ type DeleteStreetPropertyPayload {
 
 type House implements Node {
   buildingId: Int
-  buildingName: String!
+  buildingName: String
   floors: Int
 
   """


### PR DESCRIPTION
## Description

Typo meant that if you added more than one `@unique` tag to a table the fields would be treated as primary keys rather than uniques, which caused nullability to change. Thanks to @felixyz for spotting.

Fixes graphile/postgraphile#1366

## Performance impact

Negligible

## Security impact

None