### PR TITLE
feat(enum): enum views

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -466,6 +466,165 @@ function smartCommentConstraints(introspectionResults) {
   });
 }
 
+function isEnumConstraint(
+  klass: PgClass,
+  con: PgConstraint,
+  isEnumTable: boolean
+) {
+  if (con.classId === klass.id) {
+    const isPrimaryKey = con.type === "p";
+    const isUniqueConstraint = con.type === "u";
+    if (isPrimaryKey || isUniqueConstraint) {
+      const isExplicitEnumConstraint =
+        con.tags.enum === true || typeof con.tags.enum === "string";
+      const isPrimaryKeyOfEnumTableConstraint = con.type === "p" && isEnumTable;
+      if (isExplicitEnumConstraint || isPrimaryKeyOfEnumTableConstraint) {
+        const hasExactlyOneColumn = con.keyAttributeNums.length === 1;
+        if (!hasExactlyOneColumn) {
+          throw new Error(
+            `Enum table "${klass.namespaceName}"."${klass.name}" enum constraint '${con.name}' is composite; it should have exactly one column (found: ${con.keyAttributeNums.length})`
+          );
+        }
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function enumTables(introspectionResults) {
+  introspectionResults.class.map(async klass => {
+    const isEnumTable =
+      klass.tags.enum === true || typeof klass.tags.enum === "string";
+
+    if (isEnumTable) {
+      // Prevent the table being recognised as a table
+      // eslint-disable-next-line require-atomic-updates
+      klass.tags.omit = true;
+      // eslint-disable-next-line require-atomic-updates
+      klass.isSelectable = false;
+      // eslint-disable-next-line require-atomic-updates
+      klass.isInsertable = false;
+      // eslint-disable-next-line require-atomic-updates
+      klass.isUpdatable = false;
+      // eslint-disable-next-line require-atomic-updates
+      klass.isDeletable = false;
+    }
+
+    // By this point, even views should have "fake" constraints we can use
+    // (e.g. `@primaryKey`)
+    const enumConstraints = introspectionResults.constraint.filter(con =>
+      isEnumConstraint(klass, con, isEnumTable)
+    );
+
+    // Get all the columns
+    const enumTableColumns = introspectionResults.attribute.filter(
+      attr => attr.classId === klass.id
+    );
+
+    // Get description column
+    const descriptionColumn = enumTableColumns.find(
+      attr => attr.name === "description" || attr.tags.enumDescription
+    );
+    const allData = klass.fakeEnumData;
+
+    enumConstraints.forEach(constraint => {
+      const col = enumTableColumns.find(
+        col => col.num === constraint.keyAttributeNums[0]
+      );
+      if (!col) {
+        // Should never happen
+        throw new Error(
+          "Graphile Engine error - could not find column for enum constraint"
+        );
+      }
+      const data = allData.filter(row => row[col.name] != null);
+      if (data.length < 1) {
+        throw new Error(
+          `Enum table "${klass.namespaceName}"."${klass.name}" contains no entries for enum constraint '${constraint.name}'.`
+        );
+      }
+
+      // Create fake enum type
+      const constraintIdent =
+        constraint.type === "p" ? "" : `_${constraint.name}`;
+      const enumTypeArray = {
+        kind: "type",
+        isFake: true,
+        id: `FAKE_ENUM_${klass.namespaceName}_${klass.name}${constraintIdent}_list`,
+        name: `_${klass.name}${constraintIdent}`,
+        description: null,
+        tags: {},
+        namespaceId: klass.namespaceId,
+        namespaceName: klass.namespaceName,
+        type: "b",
+        category: "A",
+        domainIsNotNull: null,
+        arrayItemTypeId: null,
+        typeLength: -1,
+        isPgArray: true,
+        classId: null,
+        domainBaseTypeId: null,
+        domainTypeModifier: null,
+        domainHasDefault: false,
+        enumVariants: null,
+        enumDescriptions: null,
+        rangeSubTypeId: null,
+      };
+      const enumType = {
+        kind: "type",
+        isFake: true,
+        id: `FAKE_ENUM_${klass.namespaceName}_${klass.name}${constraintIdent}`,
+        name: `${klass.name}${constraintIdent}`,
+        description: klass.description,
+        tags: { ...klass.tags, ...constraint.tags },
+        namespaceId: klass.namespaceId,
+        namespaceName: klass.namespaceName,
+        type: "e",
+        category: "E",
+        domainIsNotNull: null,
+        arrayItemTypeId: enumTypeArray.id,
+        typeLength: 4, // ???
+        isPgArray: false,
+        classId: null,
+        domainBaseTypeId: null,
+        domainTypeModifier: null,
+        domainHasDefault: false,
+        enumVariants: data.map(r => r[col.name]),
+        enumDescriptions: descriptionColumn
+          ? data.map(r => r[descriptionColumn.name])
+          : null,
+        // TODO: enumDescriptions
+        rangeSubTypeId: null,
+      };
+      introspectionResults.type.push(enumType, enumTypeArray);
+      introspectionResults.typeById[enumType.id] = enumType;
+      introspectionResults.typeById[enumTypeArray.id] = enumTypeArray;
+
+      // Change type of all attributes that reference this table to
+      // reference this enum type
+      introspectionResults.constraint.forEach(c => {
+        if (
+          c.type === "f" &&
+          c.foreignClassId === klass.id &&
+          c.foreignKeyAttributeNums.length === 1 &&
+          c.foreignKeyAttributeNums[0] === col.num
+        ) {
+          // Get the attribute
+          const fkattr = introspectionResults.attribute.find(
+            attr =>
+              attr.classId === c.classId && attr.num === c.keyAttributeNums[0]
+          );
+          if (fkattr) {
+            // Override the detected type to pretend to be our enum
+            fkattr.typeId = enumType.id;
+          }
+        }
+      });
+    });
+  });
+}
+
 /* The argument to this must not contain cyclic references! */
 const deepClone = value => {
   if (Array.isArray(value)) {
@@ -571,108 +730,46 @@ export default (async function PgIntrospectionPlugin(
               extensionConfigurationClassIds.indexOf(klass.id) >= 0;
           });
 
+          // Assert the columns are text
+          const VARCHAR_ID = "1043";
+          const TEXT_ID = "25";
+          const CHAR_ID = "18";
+          const BPCHAR_ID = "1042";
+
+          const VALID_TYPE_IDS = [VARCHAR_ID, TEXT_ID, CHAR_ID, BPCHAR_ID];
+
           await Promise.all(
             result.class.map(async klass => {
+              if (!schemas.includes(klass.namespaceName)) {
+                // Only support enums in public tables/views
+                return;
+              }
               const isEnumTable =
                 klass.tags.enum === true || typeof klass.tags.enum === "string";
 
-              if (isEnumTable) {
-                // Prevent the table being recognised as a table
-                // eslint-disable-next-line require-atomic-updates
-                klass.tags.omit = true;
-                // eslint-disable-next-line require-atomic-updates
-                klass.isSelectable = false;
-                // eslint-disable-next-line require-atomic-updates
-                klass.isInsertable = false;
-                // eslint-disable-next-line require-atomic-updates
-                klass.isUpdatable = false;
-                // eslint-disable-next-line require-atomic-updates
-                klass.isDeletable = false;
-              }
-
-              const enumConstraints = result.constraint.filter(
-                (con: PgConstraint) => {
-                  if (con.classId === klass.id) {
-                    const isPrimaryKey = con.type === "p";
-                    const isUniqueConstraint = con.type === "u";
-                    if (isPrimaryKey || isUniqueConstraint) {
-                      const isExplicitEnumConstraint =
-                        con.tags.enum === true ||
-                        typeof con.tags.enum === "string";
-                      const isPrimaryKeyOfEnumTableConstraint =
-                        con.type === "p" && isEnumTable;
-                      if (
-                        isExplicitEnumConstraint ||
-                        isPrimaryKeyOfEnumTableConstraint
-                      ) {
-                        const hasExactlyOneColumn =
-                          con.keyAttributeNums.length === 1;
-                        if (!hasExactlyOneColumn) {
-                          throw new Error(
-                            `Enum table "${klass.namespaceName}"."${klass.name}" enum constraint '${con.name}' is composite; it should have exactly one column (found: ${con.keyAttributeNums.length})`
-                          );
-                        }
-                        return true;
-                      }
-                    }
-                  }
-                  return false;
-                }
+              // NOTE: this only matches on tables (not views, since they don't
+              // have constraints), which is why we repeat the isEnumTable check below.
+              const hasEnumConstraints = result.constraint.some(con =>
+                isEnumConstraint(klass, con, isEnumTable)
               );
-              if (enumConstraints.length > 0) {
-                // Get all the columns
+              if (isEnumTable || hasEnumConstraints) {
+                // Get the list of columns enums are defined for
                 const enumTableColumns = result.attribute
-                  .filter(attr => attr.classId === klass.id)
+                  .filter(
+                    attr =>
+                      attr.classId === klass.id &&
+                      VALID_TYPE_IDS.includes(attr.typeId)
+                  )
                   .sort((a, z) => a.num - z.num);
 
-                // Get description column
-                const descriptionColumn = enumTableColumns.find(
-                  attr =>
-                    attr.name === "description" || attr.tags.enumDescription
-                );
-
-                // Assert the columns are text
-                const VARCHAR_ID = "1043";
-                const TEXT_ID = "25";
-                const CHAR_ID = "18";
-                const BPCHAR_ID = "1042";
-
-                // Get the list of columns enums are defined for
-                const enumColumns = enumConstraints.map(con => {
-                  const attr = enumTableColumns.find(
-                    attr => attr.num === con.keyAttributeNums[0]
-                  );
-                  if (!attr) {
-                    throw new Error(
-                      `Enum table "${klass.namespaceName}"."${klass.name}" enum column '${con.keyAttributeNums[0]}' couldn't be found`
-                    );
-                  }
-                  if (
-                    attr.typeId !== VARCHAR_ID &&
-                    attr.typeId !== TEXT_ID &&
-                    attr.typeId !== CHAR_ID &&
-                    attr.typeId !== BPCHAR_ID
-                  ) {
-                    throw new Error(
-                      `Enum table "${klass.namespaceName}"."${klass.name}" enum column '${attr.name}' must be 'text', 'char' or 'varchar' (actual type OID: ${attr.typeId})`
-                    );
-                  }
-                  return attr;
-                });
-
-                // Load data from the table.
+                // Load data from the table/view.
                 const query = pgSql.compile(
                   pgSql.fragment`select ${pgSql.join(
-                    enumColumns.map(col => pgSql.identifier(col.name)),
+                    enumTableColumns.map(col => pgSql.identifier(col.name)),
                     ", "
-                  )}${
-                    descriptionColumn
-                      ? pgSql.fragment`, ${pgSql.identifier(
-                          descriptionColumn.name
-                        )}`
-                      : pgSql.blank
-                  } from ${pgSql.identifier(klass.namespaceName, klass.name)};`
+                  )} from ${pgSql.identifier(klass.namespaceName, klass.name)};`
                 );
+
                 let allData;
                 try {
                   ({ rows: allData } = await pgClient.query(query));
@@ -684,7 +781,10 @@ export default (async function PgIntrospectionPlugin(
                     } = await pgClient.query("select user;");
                     role = user;
                   } catch (e) {
-                    /* ignore */
+                    /*
+                     * Ignore; this is likely a 25P02 (transaction aborted)
+                     * error caused by the statement above failing.
+                     */
                   }
                   throw new Error(`Introspection could not read from enum table "${klass.namespaceName}"."${klass.name}", perhaps you need to grant access:
 
@@ -695,100 +795,7 @@ Original error: ${e.message}
 `);
                 }
 
-                // Assert there's at least one value
-                enumConstraints.forEach(constraint => {
-                  const col = enumColumns.find(
-                    col => col.num === constraint.keyAttributeNums[0]
-                  );
-                  if (!col) {
-                    // Should never happen
-                    throw new Error(
-                      "Graphile Engine error - could not find column for enum constraint"
-                    );
-                  }
-                  const data = allData.filter(row => row[col.name] != null);
-                  if (data.length < 1) {
-                    throw new Error(
-                      `Enum table "${klass.namespaceName}"."${klass.name}" contains no entries for enum constraint '${constraint.name}'.`
-                    );
-                  }
-
-                  // Create fake enum type
-                  const constraintIdent =
-                    constraint.type === "p" ? "" : `_${constraint.name}`;
-                  const enumTypeArray = {
-                    kind: "type",
-                    isFake: true,
-                    id: `FAKE_ENUM_${klass.namespaceName}_${klass.name}${constraintIdent}_list`,
-                    name: `_${klass.name}${constraintIdent}`,
-                    description: null,
-                    tags: {},
-                    namespaceId: klass.namespaceId,
-                    namespaceName: klass.namespaceName,
-                    type: "b",
-                    category: "A",
-                    domainIsNotNull: null,
-                    arrayItemTypeId: null,
-                    typeLength: -1,
-                    isPgArray: true,
-                    classId: null,
-                    domainBaseTypeId: null,
-                    domainTypeModifier: null,
-                    domainHasDefault: false,
-                    enumVariants: null,
-                    enumDescriptions: null,
-                    rangeSubTypeId: null,
-                  };
-                  const enumType = {
-                    kind: "type",
-                    isFake: true,
-                    id: `FAKE_ENUM_${klass.namespaceName}_${klass.name}${constraintIdent}`,
-                    name: `${klass.name}${constraintIdent}`,
-                    description: klass.description,
-                    tags: { ...klass.tags, ...constraint.tags },
-                    namespaceId: klass.namespaceId,
-                    namespaceName: klass.namespaceName,
-                    type: "e",
-                    category: "E",
-                    domainIsNotNull: null,
-                    arrayItemTypeId: enumTypeArray.id,
-                    typeLength: 4, // ???
-                    isPgArray: false,
-                    classId: null,
-                    domainBaseTypeId: null,
-                    domainTypeModifier: null,
-                    domainHasDefault: false,
-                    enumVariants: data.map(r => r[col.name]),
-                    enumDescriptions: descriptionColumn
-                      ? data.map(r => r[descriptionColumn.name])
-                      : null,
-                    // TODO: enumDescriptions
-                    rangeSubTypeId: null,
-                  };
-                  result.type.push(enumType, enumTypeArray);
-
-                  // Change type of all attributes that reference this table to
-                  // reference this enum type
-                  result.constraint.forEach(c => {
-                    if (
-                      c.type === "f" &&
-                      c.foreignClassId === klass.id &&
-                      c.foreignKeyAttributeNums.length === 1 &&
-                      c.foreignKeyAttributeNums[0] === col.num
-                    ) {
-                      // Get the attribute
-                      const fkattr = result.attribute.find(
-                        attr =>
-                          attr.classId === c.classId &&
-                          attr.num === c.keyAttributeNums[0]
-                      );
-                      if (fkattr) {
-                        // Override the detected type to pretend to be our enum
-                        fkattr.typeId = enumType.id;
-                      }
-                    }
-                  });
-                });
+                klass.fakeEnumData = allData;
               }
             })
           );
@@ -894,7 +901,7 @@ Original error: ${e.message}
               return;
             }
             throw new Error(
-              `Could not look up '${newAttr}' by '${lookupAttr}' on '${JSON.stringify(
+              `Could not look up '${newAttr}' by '${lookupAttr}' (= '${key}') on '${JSON.stringify(
                 entry
               )}'`
             );
@@ -905,9 +912,11 @@ Original error: ${e.message}
     };
 
     const augment = introspectionResults => {
-      [pgAugmentIntrospectionResults, smartCommentConstraints].forEach(fn =>
-        fn ? fn(introspectionResults) : null
-      );
+      [
+        pgAugmentIntrospectionResults,
+        smartCommentConstraints,
+        enumTables,
+      ].forEach(fn => (fn ? fn(introspectionResults) : null));
     };
     augment(introspectionResultsByKind);
 

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -81,6 +81,9 @@ export type PgClass = {
   aclUpdatable: boolean,
   aclDeletable: boolean,
   canUseAsterisk: boolean,
+
+  // eslint-disable-next-line flowtype/no-weak-types
+  _internalEnumData?: any[], // This is Graphile internal, do not use this.
 };
 
 export type PgType = {
@@ -526,7 +529,7 @@ function enumTables(introspectionResults) {
     const descriptionColumn = enumTableColumns.find(
       attr => attr.name === "description" || attr.tags.enumDescription
     );
-    const allData = klass.fakeEnumData;
+    const allData = klass._internalEnumData || [];
 
     enumConstraints.forEach(constraint => {
       const col = enumTableColumns.find(
@@ -795,7 +798,7 @@ Original error: ${e.message}
 `);
                 }
 
-                klass.fakeEnumData = allData;
+                klass._internalEnumData = allData;
               }
             })
           );

--- a/packages/postgraphile-core/__tests__/fixtures/mutations/enum_tables.mutations.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/mutations/enum_tables.mutations.graphql
@@ -3,12 +3,14 @@ mutation {
     letterDescription {
       id
       letter
+      letterViaView
     }
   }
   createLetterDescription(
     input: {
       letterDescription: {
         letter: C
+        letterViaView: C
         description: "One does like to see the letter C"
       }
     }
@@ -16,6 +18,7 @@ mutation {
     letterDescription {
       id
       letter
+      letterViaView
       description
     }
   }

--- a/packages/postgraphile-core/__tests__/fixtures/queries/enum_tables.queries.graphql
+++ b/packages/postgraphile-core/__tests__/fixtures/queries/enum_tables.queries.graphql
@@ -3,6 +3,7 @@
     nodes {
       id
       letter
+      letterViaView
       description
     }
   }
@@ -10,18 +11,43 @@
     nodes {
       id
       letter
+      letterViaView
+      description
+    }
+  }
+  reverseView: allLetterDescriptions(orderBy: [LETTER_VIA_VIEW_DESC]) {
+    nodes {
+      id
+      letter
+      letterViaView
       description
     }
   }
   b: letterDescriptionByLetter(letter: B) {
     id
     letter
+    letterViaView
+    description
+  }
+  bView: letterDescriptionByLetterViaView(letterViaView: B) {
+    id
+    letter
+    letterViaView
     description
   }
   letterC: allLetterDescriptions(condition: { letter: C }) {
     nodes {
       id
       letter
+      letterViaView
+      description
+    }
+  }
+  letterCView: allLetterDescriptions(condition: { letterViaView: C }) {
+    nodes {
+      id
+      letter
+      letterViaView
       description
     }
   }

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/mutations.test.js.snap
@@ -68,12 +68,14 @@ Object {
         "description": "One does like to see the letter C",
         "id": 105,
         "letter": "C",
+        "letterViaView": "C",
       },
     },
     "deleteLetterDescriptionByLetter": Object {
       "letterDescription": Object {
         "id": 103,
         "letter": "C",
+        "letterViaView": "C",
       },
     },
     "referencingTableMutation": Object {

--- a/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -1581,21 +1581,25 @@ Object {
           "description": "The first letter in the alphabet",
           "id": 101,
           "letter": "A",
+          "letterViaView": "A",
         },
         Object {
           "description": "Following closely behind the first letter, this is a popular choice",
           "id": 102,
           "letter": "B",
+          "letterViaView": "B",
         },
         Object {
           "description": "Pronounced like 'sea'",
           "id": 103,
           "letter": "C",
+          "letterViaView": "C",
         },
         Object {
           "description": "The first letter omitted from the 'ABC' phrase",
           "id": 104,
           "letter": "D",
+          "letterViaView": "D",
         },
       ],
     },
@@ -1603,6 +1607,13 @@ Object {
       "description": "Following closely behind the first letter, this is a popular choice",
       "id": 102,
       "letter": "B",
+      "letterViaView": "B",
+    },
+    "bView": Object {
+      "description": "Following closely behind the first letter, this is a popular choice",
+      "id": 102,
+      "letter": "B",
+      "letterViaView": "B",
     },
     "letterC": Object {
       "nodes": Array [
@@ -1610,6 +1621,17 @@ Object {
           "description": "Pronounced like 'sea'",
           "id": 103,
           "letter": "C",
+          "letterViaView": "C",
+        },
+      ],
+    },
+    "letterCView": Object {
+      "nodes": Array [
+        Object {
+          "description": "Pronounced like 'sea'",
+          "id": 103,
+          "letter": "C",
+          "letterViaView": "C",
         },
       ],
     },
@@ -1619,21 +1641,53 @@ Object {
           "description": "The first letter omitted from the 'ABC' phrase",
           "id": 104,
           "letter": "D",
+          "letterViaView": "D",
         },
         Object {
           "description": "Pronounced like 'sea'",
           "id": 103,
           "letter": "C",
+          "letterViaView": "C",
         },
         Object {
           "description": "Following closely behind the first letter, this is a popular choice",
           "id": 102,
           "letter": "B",
+          "letterViaView": "B",
         },
         Object {
           "description": "The first letter in the alphabet",
           "id": 101,
           "letter": "A",
+          "letterViaView": "A",
+        },
+      ],
+    },
+    "reverseView": Object {
+      "nodes": Array [
+        Object {
+          "description": "The first letter omitted from the 'ABC' phrase",
+          "id": 104,
+          "letter": "D",
+          "letterViaView": "D",
+        },
+        Object {
+          "description": "Pronounced like 'sea'",
+          "id": 103,
+          "letter": "C",
+          "letterViaView": "C",
+        },
+        Object {
+          "description": "Following closely behind the first letter, this is a popular choice",
+          "id": 102,
+          "letter": "B",
+          "letterViaView": "B",
+        },
+        Object {
+          "description": "The first letter in the alphabet",
+          "id": 101,
+          "letter": "A",
+          "letterViaView": "A",
         },
       ],
     },

--- a/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
+++ b/packages/postgraphile-core/__tests__/integration/schema/__snapshots__/enum_tables.test.js.snap
@@ -94,6 +94,16 @@ input DeleteLetterDescriptionByLetterInput {
   letter: LetterAToD!
 }
 
+"""All input for the \`deleteLetterDescriptionByLetterViaView\` mutation."""
+input DeleteLetterDescriptionByLetterViaViewInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  letterViaView: LetterAToDViaView!
+}
+
 """All input for the \`deleteLetterDescription\` mutation."""
 input DeleteLetterDescriptionInput {
   """
@@ -222,10 +232,25 @@ enum LetterAToD {
   D
 }
 
+enum LetterAToDViaView {
+  """The letter A"""
+  A
+
+  """The letter B"""
+  B
+
+  """The letter C"""
+  C
+
+  """The letter D"""
+  D
+}
+
 type LetterDescription implements Node {
   description: String
   id: Int!
   letter: LetterAToD!
+  letterViaView: LetterAToDViaView!
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
@@ -246,6 +271,9 @@ input LetterDescriptionCondition {
 
   """Checks for equality with the object’s \`letter\` field."""
   letter: LetterAToD
+
+  """Checks for equality with the object’s \`letterViaView\` field."""
+  letterViaView: LetterAToDViaView
 }
 
 """An input for mutations affecting \`LetterDescription\`"""
@@ -253,6 +281,7 @@ input LetterDescriptionInput {
   description: String
   id: Int
   letter: LetterAToD!
+  letterViaView: LetterAToDViaView!
 }
 
 """
@@ -262,6 +291,7 @@ input LetterDescriptionPatch {
   description: String
   id: Int
   letter: LetterAToD
+  letterViaView: LetterAToDViaView
 }
 
 """A connection to a list of \`LetterDescription\` values."""
@@ -300,6 +330,8 @@ enum LetterDescriptionsOrderBy {
   ID_DESC
   LETTER_ASC
   LETTER_DESC
+  LETTER_VIA_VIEW_ASC
+  LETTER_VIA_VIEW_DESC
   NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
@@ -363,6 +395,14 @@ type Mutation {
     input: DeleteLetterDescriptionByLetterInput!
   ): DeleteLetterDescriptionPayload
 
+  """Deletes a single \`LetterDescription\` using a unique key."""
+  deleteLetterDescriptionByLetterViaView(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLetterDescriptionByLetterViaViewInput!
+  ): DeleteLetterDescriptionPayload
+
   """Deletes a single \`ReferencingTable\` using its globally unique id."""
   deleteReferencingTable(
     """
@@ -409,6 +449,14 @@ type Mutation {
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
     input: UpdateLetterDescriptionByLetterInput!
+  ): UpdateLetterDescriptionPayload
+
+  """Updates a single \`LetterDescription\` using a unique key and a patch."""
+  updateLetterDescriptionByLetterViaView(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLetterDescriptionByLetterViaViewInput!
   ): UpdateLetterDescriptionPayload
 
   """
@@ -522,6 +570,7 @@ type Query implements Node {
   ): LetterDescription
   letterDescriptionById(id: Int!): LetterDescription
   letterDescriptionByLetter(letter: LetterAToD!): LetterDescription
+  letterDescriptionByLetterViaView(letterViaView: LetterAToDViaView!): LetterDescription
 
   """Fetches an object given its globally unique \`ID\`."""
   node(
@@ -694,6 +743,21 @@ input UpdateLetterDescriptionByLetterInput {
   An object where the defined keys will be set on the \`LetterDescription\` being updated.
   """
   letterDescriptionPatch: LetterDescriptionPatch!
+}
+
+"""All input for the \`updateLetterDescriptionByLetterViaView\` mutation."""
+input UpdateLetterDescriptionByLetterViaViewInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the \`LetterDescription\` being updated.
+  """
+  letterDescriptionPatch: LetterDescriptionPatch!
+  letterViaView: LetterAToDViaView!
 }
 
 """All input for the \`updateLetterDescription\` mutation."""

--- a/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-data.sql
@@ -276,11 +276,11 @@ insert into named_query_builder.toy_categories(toy_id, category_id, approved) va
 
 --------------------------------------------------------------------------------
 alter sequence enum_tables.letter_descriptions_id_seq restart with 101;
-insert into enum_tables.letter_descriptions(letter, description) values
-  ('A', 'The first letter in the alphabet'),
-  ('B', 'Following closely behind the first letter, this is a popular choice'),
-  ('C', 'Pronounced like ''sea'''),
-  ('D', 'The first letter omitted from the ''ABC'' phrase');
+insert into enum_tables.letter_descriptions(letter, letter_via_view, description) values
+  ('A', 'A', 'The first letter in the alphabet'),
+  ('B', 'B', 'Following closely behind the first letter, this is a popular choice'),
+  ('C', 'C', 'Pronounced like ''sea'''),
+  ('D', 'D', 'The first letter omitted from the ''ABC'' phrase');
 
 alter sequence enum_tables.referencing_table_id_seq restart with 432;
 insert into enum_tables.referencing_table(enum_1, enum_2, enum_3) values

--- a/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
+++ b/packages/postgraphile-core/__tests__/kitchen-sink-schema.sql
@@ -1143,11 +1143,17 @@ create table enum_tables.abcd (letter text primary key, description text);
 comment on column enum_tables.abcd.description is E'@enumDescription';
 comment on table enum_tables.abcd is E'@enum\n@enumName LetterAToD';
 
+create view enum_tables.abcd_view as (select * from enum_tables.abcd);
+comment on view enum_tables.abcd_view is E'@primaryKey letter\n@enum\n@enumName LetterAToDViaView';
+
 create table enum_tables.letter_descriptions(
   id serial primary key,
   letter text not null references enum_tables.abcd unique,
+  letter_via_view text not null unique,
   description text
 );
+
+comment on table enum_tables.letter_descriptions is '@foreignKey (letter_via_view) references enum_tables.abcd_view';
 
 create table enum_tables.lots_of_enums (
   id serial primary key,


### PR DESCRIPTION
## Description

Adds support for `@enum` on views as well as tables. Required re-organizing of the logic, and previously we were relying on the fact that constraints aren't introspected except in the public schemas, but since views don't have constraints we've had to explicitly opt non-public tables out of enums (this should not cause any issues).

Fixes https://github.com/graphile/postgraphile/issues/1424.

## Performance impact

Negligible.

## Security impact

None known.
