### PR TITLE
feat(pg): connections can use named queries

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js
@@ -39,14 +39,11 @@ export default (function PgConnectionTotalCount(builder) {
             ({ addDataGenerator }) => {
               addDataGenerator(() => {
                 return {
-                  pgNamedQuery: {
-                    name: "aggregates",
-                    query: aggregateQueryBuilder => {
-                      aggregateQueryBuilder.select(
-                        sql.fragment`count(1)`,
-                        "totalCount"
-                      );
-                    },
+                  pgAggregateQuery: aggregateQueryBuilder => {
+                    aggregateQueryBuilder.select(
+                      sql.fragment`count(1)`,
+                      "totalCount"
+                    );
                   },
                 };
               });

--- a/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionTotalCount.js
@@ -39,11 +39,14 @@ export default (function PgConnectionTotalCount(builder) {
             ({ addDataGenerator }) => {
               addDataGenerator(() => {
                 return {
-                  pgAggregateQuery: aggregateQueryBuilder => {
-                    aggregateQueryBuilder.select(
-                      sql.fragment`count(1)`,
-                      "totalCount"
-                    );
+                  pgNamedQuery: {
+                    name: "aggregates",
+                    query: aggregateQueryBuilder => {
+                      aggregateQueryBuilder.select(
+                        sql.fragment`count(1)`,
+                        "totalCount"
+                      );
+                    },
                   },
                 };
               });

--- a/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
+++ b/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
@@ -58,9 +58,8 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
     calculateHasPreviousPage,
     usesCursor: explicitlyUsesCursor,
   } = resolveData;
-  // Convert pgAggregateQuery to pgNamedQueryContainer/pgNamedQuery combo
-  if (pgAggregateQuery && pgAggregateQuery.length) {
-    // Push a query container
+  // Push a query container for aggregates
+  if ((pgAggregateQuery && pgAggregateQuery.length) || pgNamedQuery.length) {
     pgNamedQueryContainer.push({
       name: "aggregates",
       query: ({ queryBuilder, options, innerQueryBuilder }) => sql.fragment`\
@@ -70,7 +69,9 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
   where ${queryBuilder.buildWhereClause(false, false, options)}
 )`,
     });
-
+  }
+  // Convert pgAggregateQuery to pgNamedQueryContainer/pgNamedQuery combo
+  if (pgAggregateQuery && pgAggregateQuery.length) {
     // And a query for each previous query
     pgAggregateQuery.forEach(query => {
       pgNamedQuery.push({ name: "aggregates", query });

--- a/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
+++ b/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
@@ -49,7 +49,7 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
 ) => {
   const {
     pgQuery,
-    pgAggregateQuery, // Deprecated, use pgNamedQuery with the `aggregates` key instead
+    pgAggregateQuery, // Shorthand for using pgNamedQueryContainer/pgNamedQuery combo
     pgNamedQueryContainer = [],
     pgNamedQuery = [],
     pgCursorPrefix: reallyRawCursorPrefix,
@@ -58,7 +58,7 @@ export default (queryBuilderOptions: QueryBuilderOptions = {}) => (
     calculateHasPreviousPage,
     usesCursor: explicitlyUsesCursor,
   } = resolveData;
-  // Convert pgAggregateQuery to pgNamedQuery
+  // Convert pgAggregateQuery to pgNamedQueryContainer/pgNamedQuery combo
   if (pgAggregateQuery && pgAggregateQuery.length) {
     // Push a query container
     pgNamedQueryContainer.push({


### PR DESCRIPTION
## Description

Under a GraphQL Connection you may want to add different queries that share the same conditions but somehow differ (for example aggregates). The previous implementation only allowed one aggregate query which prevented adding GROUP BY or similar clauses to the query structure.

## Performance impact

Negligible impact in itself, but plugins that leverage it could incur significant performance costs due to adding entirely new subqueries.

## Security impact

Great care must be taken over the naming of the queries to prevent clashing with builtins. Using safeAlias will generally work so long as you can guarantee it's keyed off of something unique (such as the field alias in GraphQL).
