### PR TITLE
Send a manual notification at the end of watch-fixtures.sql

### DIFF
--- a/packages/graphile-build-pg/res/watch-fixtures.sql
+++ b/packages/graphile-build-pg/res/watch-fixtures.sql
@@ -98,3 +98,11 @@ create event trigger postgraphile_watch_ddl
 create event trigger postgraphile_watch_drop
   on sql_drop
   execute procedure postgraphile_watch.notify_watchers_drop();
+
+select pg_notify(
+  'postgraphile_watch',
+  json_build_object(
+    'type',
+    'manual'
+  )::text
+);


### PR DESCRIPTION
If the postgraphile server is started before the aatch-fixtures.sql file was loaded, this allows it to rebuild the GraphQL schema and then pick up on changes

useful when executed from the graphile-migrate afterReset hook
