### PR TITLE
Allow more specific `TArgs` types

### DIFF
--- a/packages/graphile-utils/src/makeWrapResolversPlugin.ts
+++ b/packages/graphile-utils/src/makeWrapResolversPlugin.ts
@@ -143,7 +143,7 @@ export default function makeWrapResolversPlugin<T>(
       if (!resolveWrapperOrSpec) {
         return field;
       }
-      const resolveWrapper: ResolverWrapperFn<unknown, unknown> | undefined =
+      const resolveWrapper: ResolverWrapperFn | undefined =
         typeof resolveWrapperOrSpec === "function"
           ? resolveWrapperOrSpec
           : resolveWrapperOrSpec.resolve;

--- a/packages/graphile-utils/src/makeWrapResolversPlugin.ts
+++ b/packages/graphile-utils/src/makeWrapResolversPlugin.ts
@@ -27,19 +27,33 @@ interface ResolverWrapperRequirements {
   siblingColumns?: Array<{ column: string; alias: string }>;
 }
 
-interface ResolverWrapperRule {
+interface ResolverWrapperRule<
+  TSource extends unknown = any,
+  TContext extends unknown = any,
+  TArgs extends unknown = { [argName: string]: any }
+> {
   requires?: ResolverWrapperRequirements;
-  resolve?: ResolverWrapperFn;
+  resolve?: ResolverWrapperFn<TSource, TContext, TArgs>;
   // subscribe?: ResolverWrapperFn;
 }
 
-interface ResolverWrapperRules {
+interface ResolverWrapperRules<
+  TSource extends unknown = any,
+  TContext extends unknown = any,
+  TArgs extends unknown = { [argName: string]: any }
+> {
   [typeName: string]: {
-    [fieldName: string]: ResolverWrapperRule | ResolverWrapperFn;
+    [fieldName: string]:
+      | ResolverWrapperRule<TSource, TContext, TArgs>
+      | ResolverWrapperFn<TSource, TContext, TArgs>;
   };
 }
 
-type ResolverWrapperRulesGenerator = (options: Options) => ResolverWrapperRules;
+type ResolverWrapperRulesGenerator<
+  TSource extends unknown = any,
+  TContext extends unknown = any,
+  TArgs extends unknown = { [argName: string]: any }
+> = (options: Options) => ResolverWrapperRules<TSource, TContext, TArgs>;
 
 type ResolverWrapperFilter<T> = (
   context: Context<GraphQLObjectType>,
@@ -48,21 +62,44 @@ type ResolverWrapperFilter<T> = (
   options: Options
 ) => T | null;
 
-type ResolverWrapperFilterRule<T> = (
+type ResolverWrapperFilterRule<
+  T,
+  TSource extends unknown = any,
+  TContext extends unknown = any,
+  TArgs extends unknown = { [argName: string]: any }
+> = (
   match: T
-) => ResolverWrapperRule | ResolverWrapperFn;
+) =>
+  | ResolverWrapperRule<TSource, TContext, TArgs>
+  | ResolverWrapperFn<TSource, TContext, TArgs>;
 
-export default function makeWrapResolversPlugin(
-  rulesOrGenerator: ResolverWrapperRules | ResolverWrapperRulesGenerator
+export default function makeWrapResolversPlugin<
+  TSource extends unknown = any,
+  TContext extends unknown = any,
+  TArgs extends unknown = { [argName: string]: any }
+>(
+  rulesOrGenerator:
+    | ResolverWrapperRules<TSource, TContext, TArgs>
+    | ResolverWrapperRulesGenerator<TSource, TContext, TArgs>
 ): Plugin;
-export default function makeWrapResolversPlugin<T>(
+export default function makeWrapResolversPlugin<
+  T,
+  TSource extends unknown = any,
+  TContext extends unknown = any,
+  TArgs extends unknown = { [argName: string]: any }
+>(
   filter: ResolverWrapperFilter<T>,
-  rule: ResolverWrapperFilterRule<T>
+  rule: ResolverWrapperFilterRule<T, TSource, TContext, TArgs>
 ): Plugin;
-export default function makeWrapResolversPlugin<T>(
+export default function makeWrapResolversPlugin<
+  T,
+  TSource extends unknown = any,
+  TContext extends unknown = any,
+  TArgs extends unknown = { [argName: string]: any }
+>(
   rulesOrGeneratorOrFilter:
-    | ResolverWrapperRules
-    | ResolverWrapperRulesGenerator
+    | ResolverWrapperRules<TSource, TContext, TArgs>
+    | ResolverWrapperRulesGenerator<TSource, TContext, TArgs>
     | ResolverWrapperFilter<T>,
   rule?: ResolverWrapperFilterRule<T>
 ): Plugin {


### PR DESCRIPTION
## Description

Allow types more specific than `{ [argName: string]: any }` to be
passed into `makeWrapResolversPlugin`. We now set `TSource`, `TContext`
and `TArgs` as type parameters to `makeWrapResolversPlugin` which
means we can optionally pass in types more narrow than the defaults.

This _should_ be a backwards compatible change since we set the type
defaults to be the same as in `ResolverWrapperFn`. Fixes #708.

## Performance impact

Should be zero.
<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

Should be zero.
<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
