### PR TITLE
feat(utils): makeExtendSchemaPlugin interfaces support

### DIFF
--- a/packages/graphile-build/src/SchemaBuilder.d.ts
+++ b/packages/graphile-build/src/SchemaBuilder.d.ts
@@ -14,6 +14,7 @@ import {
   GraphQLInputFieldConfigMap,
   GraphQLInputFieldConfig,
   GraphQLUnionTypeConfig,
+  GraphQLInterfaceTypeConfig,
 } from "graphql";
 import { EventEmitter } from "events";
 
@@ -178,6 +179,34 @@ export default class SchemaBuilder extends EventEmitter {
   hook(
     hookName: "GraphQLUnionType:types",
     fn: Hook<Array<GraphQLObjectType>>,
+    provides?: Array<string>,
+    before?: Array<string>,
+    after?: Array<string>
+  ): void;
+  hook<TSource, TContext>(
+    hookName: "GraphQLInterfaceType",
+    fn: Hook<GraphQLInterfaceTypeConfig<TSource, TContext>>,
+    provides?: Array<string>,
+    before?: Array<string>,
+    after?: Array<string>
+  ): void;
+  hook<TSource, TContext>(
+    hookName: "GraphQLInterfaceType:fields",
+    fn: Hook<GraphQLFieldConfigMap<TSource, TContext>>,
+    provides?: Array<string>,
+    before?: Array<string>,
+    after?: Array<string>
+  ): void;
+  hook<TSource, TContext>(
+    hookName: "GraphQLInterfaceType:fields:field",
+    fn: Hook<GraphQLFieldConfig<TSource, TContext>>,
+    provides?: Array<string>,
+    before?: Array<string>,
+    after?: Array<string>
+  ): void;
+  hook(
+    hookName: "GraphQLInterfaceType:fields:field:args",
+    fn: Hook<GraphQLFieldConfigArgumentMap>,
     provides?: Array<string>,
     before?: Array<string>,
     after?: Array<string>

--- a/packages/graphile-build/src/SchemaBuilder.js
+++ b/packages/graphile-build/src/SchemaBuilder.js
@@ -231,6 +231,19 @@ class SchemaBuilder extends EventEmitter {
       // - 'GraphQLUnionType:types' to add additional types to this union
       GraphQLUnionType: [],
       "GraphQLUnionType:types": [],
+
+      // When creating a GraphQLInterfaceType via `newWithHooks`, we'll
+      // execute, the following hooks:
+      // - 'GraphQLInterfaceType' to add any root-level attributes, e.g. add a description
+      // - 'GraphQLInterfaceType:fields' to add additional fields to this interface type (is
+      //   ran asynchronously and gets a reference to the final GraphQL Interface as
+      //   `Self` in the context)
+      // - 'GraphQLInterfaceType:fields:field' to customise an individual field from above
+      // - 'GraphQLInterfaceType:fields:field:args' to customize the arguments to a field
+      GraphQLInterfaceType: [],
+      "GraphQLInterfaceType:fields": [],
+      "GraphQLInterfaceType:fields:field": [],
+      "GraphQLInterfaceType:fields:field:args": [],
     };
   }
 

--- a/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
+++ b/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
@@ -822,17 +822,27 @@ it("supports interfaces and unions", async () => {
           abc: [ABC!]
           named: [Named!]
         }
+
+        extend interface Named {
+          nameLanguage: String
+        }
+        extend type A {
+          nameLanguage: String
+        }
+        extend type B {
+          nameLanguage: String
+        }
       `,
       resolvers: {
         Query: {
           abc: () => [
-            { name: "A-one", a: 1 },
-            { name: "B-two", b: 2 },
+            { name: "A-one", a: 1, nameLanguage: "en" },
+            { name: "B-two", b: 2, nameLanguage: "en" },
             { c: 3 },
           ],
           named: () => [
-            { name: "A-one", a: 1 },
-            { name: "B-two", b: 2 },
+            { name: "A-one", a: 1, nameLanguage: "en" },
+            { name: "B-two", b: 2, nameLanguage: "en" },
           ],
         },
         ABC: {
@@ -862,10 +872,12 @@ it("supports interfaces and unions", async () => {
           __typename
           ... on A {
             name
+            nameLanguage
             a
           }
           ... on B {
             name
+            nameLanguage
             b
           }
           ... on C {
@@ -875,6 +887,7 @@ it("supports interfaces and unions", async () => {
         named {
           __typename
           name
+          nameLanguage
           ... on A {
             a
           }

--- a/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
+++ b/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
@@ -795,3 +795,96 @@ it("supports defining a simple subscription", async () => {
   expect(done).toBeTruthy();
   expect(value).toBe(undefined);
 });
+
+it("supports interfaces and unions", async () => {
+  const schema = await buildSchema([
+    ...simplePlugins,
+    makeExtendSchemaPlugin(_build => ({
+      typeDefs: gql`
+        interface Named {
+          name: String!
+        }
+
+        type A implements Named {
+          name: String!
+          a: Int!
+        }
+        type B implements Named {
+          name(suffix: String): String!
+          b: Int!
+        }
+        type C {
+          c: Int!
+        }
+
+        union ABC = A | B | C
+        extend type Query {
+          abc: [ABC!]
+          named: [Named!]
+        }
+      `,
+      resolvers: {
+        Query: {
+          abc: () => [
+            { name: "A-one", a: 1 },
+            { name: "B-two", b: 2 },
+            { c: 3 },
+          ],
+          named: () => [
+            { name: "A-one", a: 1 },
+            { name: "B-two", b: 2 },
+          ],
+        },
+        ABC: {
+          __resolveType(obj) {
+            if (obj.a != null) return "A";
+            if (obj.b != null) return "B";
+            if (obj.c != null) return "C";
+            return null;
+          },
+        },
+        Named: {
+          __resolveType(obj) {
+            if (obj.a != null) return "A";
+            if (obj.b != null) return "B";
+            return null;
+          },
+        },
+      },
+    })),
+  ]);
+  expect(schema).toMatchSnapshot();
+  const { data, errors } = await graphql(
+    schema,
+    `
+      query {
+        abc {
+          __typename
+          ... on A {
+            name
+            a
+          }
+          ... on B {
+            name
+            b
+          }
+          ... on C {
+            c
+          }
+        }
+        named {
+          __typename
+          name
+          ... on A {
+            a
+          }
+          ... on B {
+            b
+          }
+        }
+      }
+    `
+  );
+  expect(errors).toBeFalsy();
+  expect(data).toMatchSnapshot();
+});

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -393,3 +393,70 @@ Object {
   },
 }
 `;
+
+exports[`supports interfaces and unions 1`] = `
+"""The root query type which gives access points into the data universe."""
+type Query {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+  abc: [ABC!]
+  named: [Named!]
+}
+
+union ABC = A | B | C
+
+type A implements Named {
+  name: String!
+  a: Int!
+}
+
+interface Named {
+  name: String!
+}
+
+type B implements Named {
+  name(suffix: String): String!
+  b: Int!
+}
+
+type C {
+  c: Int!
+}
+
+`;
+
+exports[`supports interfaces and unions 2`] = `
+Object {
+  "abc": Array [
+    Object {
+      "__typename": "A",
+      "a": 1,
+      "name": "A-one",
+    },
+    Object {
+      "__typename": "B",
+      "b": 2,
+      "name": "B-two",
+    },
+    Object {
+      "__typename": "C",
+      "c": 3,
+    },
+  ],
+  "named": Array [
+    Object {
+      "__typename": "A",
+      "a": 1,
+      "name": "A-one",
+    },
+    Object {
+      "__typename": "B",
+      "b": 2,
+      "name": "B-two",
+    },
+  ],
+}
+`;

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -411,15 +411,18 @@ union ABC = A | B | C
 type A implements Named {
   name: String!
   a: Int!
+  nameLanguage: String
 }
 
 interface Named {
   name: String!
+  nameLanguage: String
 }
 
 type B implements Named {
   name(suffix: String): String!
   b: Int!
+  nameLanguage: String
 }
 
 type C {
@@ -435,11 +438,13 @@ Object {
       "__typename": "A",
       "a": 1,
       "name": "A-one",
+      "nameLanguage": "en",
     },
     Object {
       "__typename": "B",
       "b": 2,
       "name": "B-two",
+      "nameLanguage": "en",
     },
     Object {
       "__typename": "C",
@@ -451,11 +456,13 @@ Object {
       "__typename": "A",
       "a": 1,
       "name": "A-one",
+      "nameLanguage": "en",
     },
     Object {
       "__typename": "B",
       "b": 2,
       "name": "B-two",
+      "nameLanguage": "en",
     },
   ],
 }

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -36,9 +36,10 @@ import {
   GraphQLList,
   GraphQLEnumType,
   GraphQLDirective,
+  InputObjectTypeExtensionNode,
+  InterfaceTypeExtensionNode,
 } from "graphql";
 import { GraphileEmbed } from "./gql";
-import { InputObjectTypeExtensionNode } from "graphql/language/ast";
 
 import { GraphileHelpers, makeFieldHelpers } from "./fieldHelpers";
 

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -545,7 +545,6 @@ export default function makeExtendSchemaPlugin(
         const {
           extend,
           [`ExtendSchemaPlugin_${uniqueId}_typeExtensions`]: typeExtensions,
-          [`ExtendSchemaPlugin_${uniqueId}_resolvers`]: resolvers,
         } = build;
         const { Self } = context;
         if (typeExtensions.GraphQLInterfaceType[Self.name]) {


### PR DESCRIPTION
## Description

Adds support for defining interfaces via makeExtendSchemaPlugin. Note that this _still does not add planning support for interfaces or unions_, so interfaces are only supported as the entrypoint, or on the leaves, and are not supported in the middle of the GraphQL request (i.e. they cannot be converted to SQL).

Fixes #238 (again).

## Performance impact

Minor, build-time only.

## Security impact

None known.
