### PR TITLE
refactor: no need for LRU for interval (2.2m parsed/s)

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -3,8 +3,7 @@ import type { Plugin } from "graphile-build";
 
 import makeGraphQLJSONType from "../GraphQLJSON";
 
-import { parseInterval as rawParseInterval } from "../postgresInterval";
-import LRU from "@graphile/lru";
+import { parseInterval } from "../postgresInterval";
 
 function indent(str) {
   return "  " + str.replace(/\n/g, "\n  ");
@@ -12,17 +11,6 @@ function indent(str) {
 
 function identity(value) {
   return value;
-}
-
-const parseCache = new LRU({ maxLength: 500 });
-function parseInterval(str) {
-  let result = parseCache.get(str);
-  if (!result) {
-    result = rawParseInterval(str);
-    Object.freeze(result);
-    parseCache.set(str, result);
-  }
-  return result;
 }
 
 export default (function PgTypesPlugin(

--- a/packages/graphile-build-pg/src/postgresInterval.js
+++ b/packages/graphile-build-pg/src/postgresInterval.js
@@ -1,5 +1,14 @@
 // @flow
 
+export type Interval = {
+  years: number,
+  months: number,
+  days: number,
+  hours: number,
+  minutes: number,
+  seconds: number,
+};
+
 // Regexp construction enhanced from `postgres-interval`, which is licensed
 // under the MIT license and is copyright (c) Ben Drucker <bvdrucker@gmail.com>
 // (bendrucker.me).
@@ -15,35 +24,15 @@ const DAY = `${NUMBER}\\s+days?`;
 const TIME = "([+-])?(\\d+):(\\d\\d):(\\d\\d(?:\\.\\d{1,6})?)";
 
 const INTERVAL = new RegExp(
-  "^\\s*" +
+  "^" +
     // All parts of an interval are optional
     [YEAR, MONTH, DAY, TIME].map(str => "(?:" + str + ")?").join("\\s*") +
-    "\\s*$"
+    "$"
 );
 
-export type Interval = {
-  years: number,
-  months: number,
-  days: number,
-  hours: number,
-  minutes: number,
-  seconds: number,
-};
-
 export function parseInterval(interval: string): Interval {
-  if (!interval) {
-    return {
-      years: 0,
-      months: 0,
-      days: 0,
-      hours: 0,
-      minutes: 0,
-      seconds: 0.0,
-    };
-  }
-
   const [, years, months, days, plusMinusTime, hours, minutes, seconds] =
-    INTERVAL.exec(interval) || [];
+    INTERVAL.exec(interval || "") || [];
 
   const timeMultiplier = plusMinusTime === "-" ? -1 : 1;
 


### PR DESCRIPTION
## Description

Remove unnecessary LRU; now we've optimised parseInterval there's no need to wrap it in an LRU. I've benchmarked parseInterval at 2.2 million parses per second, so it's unlikely an LRU is going to make a big difference here (and in fact might hurt performance?)

## Performance impact

Slightly reduces memory usage.

## Security impact

None
