### PR TITLE
feat(pg): use table enums in functions via domain

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -30,6 +30,7 @@ export default (function PgTypesPlugin(
     build => {
       const {
         pgIntrospectionResultsByKind: introspectionResultsByKind,
+        pgMakeFakeEnumIdentifier,
         getTypeByName,
         pgSql: sql,
         inflection,
@@ -1009,7 +1010,10 @@ end`;
               ? type.name.replace("_enum_domain", "")
               : type.tags.enum;
 
-            const baseTypeId = `FAKE_ENUM_${type.namespaceName}_${underlyingEnumTypeName}`;
+            const baseTypeId = pgMakeFakeEnumIdentifier(
+              type.namespaceName,
+              underlyingEnumTypeName
+            );
 
             const baseType = getGqlTypeByTypeIdAndModifier(
               baseTypeId,


### PR DESCRIPTION
This is still a draft, still figuring out how to run and use the tests, but this is working via local testing.

Your domain needs to be named either `my_enum_table_name_enum_domain` or you need a smart comment saying `@enum my_enum_table_name`.

If your enum table is on a unique constraint, this will work all the same, it just needs to be `my_enum_table_constraint_name_enum_domain` or `@enum my_enum_table_constraint_name`.

## Description

See https://github.com/graphile/postgraphile/issues/1500.

## Performance impact

Negligible, a single if statement. 

## Security impact

Unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes. (TODO)
- [ ] I have detailed the new feature in the relevant documentation. (TODO)
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists). (TODO)
- [ ] If this is a breaking change I've explained why.
