### PR TITLE
feat(graphile-utils): for makeChangeNullabilityPlugin, able to define array nullability, and Mutations and Queries args

### DIFF
--- a/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
+++ b/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
@@ -26,7 +26,7 @@ interface ChangeNullabilityRules {
 }
 
 export default function makeChangeNullabilityPlugin(
-    rules: ChangeNullabilityRules
+  rules: ChangeNullabilityRules
 ): Plugin {
   return (builder: SchemaBuilder, _options: Options) => {
     function applyNullability<Type extends GraphQLType | GraphQLInputType>(type: Type, allNullabilities: boolean[]): Type {

--- a/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
+++ b/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
@@ -1,30 +1,61 @@
 import type {
-  SchemaBuilder,
   Build,
   Context,
-  Plugin,
   Options,
+  Plugin,
+  SchemaBuilder,
 } from "graphile-build";
-import type { GraphQLInputFieldConfig, GraphQLFieldConfig } from "graphql";
+import {
+  GraphQLFieldConfig,
+  GraphQLInputFieldConfig,
+  GraphQLInputType,
+  GraphQLNonNull,  GraphQLType } from "graphql";
+import { GraphQLList } from "graphql/type/definition";
+
+interface NullabilityOpts {
+  type?: boolean | boolean[]
+  args?: {
+    [argName: string]: boolean | boolean[]
+  }
+}
 
 interface ChangeNullabilityRules {
   [typeName: string]: {
-    [fieldName: string]: boolean;
-  };
+    [fieldName: string]: boolean | boolean[] | NullabilityOpts
+  },
 }
 
 export default function makeChangeNullabilityPlugin(
-  rules: ChangeNullabilityRules
+    rules: ChangeNullabilityRules
 ): Plugin {
   return (builder: SchemaBuilder, _options: Options) => {
+    function applyNullability<Type extends GraphQLType | GraphQLInputType>(type: Type, allNullabilities: boolean[]): Type {
+      const [nullability, ...rest] = allNullabilities;
+      const nullableType = type instanceof GraphQLNonNull ? type.ofType : type;
+      let inner = null;
+      if (nullableType instanceof GraphQLList) {
+        inner = new GraphQLList(applyNullability(nullableType.ofType, rest))
+      } else {
+        if (rest.length > 0) {
+          throw new Error(`Too many booleans passed`)
+        }
+        inner = nullableType
+      }
+      return nullability ? inner : (inner === type ? new GraphQLNonNull(inner) : type) // Optimisation if it's already non-null*/;
+    }
+    function applyTypeNullability<Type extends GraphQLType | GraphQLInputType>(type: Type, shouldBeNullable: boolean | boolean[]): Type {
+      const allNullabilities: boolean[] = shouldBeNullable instanceof Array ? shouldBeNullable : [shouldBeNullable]
+      return allNullabilities.length > 0 ? applyNullability(type, allNullabilities) : type
+    }
     function changeNullability<
-      Field extends GraphQLInputFieldConfig | GraphQLFieldConfig<any, any>
-    >(field: Field, build: Build, context: Context<Field>): typeof field {
+        Field extends GraphQLInputFieldConfig | GraphQLFieldConfig<any, any>
+        >(field: Field, build: Build, context: Context<Field>): typeof field {
       const {
         Self,
         scope: { fieldName },
       } = context;
-      const typeRules = rules[Self.name];
+      const typeName = Self.name
+      const typeRules = rules[typeName];
       if (!typeRules) {
         return field;
       }
@@ -32,18 +63,29 @@ export default function makeChangeNullabilityPlugin(
       if (shouldBeNullable == null) {
         return field;
       }
-      const {
-        graphql: { getNullableType, GraphQLNonNull },
-      } = build;
-      const nullableType = getNullableType(field.type);
-      return {
-        ...field,
-        type: shouldBeNullable
-          ? nullableType
-          : nullableType === field.type
-          ? new GraphQLNonNull(field.type)
-          : field.type, // Optimisation if it's already non-null
-      };
+      const shouldApplyNullabilities: NullabilityOpts = {}
+      if (typeof shouldBeNullable === "object" && !(shouldBeNullable instanceof Array)) {
+        shouldApplyNullabilities.type = shouldBeNullable.type;
+        shouldApplyNullabilities.args = shouldBeNullable.args;
+      } else {
+        shouldApplyNullabilities.type = shouldBeNullable;
+      }
+      const updatedField = { ...field };
+      try {
+        if (shouldApplyNullabilities.type) {
+          updatedField.type = applyTypeNullability(field.type, shouldApplyNullabilities.type);
+        }
+        if (shouldApplyNullabilities.args) {
+          Object.entries(shouldApplyNullabilities.args).forEach(([argName, argShouldBeNullable]) => {
+            if (!("args" in field) || !field.args?.[argName]) return ;
+            const argType = field.args[argName].type;
+            field.args[argName].type = applyTypeNullability(argType, argShouldBeNullable)
+          })
+        }
+      } catch (err) {
+        throw new Error(`makeChangeNullabilityPlugin. For ${typeName} > ${fieldName}: ${err.message}`);
+      }
+      return updatedField;
     }
     builder.hook("GraphQLInputObjectType:fields:field", changeNullability);
     builder.hook("GraphQLObjectType:fields:field", changeNullability);

--- a/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
+++ b/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
@@ -80,20 +80,13 @@ export default function makeChangeNullabilityPlugin(
       if (shouldBeNullable == null) {
         return field;
       }
-      const shouldApplyNullabilities: NullabilityOpts = {};
-      if (
-        typeof shouldBeNullable === "object" &&
-        !Array.isArray(shouldBeNullable)
-      ) {
-        shouldApplyNullabilities.type = shouldBeNullable.type;
-        shouldApplyNullabilities.args = shouldBeNullable.args;
-      } else {
-        shouldApplyNullabilities.type = shouldBeNullable;
-      }
-      const updatedField = field;
+      const shouldApplyNullabilities: NullabilityOpts =
+        typeof shouldBeNullable === "boolean" || Array.isArray(shouldBeNullable)
+          ? { type: shouldBeNullable }
+          : shouldBeNullable;
       try {
         if (shouldApplyNullabilities.type) {
-          updatedField.type = applyTypeNullability(
+          field.type = applyTypeNullability(
             build,
             field.type,
             shouldApplyNullabilities.type
@@ -102,16 +95,16 @@ export default function makeChangeNullabilityPlugin(
         if (shouldApplyNullabilities.args) {
           Object.entries(shouldApplyNullabilities.args).forEach(
             ([argName, argShouldBeNullable]) => {
-              if (!("args" in field) || !field["args"]?.[argName]) {
+              if (!field.args || !field.args[argName]) {
                 console.warn(
                   `warning: makeChangeNullabilityPlugin. For ${typeName} > ${fieldName}: can't apply nullability rule for non-existing arg ${argName}`
                 );
                 return;
               }
-              const argType = field["args"][argName].type;
-              field["args"][argName].type = applyTypeNullability(
+              const arg = field.args[argName];
+              arg.type = applyTypeNullability(
                 build,
-                argType,
+                arg.type,
                 argShouldBeNullable
               );
             }
@@ -122,7 +115,7 @@ export default function makeChangeNullabilityPlugin(
           `makeChangeNullabilityPlugin. For ${typeName} > ${fieldName}: ${err.message}`
         );
       }
-      return updatedField;
+      return field;
     }
     builder.hook("GraphQLInputObjectType:fields:field", changeNullability);
     builder.hook("GraphQLObjectType:fields:field", changeNullability);

--- a/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
+++ b/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
@@ -9,52 +9,69 @@ import {
   GraphQLFieldConfig,
   GraphQLInputFieldConfig,
   GraphQLInputType,
-  GraphQLNonNull,  GraphQLType } from "graphql";
+  GraphQLNonNull,
+  GraphQLType,
+} from "graphql";
 import { GraphQLList } from "graphql/type/definition";
 
 interface NullabilityOpts {
-  type?: boolean | boolean[]
+  type?: boolean | boolean[];
   args?: {
-    [argName: string]: boolean | boolean[]
-  }
+    [argName: string]: boolean | boolean[];
+  };
 }
 
 interface ChangeNullabilityRules {
   [typeName: string]: {
-    [fieldName: string]: boolean | boolean[] | NullabilityOpts
-  },
+    [fieldName: string]: boolean | boolean[] | NullabilityOpts;
+  };
 }
 
 export default function makeChangeNullabilityPlugin(
   rules: ChangeNullabilityRules
 ): Plugin {
   return (builder: SchemaBuilder, _options: Options) => {
-    function applyNullability<Type extends GraphQLType | GraphQLInputType>(type: Type, allNullabilities: boolean[]): Type {
+    function applyNullability<Type extends GraphQLType | GraphQLInputType>(
+      type: Type,
+      allNullabilities: boolean[]
+    ): Type {
       const [nullability, ...rest] = allNullabilities;
       const nullableType = type instanceof GraphQLNonNull ? type.ofType : type;
       let inner = null;
       if (nullableType instanceof GraphQLList) {
-        inner = new GraphQLList(applyNullability(nullableType.ofType, rest))
+        inner = new GraphQLList(applyNullability(nullableType.ofType, rest));
       } else {
         if (rest.length > 0) {
-          throw new Error(`Too many booleans passed`)
+          throw new Error(`Too many booleans passed`);
         }
-        inner = nullableType
+        inner = nullableType;
       }
-      return nullability ? inner : (inner === type ? new GraphQLNonNull(inner) : type) // Optimisation if it's already non-null*/;
+      return nullability
+        ? inner
+        : inner === type
+        ? new GraphQLNonNull(inner)
+        : type; // Optimisation if it's already non-null*/;
     }
-    function applyTypeNullability<Type extends GraphQLType | GraphQLInputType>(type: Type, shouldBeNullable: boolean | boolean[]): Type {
-      const allNullabilities: boolean[] = shouldBeNullable instanceof Array ? shouldBeNullable : [shouldBeNullable]
-      return allNullabilities.length > 0 ? applyNullability(type, allNullabilities) : type
+    function applyTypeNullability<Type extends GraphQLType | GraphQLInputType>(
+      type: Type,
+      shouldBeNullable: boolean | boolean[]
+    ): Type {
+      const allNullabilities: boolean[] =
+        shouldBeNullable instanceof Array
+          ? shouldBeNullable
+          : [shouldBeNullable];
+      return allNullabilities.length > 0
+        ? applyNullability(type, allNullabilities)
+        : type;
     }
     function changeNullability<
-        Field extends GraphQLInputFieldConfig | GraphQLFieldConfig<any, any>
-        >(field: Field, build: Build, context: Context<Field>): typeof field {
+      Field extends GraphQLInputFieldConfig | GraphQLFieldConfig<any, any>
+    >(field: Field, build: Build, context: Context<Field>): typeof field {
       const {
         Self,
         scope: { fieldName },
       } = context;
-      const typeName = Self.name
+      const typeName = Self.name;
       const typeRules = rules[typeName];
       if (!typeRules) {
         return field;
@@ -63,8 +80,11 @@ export default function makeChangeNullabilityPlugin(
       if (shouldBeNullable == null) {
         return field;
       }
-      const shouldApplyNullabilities: NullabilityOpts = {}
-      if (typeof shouldBeNullable === "object" && !(shouldBeNullable instanceof Array)) {
+      const shouldApplyNullabilities: NullabilityOpts = {};
+      if (
+        typeof shouldBeNullable === "object" &&
+        !(shouldBeNullable instanceof Array)
+      ) {
         shouldApplyNullabilities.type = shouldBeNullable.type;
         shouldApplyNullabilities.args = shouldBeNullable.args;
       } else {
@@ -73,17 +93,27 @@ export default function makeChangeNullabilityPlugin(
       const updatedField = { ...field };
       try {
         if (shouldApplyNullabilities.type) {
-          updatedField.type = applyTypeNullability(field.type, shouldApplyNullabilities.type);
+          updatedField.type = applyTypeNullability(
+            field.type,
+            shouldApplyNullabilities.type
+          );
         }
         if (shouldApplyNullabilities.args) {
-          Object.entries(shouldApplyNullabilities.args).forEach(([argName, argShouldBeNullable]) => {
-            if (!("args" in field) || !field.args?.[argName]) return ;
-            const argType = field.args[argName].type;
-            field.args[argName].type = applyTypeNullability(argType, argShouldBeNullable)
-          })
+          Object.entries(shouldApplyNullabilities.args).forEach(
+            ([argName, argShouldBeNullable]) => {
+              if (!("args" in field) || !field.args?.[argName]) return;
+              const argType = field.args[argName].type;
+              field.args[argName].type = applyTypeNullability(
+                argType,
+                argShouldBeNullable
+              );
+            }
+          );
         }
       } catch (err) {
-        throw new Error(`makeChangeNullabilityPlugin. For ${typeName} > ${fieldName}: ${err.message}`);
+        throw new Error(
+          `makeChangeNullabilityPlugin. For ${typeName} > ${fieldName}: ${err.message}`
+        );
       }
       return updatedField;
     }

--- a/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
+++ b/packages/graphile-utils/src/makeChangeNullabilityPlugin.ts
@@ -57,7 +57,7 @@ export default function makeChangeNullabilityPlugin(
       shouldBeNullable: boolean | boolean[]
     ): any {
       const allNullabilities: boolean[] =
-        shouldBeNullable instanceof Array
+        Array.isArray(shouldBeNullable)
           ? shouldBeNullable
           : [shouldBeNullable];
       return allNullabilities.length > 0


### PR DESCRIPTION
## Description

In the **makeChangeNullabilityPlugin**
Allow to use define nullability for Arrays.
Allow manipulation of Queries and Mutation arguments

## Performance impact

unknown

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

unknown

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
