### PR TITLE
fix(graphql): ensure buildSchema fails on invalid GraphQL schema

### DIFF
--- a/packages/graphile-build/__tests__/invalid.test.js
+++ b/packages/graphile-build/__tests__/invalid.test.js
@@ -1,0 +1,41 @@
+const { buildSchema, defaultPlugins } = require("../");
+
+const InvalidSchemaPlugin = builder => {
+  builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
+    if (!context.scope.isRootQuery) {
+      return fields;
+    }
+    return build.extend(fields, {
+      invalidField: {
+        type: build.graphql.GraphQLInt,
+        args: {
+          invalidArgument: {
+            // Output types cannot be used as argument types
+            type: new build.graphql.GraphQLObjectType({
+              name: "OutputType",
+              fields: {
+                anything: {
+                  type: build.graphql.GraphQLInt,
+                },
+              },
+            }),
+          },
+        },
+      },
+    });
+  });
+};
+
+test("throws error on invalid schema", async () => {
+  let error;
+  try {
+    await buildSchema([...defaultPlugins, InvalidSchemaPlugin]);
+  } catch (err) {
+    error = err;
+  }
+  expect(error).toBeTruthy();
+  expect(error).toMatchInlineSnapshot(`
+    [Error: GraphQL schema is invalid:
+    - The type of Query.invalidField(invalidArgument:) must be Input Type but got: OutputType.]
+  `);
+});

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -488,13 +488,21 @@ class SchemaBuilder extends EventEmitter {
           isSchema: true,
         }
       );
-      this._generatedSchema = this.applyHooks(
+      const hookedSchema = this.applyHooks(
         build,
         "finalize",
         schema,
         {},
         "Finalising GraphQL schema"
       );
+      const errors = build.graphql.validateSchema(hookedSchema);
+      if (errors && errors.length) {
+        throw new Error(
+          "GraphQL schema is invalid:\n" +
+            errors.map(e => `- ` + e.message.replace(/\n/g, "\n  ")).join("\n")
+        );
+      }
+      this._generatedSchema = hookedSchema;
     }
     if (!this._generatedSchema) {
       throw new Error("Schema generation failed");


### PR DESCRIPTION
## Description

Apparently we never called `validateSchema` before...

## Performance impact

Small startup cost.

## Security impact

No invalid schemas were known (no other tests needed to change), however third party plugins (including user's own `makeExtendSchemaPlugin`) could have invalidated the schema and this would not have been previously prevented. So potentially this fixes security vulnerabilities, though none are known and I discovered this omission by accident.