### PR TITLE
feat(inflection): use builtin for NATURAL and PRIMARY_KEY_ASC/DESC

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -31,7 +31,7 @@ export default (function PgConnectionArgOrderBy(builder, { orderByNullsLast }) {
               "type"
             ),
             values: {
-              [inflection.builtin('NATURAL')]: {
+              [inflection.builtin("NATURAL")]: {
                 value: {
                   alias: null,
                   specs: [],

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -31,7 +31,7 @@ export default (function PgConnectionArgOrderBy(builder, { orderByNullsLast }) {
               "type"
             ),
             values: {
-              NATURAL: {
+              [inflection.builtin('NATURAL')]: {
                 value: {
                   alias: null,
                   specs: [],

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
@@ -37,7 +37,8 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
 
       const primaryKeyAsc = inflection.builtin("PRIMARY_KEY_ASC");
       const defaultValueEnum =
-        TableOrderByType.getValues().find(v => v.name === primaryKeyAsc) || TableOrderByType.getValues()[0];
+        TableOrderByType.getValues().find(v => v.name === primaryKeyAsc) ||
+        TableOrderByType.getValues()[0];
 
       return extend(args, {
         orderBy: extend(

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
@@ -36,7 +36,7 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
       }
 
       const defaultValueEnum =
-        TableOrderByType.getValues().find(v => v.name === "PRIMARY_KEY_ASC") ||
+        TableOrderByType.getValues().find(v => v.name === inflection.builtin('PRIMARY_KEY_ASC')) ||
         TableOrderByType.getValues()[0];
 
       return extend(args, {

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
@@ -35,10 +35,9 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
         return args;
       }
 
+      const primaryKeyAsc = inflection.builtin("PRIMARY_KEY_ASC");
       const defaultValueEnum =
-        TableOrderByType.getValues().find(
-          v => v.name === inflection.builtin("PRIMARY_KEY_ASC")
-        ) || TableOrderByType.getValues()[0];
+        TableOrderByType.getValues().find(v => v.name === primaryKeyAsc) || TableOrderByType.getValues()[0];
 
       return extend(args, {
         orderBy: extend(

--- a/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
+++ b/packages/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValue.js
@@ -36,8 +36,9 @@ export default (function PgConnectionArgOrderByDefaultValue(builder) {
       }
 
       const defaultValueEnum =
-        TableOrderByType.getValues().find(v => v.name === inflection.builtin('PRIMARY_KEY_ASC')) ||
-        TableOrderByType.getValues()[0];
+        TableOrderByType.getValues().find(
+          v => v.name === inflection.builtin("PRIMARY_KEY_ASC")
+        ) || TableOrderByType.getValues()[0];
 
       return extend(args, {
         orderBy: extend(

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -70,7 +70,7 @@ export default (function PgMutationPayloadEdgePlugin(
       const fieldName = inflection.edgeField(table);
       const defaultValueEnum =
         canOrderBy &&
-        (TableOrderByType.getValues().find(v => v.name === "PRIMARY_KEY_ASC") ||
+        (TableOrderByType.getValues().find(v => v.name === inflection.builtin('PRIMARY_KEY_ASC')) ||
           TableOrderByType.getValues()[0]);
       return extend(
         fields,

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -71,9 +71,7 @@ export default (function PgMutationPayloadEdgePlugin(
       const primaryKeyAsc = inflection.builtin("PRIMARY_KEY_ASC");
       const defaultValueEnum =
         canOrderBy &&
-        (TableOrderByType.getValues().find(
-          v => v.name === primaryKeyAsc
-        ) ||
+        (TableOrderByType.getValues().find(v => v.name === primaryKeyAsc) ||
           TableOrderByType.getValues()[0]);
       return extend(
         fields,

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -68,10 +68,11 @@ export default (function PgMutationPayloadEdgePlugin(
       const canOrderBy = !omit(table, "order");
 
       const fieldName = inflection.edgeField(table);
+      const primaryKeyAsc = inflection.builtin("PRIMARY_KEY_ASC");
       const defaultValueEnum =
         canOrderBy &&
         (TableOrderByType.getValues().find(
-          v => v.name === inflection.builtin("PRIMARY_KEY_ASC")
+          v => v.name === primaryKeyAsc
         ) ||
           TableOrderByType.getValues()[0]);
       return extend(

--- a/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.js
@@ -70,7 +70,9 @@ export default (function PgMutationPayloadEdgePlugin(
       const fieldName = inflection.edgeField(table);
       const defaultValueEnum =
         canOrderBy &&
-        (TableOrderByType.getValues().find(v => v.name === inflection.builtin('PRIMARY_KEY_ASC')) ||
+        (TableOrderByType.getValues().find(
+          v => v.name === inflection.builtin("PRIMARY_KEY_ASC")
+        ) ||
           TableOrderByType.getValues()[0]);
       return extend(
         fields,

--- a/packages/graphile-build-pg/src/plugins/PgOrderByPrimaryKeyPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgOrderByPrimaryKeyPlugin.js
@@ -5,7 +5,7 @@ export default (function PgOrderByPrimaryKeyPlugin(builder) {
   builder.hook(
     "GraphQLEnumType:values",
     (values, build, context) => {
-      const { extend } = build;
+      const { extend, inflection } = build;
       const {
         scope: { isPgRowSortEnum, pgIntrospection: table },
       } = context;
@@ -22,14 +22,14 @@ export default (function PgOrderByPrimaryKeyPlugin(builder) {
       return extend(
         values,
         {
-          PRIMARY_KEY_ASC: {
+          [inflection.builtin('PRIMARY_KEY_ASC')]: {
             value: {
               alias: "primary_key_asc",
               specs: primaryKeys.map(key => [key.name, true]),
               unique: true,
             },
           },
-          PRIMARY_KEY_DESC: {
+          [inflection.builtin('PRIMARY_KEY_DESC')]: {
             value: {
               alias: "primary_key_desc",
               specs: primaryKeys.map(key => [key.name, false]),

--- a/packages/graphile-build-pg/src/plugins/PgOrderByPrimaryKeyPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgOrderByPrimaryKeyPlugin.js
@@ -22,14 +22,14 @@ export default (function PgOrderByPrimaryKeyPlugin(builder) {
       return extend(
         values,
         {
-          [inflection.builtin('PRIMARY_KEY_ASC')]: {
+          [inflection.builtin("PRIMARY_KEY_ASC")]: {
             value: {
               alias: "primary_key_asc",
               specs: primaryKeys.map(key => [key.name, true]),
               unique: true,
             },
           },
-          [inflection.builtin('PRIMARY_KEY_DESC')]: {
+          [inflection.builtin("PRIMARY_KEY_DESC")]: {
             value: {
               alias: "primary_key_desc",
               specs: primaryKeys.map(key => [key.name, false]),


### PR DESCRIPTION
## Description
I am trying to turn all my enums in snake_case and I couldn't get those three -`NATURAL`, `PRIMARY_KEY_ASC`, `PRIMARY_KEY_DESC`- to follow the global enum inflector. This PR wraps those with `inflection.builtin`, following @benjie advice on discord, allowing to customize them through `makeAddInflectorsPlugin`, eg. :

```js
export const NaturalCasePlugin = makeAddInflectorsPlugin((inflectors) => {
  const { enumName: oldEnumName } = inflectors
  return {
    enumName(value: string) {
      return oldEnumName.call(this, snakeCase(value))
    },
    builtin(value: string) {
      if (value === 'NATURAL') {
        return this.enumName(value)
      }
      return value
    }
  }
}
```

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->
unknown

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->
unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
