### PR TITLE
chore: revert breaking fake enum name change

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -715,8 +715,7 @@ Original error: ${e.message}
 
                   // Create fake enum type
                   const constraintIdent =
-                    (constraint.type === "p" ? "" : `_${constraint.name}`) +
-                    "_fake_enum";
+                    constraint.type === "p" ? "" : `_${constraint.name}`;
                   const enumTypeArray = {
                     kind: "type",
                     isFake: true,

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
@@ -208,20 +208,6 @@ enum EnumTheSecond {
   B4
 }
 
-enum EnumTheThird {
-  """Desc C1"""
-  C1
-
-  """Desc C2"""
-  C2
-
-  """Desc C3"""
-  C3
-
-  """Desc C4"""
-  C4
-}
-
 enum LetterAToD {
   """The letter A"""
   A
@@ -317,6 +303,20 @@ enum LetterDescriptionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+}
+
+enum LotsOfEnumsEnum3 {
+  """Desc C1"""
+  C1
+
+  """Desc C2"""
+  C2
+
+  """Desc C3"""
+  C3
+
+  """Desc C4"""
+  C4
 }
 
 """
@@ -553,7 +553,7 @@ type Query implements Node {
 type ReferencingTable implements Node {
   enum1: EnumTheFirst
   enum2: EnumTheSecond
-  enum3: EnumTheThird
+  enum3: LotsOfEnumsEnum3
   id: Int!
 
   """
@@ -574,7 +574,7 @@ input ReferencingTableCondition {
   enum2: EnumTheSecond
 
   """Checks for equality with the object’s \`enum3\` field."""
-  enum3: EnumTheThird
+  enum3: LotsOfEnumsEnum3
 
   """Checks for equality with the object’s \`id\` field."""
   id: Int
@@ -584,7 +584,7 @@ input ReferencingTableCondition {
 input ReferencingTableInput {
   enum1: EnumTheFirst
   enum2: EnumTheSecond
-  enum3: EnumTheThird
+  enum3: LotsOfEnumsEnum3
   id: Int
 }
 
@@ -619,7 +619,7 @@ Represents an update to a \`ReferencingTable\`. Fields that are set will be upda
 input ReferencingTablePatch {
   enum1: EnumTheFirst
   enum2: EnumTheSecond
-  enum3: EnumTheThird
+  enum3: LotsOfEnumsEnum3
   id: Int
 }
 

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -1165,8 +1165,8 @@ create table enum_tables.lots_of_enums (
 comment on table enum_tables.lots_of_enums is E'@omit';
 comment on constraint enum_1 on enum_tables.lots_of_enums is E'@enum\n@enumName EnumTheFirst';
 comment on constraint enum_2 on enum_tables.lots_of_enums is E'@enum\n@enumName EnumTheSecond';
-comment on constraint enum_3 on enum_tables.lots_of_enums is E'@enum\n@enumName EnumTheThird';
-comment on constraint enum_4 on enum_tables.lots_of_enums is E'@enum\n@enumName EnumTheFourth';
+comment on constraint enum_3 on enum_tables.lots_of_enums is E'@enum';
+comment on constraint enum_4 on enum_tables.lots_of_enums is E'@enum';
 
 -- Enum table needs values added as part of the migration, not as part of the
 -- data.


### PR DESCRIPTION
## Description

Adding `_fake_enum` to the type name would have been a breaking change; this didn't show up in the tests because we explicitly named all of our enums. Have removed explicit naming from a couple enums and reverted the change.

(The change was only added to make errors from this more obvious, but it's safer to not have this change.)

## Performance impact

Negligible

## Security impact

None
