### PR TITLE
feat(pubsub): add maxListeners to subscription eventEmitter

### DIFF
--- a/packages/pg-pubsub/README.md
+++ b/packages/pg-pubsub/README.md
@@ -65,6 +65,7 @@ const postgraphileOptions = {
   pluginHook,
   subscriptions: true, // Enable PostGraphile websocket capabilities
   simpleSubscriptions: true, // Add the `listen` subscription field
+  subscriptionEventEmitterMaxListeners: 20, // Set max listeners on eventEmitter, 0 unlimited, 10 default
   websocketMiddlewares: [
     // Add whatever middlewares you need here, note that they should only
     // manipulate properties on req/res, they must not sent response data. e.g.:

--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -13,6 +13,7 @@ declare module "postgraphile" {
   interface PostGraphileOptions {
     simpleSubscriptions?: boolean;
     subscriptionAuthorizationFunction?: string;
+    subscriptionEventEmitterMaxListeners?: number;
   }
 }
 
@@ -56,6 +57,11 @@ const plugin: PostGraphilePlugin = {
 
   ["postgraphile:options"](incomingOptions, { pgPool }) {
     const eventEmitter = new EventEmitter();
+    if (incomingOptions.subscriptionEventEmitterMaxListeners) {
+      eventEmitter.setMaxListeners(
+        incomingOptions.subscriptionEventEmitterMaxListeners
+      );
+    }
     const {
       simpleSubscriptions,
       subscriptionAuthorizationFunction,

--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -57,7 +57,7 @@ const plugin: PostGraphilePlugin = {
 
   ["postgraphile:options"](incomingOptions, { pgPool }) {
     const eventEmitter = new EventEmitter();
-    if (incomingOptions.subscriptionEventEmitterMaxListeners) {
+    if (incomingOptions.subscriptionEventEmitterMaxListeners != null) {
       eventEmitter.setMaxListeners(
         incomingOptions.subscriptionEventEmitterMaxListeners
       );


### PR DESCRIPTION
## Description

As talked in discord. If multiple subscription to same topic (over 10 as default), you get a warning:
```
(node:42281) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 graphql:projectList listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
```

## Performance impact

unknown

## Security impact

unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
