### PR TITLE
feat: export pgSmartTagRulesFromJSON

### DIFF
--- a/packages/graphile-utils/src/makePgSmartTagsPlugin.ts
+++ b/packages/graphile-utils/src/makePgSmartTagsPlugin.ts
@@ -240,7 +240,7 @@ export type JSONPgSmartTags = {
   };
 };
 
-function pgSmartTagRulesFromJSON(
+export function pgSmartTagRulesFromJSON(
   json: JSONPgSmartTags | null
 ): PgSmartTagRule[] {
   if (!json) {


### PR DESCRIPTION

## Description

We're building out a JSON schema -> Smart Tags File utility. We want to verify that the Smart Tags File fully compiles so we make a call to makeJSONPgSmartTagsPlugin. If that call fails, we want to throw the exception and stop building the Smart Tags File. Currently, there are just warning messages.

Exporting the pgSmartTagRulesFromJSON function gives the ability to do this.

## Performance impact

There should be no impact on performance.

## Security impact

unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [X] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
