### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/graphile-build-pg/src/omit.js
+++ b/packages/graphile-build-pg/src/omit.js
@@ -50,7 +50,7 @@ function parse(arrOrNot, errorPrefix = "Error") {
       }
       if (str[0] === ":") {
         const perms = str
-          .substr(1)
+          .slice(1)
           .split("")
           .map(p => aliases[p]);
         const bad = perms.find(p => !p);

--- a/packages/graphile-build-pg/src/plugins/PgComputedColumnsPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgComputedColumnsPlugin.js
@@ -32,7 +32,7 @@ export const getComputedColumnDetails = (
     return null;
   }
 
-  const pseudoColumnName = proc.name.substr(table.name.length + 1);
+  const pseudoColumnName = proc.name.slice(table.name.length + 1);
   return { argTypes, pseudoColumnName };
 };
 

--- a/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgIntrospectionPlugin.js
@@ -245,7 +245,7 @@ const removeQuotes = str => {
         `We failed to parse a quoted identifier '${str}'. Please avoid putting quotes or commas in smart comment identifiers (or file a PR to fix the parser).`
       );
     }
-    return trimmed.substr(1, trimmed.length - 2);
+    return trimmed.slice(1, -1);
   } else {
     // PostgreSQL lower-cases unquoted columns, so we should too.
     return trimmed.toLowerCase();

--- a/packages/graphile-build-pg/src/plugins/PgRecordReturnTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgRecordReturnTypesPlugin.js
@@ -71,7 +71,7 @@ export default (function PgRecordReturnTypesPlugin(builder) {
           ? inflection.functionMutationName(proc)
           : computed
           ? inflection.computedColumn(
-              proc.name.substr(firstArgType.name.length + 1),
+              proc.name.slice(firstArgType.name.length + 1),
               proc
             )
           : inflection.functionQueryName(proc);

--- a/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
+++ b/packages/graphile-build-pg/src/plugins/PgTypesPlugin.js
@@ -687,7 +687,7 @@ export default (function PgTypesPlugin(
         map: f => {
           if (f[0] === "(" && f[f.length - 1] === ")") {
             const [x, y] = f
-              .substr(1, f.length - 2)
+              .slice(1, -1)
               .split(",")
               .map(f => parseFloat(f));
             return { x, y };
@@ -1434,7 +1434,7 @@ end`;
         map: f => {
           if (f[0] === "{" && f[f.length - 1] === "}") {
             const [A, B, C] = f
-              .substr(1, f.length - 2)
+              .slice(1, -1)
               .split(",")
               .map(f => parseFloat(f));
             // Lines have the form Ax + By + C = 0.
@@ -1484,7 +1484,7 @@ end`;
         map: f => {
           if (f[0] === "[" && f[f.length - 1] === "]") {
             const [x1, y1, x2, y2] = f
-              .substr(1, f.length - 2)
+              .slice(1, -1)
               .replace(/[()]/g, "")
               .split(",")
               .map(f => parseFloat(f));
@@ -1532,7 +1532,7 @@ end`;
         map: f => {
           if (f[0] === "(" && f[f.length - 1] === ")") {
             const [x1, y1, x2, y2] = f
-              .substr(1, f.length - 2)
+              .slice(1, -1)
               .replace(/[()]/g, "")
               .split(",")
               .map(f => parseFloat(f));
@@ -1602,7 +1602,7 @@ end`;
           }
           if (isOpen !== null) {
             const xsAndYs = f
-              .substr(1, f.length - 2)
+              .slice(1, -1)
               .replace(/[()]/g, "")
               .split(",")
               .map(f => parseFloat(f));
@@ -1655,7 +1655,7 @@ end`;
         map: f => {
           if (f[0] === "(" && f[f.length - 1] === ")") {
             const xsAndYs = f
-              .substr(1, f.length - 2)
+              .slice(1, -1)
               .replace(/[()]/g, "")
               .split(",")
               .map(f => parseFloat(f));
@@ -1701,7 +1701,7 @@ end`;
         map: f => {
           if (f[0] === "<" && f[f.length - 1] === ">") {
             const [x, y, r] = f
-              .substr(1, f.length - 2)
+              .slice(1, -1)
               .replace(/[()]/g, "")
               .split(",")
               .map(f => parseFloat(f));

--- a/packages/graphile-build-pg/src/utils.js
+++ b/packages/graphile-build-pg/src/utils.js
@@ -9,7 +9,7 @@ export const parseTags = (str: string) => {
       if (!match) {
         return { ...prev, text: curr };
       }
-      const key = match[0].substr(1).trim();
+      const key = match[0].slice(1).trim();
       const value = match[0] === curr ? true : curr.replace(match[0], "");
       return {
         ...prev,

--- a/packages/graphile-build/src/swallowError.js
+++ b/packages/graphile-build/src/swallowError.js
@@ -13,7 +13,7 @@ export default function swallowError(e: Error): void {
   } else {
     const errorSnippet =
       e && typeof e.toString === "function"
-        ? String(e).replace(/\n.*/g, "").substr(0, 320).trim()
+        ? String(e).replace(/\n.*/g, "").slice(0, 320).trim()
         : null;
     if (errorSnippet) {
       // eslint-disable-next-line no-console

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -104,7 +104,7 @@ export default function makeExtendSchemaPlugin(
   generator:
     | ExtensionDefinition
     | ((build: Build, schemaOptions: Options) => ExtensionDefinition),
-  uniqueId = String(Math.random()).substr(2)
+  uniqueId = String(Math.random()).slice(2)
 ): Plugin {
   let graphql: Build["graphql"];
   return (builder: SchemaBuilder, schemaOptions: Options): void => {

--- a/packages/lds/src/cli.ts
+++ b/packages/lds/src/cli.ts
@@ -74,10 +74,10 @@ async function main() {
       let topicJSON: string;
       let sub: boolean;
       if (message.startsWith("SUB ")) {
-        topicJSON = message.substr(4);
+        topicJSON = message.slice(4);
         sub = true;
       } else if (message.startsWith("UNSUB ")) {
-        topicJSON = message.substr(6);
+        topicJSON = message.slice(6);
         sub = false;
       } else {
         console.error("Unknown command", message);


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Performance impact

From past experience there is no performance impact due to switching to slice()

## Security impact

None as the returned values are still the same

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

