### PR TITLE
feat(tags): allow smart tags to indicate a column has a default

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgColumnsPlugin.js
@@ -255,6 +255,7 @@ end
                             attr.type.domainHasDefault) &&
                           !attr.tags.notNull) ||
                         attr.hasDefault ||
+                        attr.tags.hasDefault ||
                         attr.identity === "d",
                       pgGetGqlInputTypeByTypeIdAndModifier(
                         attr.typeId,


### PR DESCRIPTION
## Description

PostGraphile automatically determines when a table column has a default, and thus makes that field nullable on the input to a create mutation. However, when we are looking at a different source (for example a view) we cannot determine whether the column has a default or not. If you use the smart tag `@primaryKey` then we'll know that that column is not-null, but it does not indicate that it has a default, and so we think it's required. Often this is not the case (many primary keys have defaults), so in this PR we introduce the `@hasDefault` smart tag that you can use to indicate that a column (e.g. your `@primaryKey` column) has a default and thus should be exposed as nullable.

Fixes graphile/postgraphile#1544

## Performance impact

Negligible.

## Security impact

None known.
