### PR TITLE
chore(deps): drop unused graphql-iso-date

### DIFF
--- a/packages/graphile-build-pg/package.json
+++ b/packages/graphile-build-pg/package.json
@@ -41,7 +41,6 @@
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
     "graphile-build": "4.11.0",
-    "graphql-iso-date": "^3.6.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": ">=4 <5",
     "lru-cache": ">=4 <5",


### PR DESCRIPTION
[Discord discussion](https://discord.com/channels/489127045289476126/498852330754801666/805478066133925888)

## Description
The motivation behind this one-liner PR mostly boils down to cleaning up what appears to be a spurious warning when running `npm i --no-package-lock` in projects consuming graphile-engine/PostGraphile. 
Apologies if I'm wrong in my hypothesis - I `ack`ed through the repos for both graphile-engine as well as PostGraphile, looking for any instances of `require()` or `import` for this module and found no actual usages (only inside `yarn.lock`).

I happily defer to those smarter than me on this topic -- it would seem `graphql-iso-date` is going unused these days. 
The module itself appears to be unmaintained since late 2018; the README [steers](https://github.com/excitement-engineer/graphql-iso-date#graphql-iso-date) users towards [graphql-scalars](https://github.com/Urigo/graphql-scalars).

Also it sounds like PostGraphile may [already have this functionality](https://discord.com/channels/489127045289476126/498852330754801666/805478066133925888) anyway?

Here's the [previous PR](https://github.com/graphile/graphile-engine/pull/349) that touched this.

```
$ npm i --no-package-lock
npm WARN graphql-iso-date@3.6.1 requires a peer of graphql@^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 but none is installed. You must install peer dependencies yourself.

added 176 packages from 205 contributors and audited 178 packages in 6.233s
```

## Performance impact
I would imagine that running `npm install` and possibly other things (e.g. app init) might be a tiny bit faster.

## Security impact
This dependency doesn't appear to be getting used anyway, so it should be immaterial, AFAICT.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.

(Since this PR is a chore, the items under here seem irrelevant, but can expound more as desired)

- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.