### PR TITLE
polish: improve error message when enum creation fails

### DIFF
--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -546,7 +546,7 @@ function enumTables(introspectionResults) {
       const data = allData.filter(row => row[col.name] != null);
       if (data.length < 1) {
         throw new Error(
-          `Enum table "${klass.namespaceName}"."${klass.name}" contains no entries for enum constraint '${constraint.name}'.`
+          `Enum table "${klass.namespaceName}"."${klass.name}" contains no visible entries for enum constraint '${constraint.name}'. Check that the table contains rows and that no security policies hide them.`
         );
       }
 

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -546,7 +546,7 @@ function enumTables(introspectionResults) {
       const data = allData.filter(row => row[col.name] != null);
       if (data.length < 1) {
         throw new Error(
-          `Enum table "${klass.namespaceName}"."${klass.name}" contains no visible entries for enum constraint '${constraint.name}'. Check that the table contains rows and that no security policies hide them.`
+          `Enum table "${klass.namespaceName}"."${klass.name}" contains no visible entries for enum constraint '${constraint.name}'. Check that the table contains at least one row and that the rows are not hidden by row-level security policies.`
         );
       }
 


### PR DESCRIPTION
Let me know if you think this could be better rephrased.

## Description

Improve error message when creating an enum fails, to explain that it could be caused by a security policy that hides the rows.

## Performance impact

None, just rephrasing an error message.

## Security impact

None, just rephrasing an error message.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
