### PR TITLE
feat: allow for conditions with default values

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -100,6 +100,7 @@ export default (function PgConnectionArgCondition(builder) {
         pgColumnFilter,
         inflection,
         pgOmit: omit,
+        graphql: { coerceInputValue = v => v },
       } = build;
       const {
         scope: {
@@ -192,6 +193,7 @@ export default (function PgConnectionArgCondition(builder) {
               "arg"
             ),
             type: TableConditionType,
+            defaultValue: coerceInputValue({}, TableConditionType),
           },
         },
         `Adding condition to connection field '${fieldName}' of '${Self.name}'`

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
@@ -43,7 +43,7 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
         orderBy: extend(
           args.orderBy,
           {
-            defaultValue: defaultValueEnum && [defaultValueEnum.value],
+            defaultValue: defaultValueEnum ? [defaultValueEnum.value] : null,
           },
           `Adding defaultValue to orderBy for field '${fieldName}' of '${Self.name}'`
         ),

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -72,6 +72,9 @@ export default (function PgMutationPayloadEdgePlugin(
         canOrderBy &&
         (TableOrderByType.getValues().find(v => v.name === "PRIMARY_KEY_ASC") ||
           TableOrderByType.getValues()[0]);
+      const OrderByType = canOrderBy
+        ? new GraphQLList(new GraphQLNonNull(TableOrderByType))
+        : null;
       return extend(
         fields,
         {
@@ -85,22 +88,21 @@ export default (function PgMutationPayloadEdgePlugin(
                 "field"
               ),
               type: TableEdgeType,
-              args: canOrderBy
-                ? {
-                    orderBy: {
-                      description: build.wrapDescription(
-                        `The method to use when ordering \`${tableTypeName}\`.`,
-                        "arg"
-                      ),
-                      type: new GraphQLList(
-                        new GraphQLNonNull(TableOrderByType)
-                      ),
-                      defaultValue: defaultValueEnum
-                        ? [defaultValueEnum.value]
-                        : null,
-                    },
-                  }
-                : {},
+              args:
+                canOrderBy && OrderByType
+                  ? {
+                      orderBy: {
+                        description: build.wrapDescription(
+                          `The method to use when ordering \`${tableTypeName}\`.`,
+                          "arg"
+                        ),
+                        type: OrderByType,
+                        defaultValue: defaultValueEnum
+                          ? [defaultValueEnum.value]
+                          : null,
+                      },
+                    }
+                  : {},
               resolve(data, { orderBy: rawOrderBy }, _context, resolveInfo) {
                 if (!data.data) {
                   return null;

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
@@ -46,7 +46,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -75,7 +75,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -116,7 +116,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
 }
 
@@ -361,7 +361,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -390,7 +390,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -556,7 +556,7 @@ type User implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 }
 
@@ -808,7 +808,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -837,7 +837,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -878,7 +878,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
 }
 
@@ -1123,7 +1123,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -1152,7 +1152,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -1412,7 +1412,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -1441,7 +1441,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -1701,7 +1701,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -1730,7 +1730,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -1990,7 +1990,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -2019,7 +2019,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -2279,7 +2279,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -2308,7 +2308,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -2612,7 +2612,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -2641,7 +2641,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -2901,7 +2901,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -2930,7 +2930,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -3192,7 +3192,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -3221,7 +3221,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User

--- a/packages/graphile-utils/__tests__/__snapshots__/makeAddPgTableConditionPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/makeAddPgTableConditionPlugin.test.js.snap
@@ -46,7 +46,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -75,7 +75,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -337,7 +337,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): PetsConnection
 
   """Reads a set of \`Pet\`."""
@@ -354,7 +354,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
   ): [Pet!]
 
   """Reads and enables pagination through a set of \`User\`."""
@@ -383,7 +383,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): UsersConnection
 
   """Reads a set of \`User\`."""
@@ -400,7 +400,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
   ): [User!]
   petById(id: Int!): Pet
   userById(id: Int!): User
@@ -606,6 +606,656 @@ input UserCondition {
 
   """Filters users to those that have at least this many pets"""
   petCountAtLeast: Int
+}
+
+"""An input for mutations affecting \`Complex\`"""
+input ComplexInput {
+  numberInt: Int
+  stringText: String
+}
+
+`;
+
+exports[`uses defaultValue when condition empty 1`] = `
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of \`Pet\`."""
+  allPets(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`Pet\`."""
+    orderBy: [PetsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PetCondition = {}
+  ): PetsConnection
+
+  """Reads a set of \`Pet\`."""
+  allPetsList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Pet\`."""
+    orderBy: [PetsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PetCondition = {}
+  ): [Pet!]
+
+  """Reads and enables pagination through a set of \`User\`."""
+  allUsers(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`User\`."""
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition = {petCountAtLeast: 3}
+  ): UsersConnection
+
+  """Reads a set of \`User\`."""
+  allUsersList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`User\`."""
+    orderBy: [UsersOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition = {petCountAtLeast: 3}
+  ): [User!]
+  petById(id: Int!): Pet
+  userById(id: Int!): User
+
+  """Reads a single \`Pet\` using its globally unique \`ID\`."""
+  pet(
+    """The globally unique \`ID\` to be used in selecting a single \`Pet\`."""
+    nodeId: ID!
+  ): Pet
+
+  """Reads a single \`User\` using its globally unique \`ID\`."""
+  user(
+    """The globally unique \`ID\` to be used in selecting a single \`User\`."""
+    nodeId: ID!
+  ): User
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""A connection to a list of \`Pet\` values."""
+type PetsConnection {
+  """A list of \`Pet\` objects."""
+  nodes: [Pet]!
+
+  """
+  A list of edges which contains the \`Pet\` and cursor to aid in pagination.
+  """
+  edges: [PetsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Pet\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Pet implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  userId: Int!
+  name: String!
+  type: String!
+}
+
+"""A \`Pet\` edge in the connection."""
+type PetsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Pet\` at the end of the edge."""
+  node: Pet
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""Methods to use when ordering \`Pet\`."""
+enum PetsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  TYPE_ASC
+  TYPE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against \`Pet\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PetCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`userId\` field."""
+  userId: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`type\` field."""
+  type: String
+}
+
+"""A connection to a list of \`User\` values."""
+type UsersConnection {
+  """A list of \`User\` objects."""
+  nodes: [User]!
+
+  """
+  A list of edges which contains the \`User\` and cursor to aid in pagination.
+  """
+  edges: [UsersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`User\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type User implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+  email: String!
+  bio: String
+  renamedComplexColumn: [Complex]
+  createdAt: Datetime!
+}
+
+type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+"""
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+"""
+scalar Datetime
+
+"""A \`User\` edge in the connection."""
+type UsersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`User\` at the end of the edge."""
+  node: User
+}
+
+"""Methods to use when ordering \`User\`."""
+enum UsersOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  BIO_ASC
+  BIO_DESC
+  RENAMED_COMPLEX_COLUMN_ASC
+  RENAMED_COMPLEX_COLUMN_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against \`User\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input UserCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`email\` field."""
+  email: String
+
+  """Checks for equality with the object’s \`bio\` field."""
+  bio: String
+
+  """Checks for equality with the object’s \`renamedComplexColumn\` field."""
+  renamedComplexColumn: [ComplexInput]
+
+  """Checks for equality with the object’s \`createdAt\` field."""
+  createdAt: Datetime
+
+  """Filters users to those that have at least this many pets"""
+  petCountAtLeast: Int = 3
+}
+
+"""An input for mutations affecting \`Complex\`"""
+input ComplexInput {
+  numberInt: Int
+  stringText: String
+}
+
+`;
+
+exports[`uses defaultValue when condition not specified 1`] = `
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of \`Pet\`."""
+  allPets(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`Pet\`."""
+    orderBy: [PetsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PetCondition = {}
+  ): PetsConnection
+
+  """Reads a set of \`Pet\`."""
+  allPetsList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Pet\`."""
+    orderBy: [PetsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PetCondition = {}
+  ): [Pet!]
+
+  """Reads and enables pagination through a set of \`User\`."""
+  allUsers(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`User\`."""
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition = {petCountAtLeast: 3}
+  ): UsersConnection
+
+  """Reads a set of \`User\`."""
+  allUsersList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`User\`."""
+    orderBy: [UsersOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition = {petCountAtLeast: 3}
+  ): [User!]
+  petById(id: Int!): Pet
+  userById(id: Int!): User
+
+  """Reads a single \`Pet\` using its globally unique \`ID\`."""
+  pet(
+    """The globally unique \`ID\` to be used in selecting a single \`Pet\`."""
+    nodeId: ID!
+  ): Pet
+
+  """Reads a single \`User\` using its globally unique \`ID\`."""
+  user(
+    """The globally unique \`ID\` to be used in selecting a single \`User\`."""
+    nodeId: ID!
+  ): User
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""A connection to a list of \`Pet\` values."""
+type PetsConnection {
+  """A list of \`Pet\` objects."""
+  nodes: [Pet]!
+
+  """
+  A list of edges which contains the \`Pet\` and cursor to aid in pagination.
+  """
+  edges: [PetsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Pet\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Pet implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  userId: Int!
+  name: String!
+  type: String!
+}
+
+"""A \`Pet\` edge in the connection."""
+type PetsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Pet\` at the end of the edge."""
+  node: Pet
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""Methods to use when ordering \`Pet\`."""
+enum PetsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  USER_ID_ASC
+  USER_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  TYPE_ASC
+  TYPE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against \`Pet\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PetCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`userId\` field."""
+  userId: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`type\` field."""
+  type: String
+}
+
+"""A connection to a list of \`User\` values."""
+type UsersConnection {
+  """A list of \`User\` objects."""
+  nodes: [User]!
+
+  """
+  A list of edges which contains the \`User\` and cursor to aid in pagination.
+  """
+  edges: [UsersEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`User\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type User implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+  email: String!
+  bio: String
+  renamedComplexColumn: [Complex]
+  createdAt: Datetime!
+}
+
+type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+"""
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+"""
+scalar Datetime
+
+"""A \`User\` edge in the connection."""
+type UsersEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`User\` at the end of the edge."""
+  node: User
+}
+
+"""Methods to use when ordering \`User\`."""
+enum UsersOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  BIO_ASC
+  BIO_DESC
+  RENAMED_COMPLEX_COLUMN_ASC
+  RENAMED_COMPLEX_COLUMN_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against \`User\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input UserCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`email\` field."""
+  email: String
+
+  """Checks for equality with the object’s \`bio\` field."""
+  bio: String
+
+  """Checks for equality with the object’s \`renamedComplexColumn\` field."""
+  renamedComplexColumn: [ComplexInput]
+
+  """Checks for equality with the object’s \`createdAt\` field."""
+  createdAt: Datetime
+
+  """Filters users to those that have at least this many pets"""
+  petCountAtLeast: Int = 3
 }
 
 """An input for mutations affecting \`Complex\`"""

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.inheritence.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.inheritence.test.js.snap
@@ -407,7 +407,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FileCondition
+    condition: FileCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -436,7 +436,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserFileCondition
+    condition: UserFileCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -465,7 +465,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserCondition
+    condition: UserCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -649,7 +649,7 @@ type User implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UserFileCondition
+    condition: UserFileCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -394,7 +394,7 @@ type CompoundKey implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5784,7 +5784,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5813,7 +5813,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5855,7 +5855,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5916,7 +5916,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5956,7 +5956,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5985,7 +5985,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6284,7 +6284,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6313,7 +6313,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6533,7 +6533,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6562,7 +6562,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6591,7 +6591,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6620,7 +6620,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6649,7 +6649,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6678,7 +6678,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6707,7 +6707,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6736,7 +6736,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6765,7 +6765,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NonUpdatableViewCondition
+    condition: NonUpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6794,7 +6794,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6823,7 +6823,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6852,7 +6852,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6881,7 +6881,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6910,7 +6910,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6939,7 +6939,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6968,7 +6968,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6997,7 +6997,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7026,7 +7026,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7055,7 +7055,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7084,7 +7084,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7113,7 +7113,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TestviewCondition
+    condition: TestviewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7142,7 +7142,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7171,7 +7171,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UpdatableViewCondition
+    condition: UpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7200,7 +7200,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7634,7 +7634,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10591,7 +10591,7 @@ type CompoundKey implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15981,7 +15981,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16010,7 +16010,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16052,7 +16052,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16113,7 +16113,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16153,7 +16153,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16182,7 +16182,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16481,7 +16481,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16510,7 +16510,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16730,7 +16730,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16759,7 +16759,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16788,7 +16788,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16817,7 +16817,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16846,7 +16846,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16875,7 +16875,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16904,7 +16904,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16933,7 +16933,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16962,7 +16962,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NonUpdatableViewCondition
+    condition: NonUpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -16991,7 +16991,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17020,7 +17020,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17049,7 +17049,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17078,7 +17078,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17107,7 +17107,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17136,7 +17136,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17165,7 +17165,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17194,7 +17194,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17223,7 +17223,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17252,7 +17252,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17281,7 +17281,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17310,7 +17310,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TestviewCondition
+    condition: TestviewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17339,7 +17339,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17368,7 +17368,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UpdatableViewCondition
+    condition: UpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17397,7 +17397,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -17831,7 +17831,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/disabledTagsNoLegacyRelations.test.js.snap
@@ -2874,7 +2874,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2903,7 +2903,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3247,7 +3247,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3276,7 +3276,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3305,7 +3305,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3334,7 +3334,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3363,7 +3363,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3392,7 +3392,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3421,7 +3421,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3450,7 +3450,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
@@ -466,7 +466,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LetterDescriptionCondition
+    condition: LetterDescriptionCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -495,7 +495,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReferencingTableCondition
+    condition: ReferencingTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/function-clash.test.js.snap
@@ -394,7 +394,7 @@ type CompoundKey implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5784,7 +5784,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5813,7 +5813,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5855,7 +5855,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5916,7 +5916,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5956,7 +5956,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5985,7 +5985,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6284,7 +6284,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6313,7 +6313,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6533,7 +6533,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6562,7 +6562,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6591,7 +6591,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6620,7 +6620,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6649,7 +6649,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6678,7 +6678,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6707,7 +6707,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6736,7 +6736,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6765,7 +6765,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NonUpdatableViewCondition
+    condition: NonUpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6794,7 +6794,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6823,7 +6823,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6852,7 +6852,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6881,7 +6881,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6910,7 +6910,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6939,7 +6939,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6968,7 +6968,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6997,7 +6997,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7026,7 +7026,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7055,7 +7055,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7084,7 +7084,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7113,7 +7113,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TestviewCondition
+    condition: TestviewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7142,7 +7142,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7171,7 +7171,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UpdatableViewCondition
+    condition: UpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7200,7 +7200,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7634,7 +7634,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/geometry.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/geometry.test.js.snap
@@ -372,7 +372,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: GeomCondition
+    condition: GeomCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/indexes.test.js.snap
@@ -249,7 +249,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EmployeeCondition
+    condition: EmployeeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -456,7 +456,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EmployeeCondition
+    condition: EmployeeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6109,7 +6109,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6183,7 +6183,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6223,7 +6223,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6252,7 +6252,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6519,7 +6519,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6548,7 +6548,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6748,7 +6748,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6777,7 +6777,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6854,7 +6854,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6883,7 +6883,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6912,7 +6912,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6941,7 +6941,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6994,7 +6994,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7023,7 +7023,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7052,7 +7052,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7081,7 +7081,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7110,7 +7110,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7139,7 +7139,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7168,7 +7168,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7197,7 +7197,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7226,7 +7226,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7255,7 +7255,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7284,7 +7284,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7337,7 +7337,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7390,7 +7390,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7824,7 +7824,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/inflect-core.test.js.snap
@@ -399,7 +399,7 @@ type CompoundKey implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5779,7 +5779,7 @@ type Person implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5808,7 +5808,7 @@ type Person implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5850,7 +5850,7 @@ type Person implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5911,7 +5911,7 @@ type Person implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5951,7 +5951,7 @@ type Person implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5980,7 +5980,7 @@ type Person implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6284,7 +6284,7 @@ type Post implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6313,7 +6313,7 @@ type Post implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6538,7 +6538,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6567,7 +6567,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6596,7 +6596,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6625,7 +6625,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6654,7 +6654,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6683,7 +6683,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6712,7 +6712,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6741,7 +6741,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6770,7 +6770,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NonUpdatableViewCondition
+    condition: NonUpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6799,7 +6799,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6828,7 +6828,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6857,7 +6857,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6886,7 +6886,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6915,7 +6915,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6944,7 +6944,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6973,7 +6973,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7002,7 +7002,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7031,7 +7031,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7060,7 +7060,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7089,7 +7089,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7118,7 +7118,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TestviewCondition
+    condition: TestviewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7147,7 +7147,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7176,7 +7176,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UpdatableViewCondition
+    condition: UpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7205,7 +7205,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7639,7 +7639,7 @@ type Q implements N {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/jwt.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/jwt.test.js.snap
@@ -906,7 +906,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -935,7 +935,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UpdatableViewCondition
+    condition: UpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyFunctionsOnly.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyFunctionsOnly.test.js.snap
@@ -2156,7 +2156,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2185,7 +2185,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2252,7 +2252,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2292,7 +2292,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2523,7 +2523,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2552,7 +2552,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2581,7 +2581,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2610,7 +2610,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2639,7 +2639,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2668,7 +2668,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2697,7 +2697,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2726,7 +2726,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2899,7 +2899,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/legacyRelationsOnlyLegacyJsonNoTags.test.js.snap
@@ -2874,7 +2874,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2903,7 +2903,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2979,7 +2979,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3019,7 +3019,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3299,7 +3299,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3328,7 +3328,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3357,7 +3357,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3386,7 +3386,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3415,7 +3415,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3444,7 +3444,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3473,7 +3473,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3502,7 +3502,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/network_types.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/network_types.test.js.snap
@@ -265,7 +265,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NetworkCondition
+    condition: NetworkCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -626,7 +626,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NetworkCondition
+    condition: NetworkCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/noDefaultMutations.test.js.snap
@@ -1804,7 +1804,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1833,7 +1833,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1907,7 +1907,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1947,7 +1947,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2148,7 +2148,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2177,7 +2177,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2206,7 +2206,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2235,7 +2235,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2264,7 +2264,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2293,7 +2293,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2322,7 +2322,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2351,7 +2351,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2663,7 +2663,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/omit-rename.omitcolumns.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/omit-rename.omitcolumns.test.js.snap
@@ -1048,7 +1048,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1208,7 +1208,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1237,7 +1237,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1266,7 +1266,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1295,7 +1295,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1324,7 +1324,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1353,7 +1353,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1382,7 +1382,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1554,7 +1554,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1743,7 +1743,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3230,7 +3230,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3390,7 +3390,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3419,7 +3419,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3448,7 +3448,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3477,7 +3477,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3506,7 +3506,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3535,7 +3535,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3564,7 +3564,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3736,7 +3736,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3925,7 +3925,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5414,7 +5414,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5574,7 +5574,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5603,7 +5603,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5632,7 +5632,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5661,7 +5661,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5690,7 +5690,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5719,7 +5719,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5748,7 +5748,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5920,7 +5920,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6100,7 +6100,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7582,7 +7582,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7742,7 +7742,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7771,7 +7771,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7800,7 +7800,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7829,7 +7829,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7858,7 +7858,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7887,7 +7887,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7916,7 +7916,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8088,7 +8088,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8275,7 +8275,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9764,7 +9764,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9924,7 +9924,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9953,7 +9953,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9982,7 +9982,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10011,7 +10011,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10040,7 +10040,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10069,7 +10069,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10098,7 +10098,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10270,7 +10270,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10458,7 +10458,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11945,7 +11945,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12105,7 +12105,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12134,7 +12134,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12163,7 +12163,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12192,7 +12192,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12221,7 +12221,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12250,7 +12250,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12279,7 +12279,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12451,7 +12451,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12640,7 +12640,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/omit-rename.omitstuff.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/omit-rename.omitstuff.test.js.snap
@@ -720,7 +720,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -880,7 +880,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -909,7 +909,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -938,7 +938,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -967,7 +967,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -996,7 +996,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2519,7 +2519,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2679,7 +2679,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2708,7 +2708,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2737,7 +2737,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2766,7 +2766,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2795,7 +2795,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2824,7 +2824,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2853,7 +2853,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3025,7 +3025,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3214,7 +3214,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4568,7 +4568,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4728,7 +4728,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4757,7 +4757,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4786,7 +4786,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4815,7 +4815,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4844,7 +4844,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4873,7 +4873,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4902,7 +4902,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5074,7 +5074,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5263,7 +5263,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6631,7 +6631,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6791,7 +6791,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6820,7 +6820,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6849,7 +6849,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6878,7 +6878,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6907,7 +6907,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6936,7 +6936,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6965,7 +6965,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7137,7 +7137,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7326,7 +7326,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8946,7 +8946,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8975,7 +8975,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9004,7 +9004,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9033,7 +9033,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9062,7 +9062,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9091,7 +9091,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9120,7 +9120,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10906,7 +10906,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11066,7 +11066,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11095,7 +11095,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11124,7 +11124,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11153,7 +11153,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11182,7 +11182,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11211,7 +11211,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11240,7 +11240,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11409,7 +11409,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -11595,7 +11595,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12875,7 +12875,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -13035,7 +13035,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -13064,7 +13064,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -13093,7 +13093,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -13122,7 +13122,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -13151,7 +13151,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -13180,7 +13180,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -13345,7 +13345,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -13534,7 +13534,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -14944,7 +14944,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15104,7 +15104,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15133,7 +15133,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15162,7 +15162,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15191,7 +15191,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15220,7 +15220,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15249,7 +15249,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15278,7 +15278,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15450,7 +15450,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -15639,7 +15639,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/omit-rename.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/omit-rename.test.js.snap
@@ -1048,7 +1048,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1208,7 +1208,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: FilmCondition
+    condition: FilmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1237,7 +1237,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1266,7 +1266,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1295,7 +1295,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: RenamedTableCondition
+    condition: RenamedTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1324,7 +1324,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StudioCondition
+    condition: StudioCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1353,7 +1353,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1382,7 +1382,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1554,7 +1554,7 @@ type Studio implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvShowCondition
+    condition: TvShowCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1743,7 +1743,7 @@ type TvShow implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TvEpisodeCondition
+    condition: TvEpisodeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pg11.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pg11.test.js.snap
@@ -894,7 +894,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: AlwaysAsIdentityCondition
+    condition: AlwaysAsIdentityCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -923,7 +923,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ByDefaultAsIdentityCondition
+    condition: ByDefaultAsIdentityCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -952,7 +952,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NetworkCondition
+    condition: NetworkCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -981,7 +981,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2271,7 +2271,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: AlwaysAsIdentityCondition
+    condition: AlwaysAsIdentityCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2300,7 +2300,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ByDefaultAsIdentityCondition
+    condition: ByDefaultAsIdentityCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2329,7 +2329,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NetworkCondition
+    condition: NetworkCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2358,7 +2358,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pgColumnFilter.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/pgColumnFilter.test.js.snap
@@ -2518,7 +2518,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2547,7 +2547,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2576,7 +2576,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2605,7 +2605,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NonUpdatableViewCondition
+    condition: NonUpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2634,7 +2634,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2663,7 +2663,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2692,7 +2692,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2721,7 +2721,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2750,7 +2750,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2779,7 +2779,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2808,7 +2808,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2837,7 +2837,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2866,7 +2866,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TestviewCondition
+    condition: TestviewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2895,7 +2895,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/rbac.test.js.snap
@@ -702,7 +702,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -742,7 +742,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -771,7 +771,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1010,7 +1010,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1039,7 +1039,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1068,7 +1068,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1097,7 +1097,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1721,7 +1721,7 @@ type CompoundKey implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7111,7 +7111,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7140,7 +7140,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7182,7 +7182,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7243,7 +7243,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7283,7 +7283,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7312,7 +7312,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7611,7 +7611,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7640,7 +7640,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7860,7 +7860,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7889,7 +7889,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7918,7 +7918,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7947,7 +7947,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7976,7 +7976,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8005,7 +8005,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8034,7 +8034,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8063,7 +8063,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8092,7 +8092,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NonUpdatableViewCondition
+    condition: NonUpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8121,7 +8121,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8150,7 +8150,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8179,7 +8179,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8208,7 +8208,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8237,7 +8237,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8266,7 +8266,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8295,7 +8295,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8324,7 +8324,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8353,7 +8353,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8382,7 +8382,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8411,7 +8411,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8440,7 +8440,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TestviewCondition
+    condition: TestviewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8469,7 +8469,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8498,7 +8498,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UpdatableViewCondition
+    condition: UpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8527,7 +8527,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8961,7 +8961,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/relay1.test.js.snap
@@ -2875,7 +2875,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2904,7 +2904,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2980,7 +2980,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3015,7 +3015,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3277,7 +3277,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3306,7 +3306,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3335,7 +3335,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3364,7 +3364,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3393,7 +3393,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3422,7 +3422,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3451,7 +3451,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3480,7 +3480,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3792,7 +3792,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simple-collections.test.js.snap
@@ -2879,7 +2879,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2902,7 +2902,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2925,7 +2925,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2948,7 +2948,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3028,7 +3028,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3068,7 +3068,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3336,7 +3336,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3359,7 +3359,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3382,7 +3382,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3405,7 +3405,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3428,7 +3428,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3451,7 +3451,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3474,7 +3474,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3497,7 +3497,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3520,7 +3520,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3543,7 +3543,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3566,7 +3566,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3589,7 +3589,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3612,7 +3612,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3635,7 +3635,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3658,7 +3658,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3681,7 +3681,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4064,7 +4064,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4087,7 +4087,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7183,7 +7183,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7200,7 +7200,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7453,7 +7453,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7470,7 +7470,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7487,7 +7487,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7504,7 +7504,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7521,7 +7521,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7538,7 +7538,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7555,7 +7555,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7572,7 +7572,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7764,7 +7764,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8708,7 +8708,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8814,7 +8814,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8837,7 +8837,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9344,7 +9344,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9482,7 +9482,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9511,7 +9511,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10036,7 +10036,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10168,7 +10168,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10197,7 +10197,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PetCondition
+    condition: PetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simplePrint.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/simplePrint.test.js.snap
@@ -46,7 +46,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
   ): DefaultValuesConnection
 
   """Reads and enables pagination through a set of \`ForeignKey\`."""
@@ -75,7 +75,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
   ): ForeignKeysConnection
 
   """Reads and enables pagination through a set of \`Input\`."""
@@ -104,7 +104,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
   ): InputsConnection
 
   """Reads and enables pagination through a set of \`NoPrimaryKey\`."""
@@ -133,7 +133,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
   ): NoPrimaryKeysConnection
 
   """Reads and enables pagination through a set of \`NonUpdatableView\`."""
@@ -162,7 +162,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NonUpdatableViewCondition
+    condition: NonUpdatableViewCondition = {}
   ): NonUpdatableViewsConnection
 
   """Reads and enables pagination through a set of \`Patch\`."""
@@ -191,7 +191,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
   ): PatchesConnection
 
   """Reads and enables pagination through a set of \`Post\`."""
@@ -220,7 +220,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
   ): PostsConnection
 
   """Reads and enables pagination through a set of \`Reserved\`."""
@@ -249,7 +249,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
   ): ReservedsConnection
 
   """Reads and enables pagination through a set of \`ReservedPatchRecord\`."""
@@ -278,7 +278,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
   ): ReservedPatchRecordsConnection
 
   """Reads and enables pagination through a set of \`ReservedInputRecord\`."""
@@ -307,7 +307,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
   ): ReservedInputRecordsConnection
 
   """Reads and enables pagination through a set of \`SimilarTable1\`."""
@@ -336,7 +336,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
   ): SimilarTable1SConnection
 
   """Reads and enables pagination through a set of \`SimilarTable2\`."""
@@ -365,7 +365,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
   ): SimilarTable2SConnection
 
   """Reads and enables pagination through a set of \`Testview\`."""
@@ -394,7 +394,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TestviewCondition
+    condition: TestviewCondition = {}
   ): TestviewsConnection
 
   """Reads and enables pagination through a set of \`ViewTable\`."""
@@ -423,7 +423,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
   ): ViewTablesConnection
 
   """Reads and enables pagination through a set of \`Type\`."""
@@ -452,7 +452,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
   ): TypesConnection
 
   """Reads and enables pagination through a set of \`UpdatableView\`."""
@@ -481,7 +481,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UpdatableViewCondition
+    condition: UpdatableViewCondition = {}
   ): UpdatableViewsConnection
 
   """Reads and enables pagination through a set of \`CompoundKey\`."""
@@ -510,7 +510,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
   ): CompoundKeysConnection
 
   """Reads and enables pagination through a set of \`EdgeCase\`."""
@@ -539,7 +539,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
   ): EdgeCasesConnection
 
   """Reads and enables pagination through a set of \`Issue756\`."""
@@ -568,7 +568,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
   ): Issue756SConnection
 
   """Reads and enables pagination through a set of \`LeftArm\`."""
@@ -597,7 +597,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
   ): LeftArmsConnection
 
   """Reads and enables pagination through a set of \`MyTable\`."""
@@ -626,7 +626,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
   ): MyTablesConnection
 
   """Reads and enables pagination through a set of \`NullTestRecord\`."""
@@ -655,7 +655,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
   ): NullTestRecordsConnection
 
   """Reads and enables pagination through a set of \`Person\`."""
@@ -684,7 +684,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
   ): PeopleConnection
 
   """Reads and enables pagination through a set of \`PersonSecret\`."""
@@ -713,7 +713,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
   ): PersonSecretsConnection @deprecated(reason: "This is deprecated (comment on table c.person_secret).")
   defaultValueById(id: Int!): DefaultValue
   inputById(id: Int!): Input
@@ -1059,7 +1059,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
   ): PeopleConnection
 
   """Reads and enables pagination through a set of \`Person\`."""
@@ -1373,7 +1373,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
   ): PersonSecretsConnection! @deprecated(reason: "This is deprecated (comment on table c.person_secret).")
 
   """Reads a single \`LeftArm\` that is related to this \`Person\`."""
@@ -1405,7 +1405,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
   ): LeftArmsConnection! @deprecated(reason: "Please use leftArmByPersonId instead")
 
   """Reads and enables pagination through a set of \`Post\`."""
@@ -1434,7 +1434,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
   ): PostsConnection!
 
   """Reads and enables pagination through a set of \`CompoundKey\`."""
@@ -1463,7 +1463,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
   ): CompoundKeysConnection!
 
   """Reads and enables pagination through a set of \`CompoundKey\`."""
@@ -1492,7 +1492,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
   ): CompoundKeysConnection!
 
   """Reads and enables pagination through a set of \`ForeignKey\`."""
@@ -1521,7 +1521,7 @@ type Person implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
   ): ForeignKeysConnection!
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
   computedFirstArgInout: Person
@@ -1799,7 +1799,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
   ): TypesConnection!
 
   """Reads a single \`Type\` that is related to this \`Post\`."""
@@ -1831,7 +1831,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
   ): TypesConnection! @deprecated(reason: "Please use typeById instead")
   computedCompoundTypeArray(object: CompoundTypeInput): [CompoundType]
   computedIntervalArray: [Interval]
@@ -2653,7 +2653,7 @@ type CompoundKey implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
   ): ForeignKeysConnection!
 
   """

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/skipNodePlugin.test.js.snap
@@ -394,7 +394,7 @@ type CompoundKey {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5180,7 +5180,7 @@ type Person {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5209,7 +5209,7 @@ type Person {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5251,7 +5251,7 @@ type Person {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5312,7 +5312,7 @@ type Person {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5347,7 +5347,7 @@ type Person {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5376,7 +5376,7 @@ type Person {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5665,7 +5665,7 @@ type Post {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5694,7 +5694,7 @@ type Post {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5914,7 +5914,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CompoundKeyCondition
+    condition: CompoundKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5943,7 +5943,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: DefaultValueCondition
+    condition: DefaultValueCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5972,7 +5972,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: EdgeCaseCondition
+    condition: EdgeCaseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6001,7 +6001,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ForeignKeyCondition
+    condition: ForeignKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6030,7 +6030,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: InputCondition
+    condition: InputCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6059,7 +6059,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: Issue756Condition
+    condition: Issue756Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6088,7 +6088,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: LeftArmCondition
+    condition: LeftArmCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6117,7 +6117,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MyTableCondition
+    condition: MyTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6146,7 +6146,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NonUpdatableViewCondition
+    condition: NonUpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6175,7 +6175,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NoPrimaryKeyCondition
+    condition: NoPrimaryKeyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6204,7 +6204,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: NullTestRecordCondition
+    condition: NullTestRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6233,7 +6233,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PatchCondition
+    condition: PatchCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6262,7 +6262,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6291,7 +6291,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonSecretCondition
+    condition: PersonSecretCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6320,7 +6320,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6349,7 +6349,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedInputRecordCondition
+    condition: ReservedInputRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6378,7 +6378,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedPatchRecordCondition
+    condition: ReservedPatchRecordCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6407,7 +6407,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ReservedCondition
+    condition: ReservedCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6436,7 +6436,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable1Condition
+    condition: SimilarTable1Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6465,7 +6465,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: SimilarTable2Condition
+    condition: SimilarTable2Condition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6494,7 +6494,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TestviewCondition
+    condition: TestviewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6523,7 +6523,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TypeCondition
+    condition: TypeCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6552,7 +6552,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: UpdatableViewCondition
+    condition: UpdatableViewCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6581,7 +6581,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: ViewTableCondition
+    condition: ViewTableCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6892,7 +6892,7 @@ type Query {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
+    condition: PersonCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/smart_comment_relations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/smart_comment_relations.test.js.snap
@@ -15,7 +15,7 @@ type Building implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1134,7 +1134,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1257,7 +1257,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1286,7 +1286,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1326,7 +1326,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1389,7 +1389,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1418,7 +1418,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1447,7 +1447,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1476,7 +1476,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1505,7 +1505,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1534,7 +1534,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1563,7 +1563,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetCondition
+    condition: StreetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1662,7 +1662,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1691,7 +1691,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1727,7 +1727,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1756,7 +1756,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -1856,7 +1856,7 @@ type StreetProperty implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -2334,7 +2334,7 @@ type Building implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3538,7 +3538,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3567,7 +3567,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3607,7 +3607,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3670,7 +3670,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3699,7 +3699,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3728,7 +3728,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3757,7 +3757,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3786,7 +3786,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3815,7 +3815,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3844,7 +3844,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetCondition
+    condition: StreetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3943,7 +3943,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -3972,7 +3972,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4008,7 +4008,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4037,7 +4037,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4137,7 +4137,7 @@ type StreetProperty implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -4612,7 +4612,7 @@ type Building implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5731,7 +5731,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5854,7 +5854,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5883,7 +5883,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5923,7 +5923,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -5986,7 +5986,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6015,7 +6015,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6044,7 +6044,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6073,7 +6073,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6102,7 +6102,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6131,7 +6131,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6160,7 +6160,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetCondition
+    condition: StreetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6259,7 +6259,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6288,7 +6288,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6324,7 +6324,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6353,7 +6353,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6453,7 +6453,7 @@ type StreetProperty implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -6931,7 +6931,7 @@ type Building implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -7965,7 +7965,7 @@ type Post {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8081,7 +8081,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8110,7 +8110,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8150,7 +8150,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8213,7 +8213,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8242,7 +8242,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8271,7 +8271,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8300,7 +8300,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8329,7 +8329,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8358,7 +8358,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8387,7 +8387,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetCondition
+    condition: StreetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8479,7 +8479,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8508,7 +8508,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8544,7 +8544,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8573,7 +8573,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -8673,7 +8673,7 @@ type StreetProperty implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -9094,7 +9094,7 @@ type Building implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10178,7 +10178,7 @@ type Post {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10299,7 +10299,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10328,7 +10328,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10368,7 +10368,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10431,7 +10431,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10460,7 +10460,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10489,7 +10489,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10518,7 +10518,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10547,7 +10547,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10576,7 +10576,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10605,7 +10605,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetCondition
+    condition: StreetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10698,7 +10698,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10727,7 +10727,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10763,7 +10763,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10792,7 +10792,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -10892,7 +10892,7 @@ type StreetProperty implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12430,7 +12430,7 @@ type Post implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12553,7 +12553,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12593,7 +12593,7 @@ type Property implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12656,7 +12656,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12685,7 +12685,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: HouseCondition
+    condition: HouseCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12714,7 +12714,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: OfferCondition
+    condition: OfferCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12743,7 +12743,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PostCondition
+    condition: PostCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12772,7 +12772,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12801,7 +12801,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12830,7 +12830,7 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetCondition
+    condition: StreetCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12932,7 +12932,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: BuildingCondition
+    condition: BuildingCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12968,7 +12968,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PropertyCondition
+    condition: PropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int
@@ -12997,7 +12997,7 @@ type Street implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: StreetPropertyCondition
+    condition: StreetPropertyCondition = {}
 
     """Only read the first \`n\` values of the set."""
     first: Int


### PR DESCRIPTION
## Description

Changes the `condition` argument so that it has a `defaultValue` of `{}` (but [coerced to a value respecting child defaultValues](https://github.com/graphql/graphql-js/issues/385#issuecomment-726741458)), this means that `defaultValue` inside of a `*Condition` will be respected.

## Performance impact

TBD.

## Security impact

None known.

## Status

On hold; needs more thought. See discussion: https://github.com/graphile/graphile-engine/issues/691