### PR TITLE
fix(pubsub): listen for PG client error to prevent crashes

### DIFF
--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -161,7 +161,7 @@ const plugin: PostGraphilePlugin = {
       let client: pg.PoolClient;
       try {
         client = await pgPool.connect();
-        client.once("error", async e => {
+        client.once("error", e => {
           // eslint-disable-next-line no-console
           console.error("Error occurred in subscriptions client; retrying...");
           // eslint-disable-next-line no-console

--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -23,6 +23,8 @@ declare module "graphile-build" {
   }
 }
 
+const noop = () => {};
+
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 const debugSubscriptions = createDebugger("postgraphile:subscriptions");
@@ -86,6 +88,7 @@ const plugin: PostGraphilePlugin = {
     };
     let listeningClient: pg.PoolClient | null;
     const cleanClient = function (client: pg.PoolClient) {
+      client.removeListener("error", noop);
       client.removeListener("notification", handleNotification);
       clearInterval(client["keepAliveInterval"]);
       delete client["keepAliveInterval"];
@@ -161,7 +164,7 @@ const plugin: PostGraphilePlugin = {
       let client: pg.PoolClient;
       try {
         client = await pgPool.connect();
-        client.on("error", () => {});
+        client.on("error", noop);
       } catch (e) {
         // Exponential back-off
         const delay = Math.floor(

--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -161,6 +161,16 @@ const plugin: PostGraphilePlugin = {
       let client: pg.PoolClient;
       try {
         client = await pgPool.connect();
+        client.once("error", async e => {
+          // eslint-disable-next-line no-console
+          console.error(`Error occurred in subscriptions client; retrying...`);
+          // eslint-disable-next-line no-console
+          console.error(e);
+          releaseClient(client);
+          if (!pgPool.ending) {
+            setupClient();
+          }
+        });
       } catch (e) {
         // Exponential back-off
         const delay = Math.floor(

--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -68,9 +68,6 @@ const plugin: PostGraphilePlugin = {
       eventEmitter,
     });
 
-    const handleError = function () {
-      // noop
-    };
     const handleNotification = function (msg: {
       channel: string;
       payload?: string;
@@ -89,7 +86,6 @@ const plugin: PostGraphilePlugin = {
     };
     let listeningClient: pg.PoolClient | null;
     const cleanClient = function (client: pg.PoolClient) {
-      client.removeListener("error", handleError);
       client.removeListener("notification", handleNotification);
       clearInterval(client["keepAliveInterval"]);
       delete client["keepAliveInterval"];
@@ -165,7 +161,7 @@ const plugin: PostGraphilePlugin = {
       let client: pg.PoolClient;
       try {
         client = await pgPool.connect();
-        client.addListener("error", handleError);
+        client.on("error", () => {});
       } catch (e) {
         // Exponential back-off
         const delay = Math.floor(

--- a/packages/pg-pubsub/src/index.ts
+++ b/packages/pg-pubsub/src/index.ts
@@ -163,7 +163,7 @@ const plugin: PostGraphilePlugin = {
         client = await pgPool.connect();
         client.once("error", async e => {
           // eslint-disable-next-line no-console
-          console.error(`Error occurred in subscriptions client; retrying...`);
+          console.error("Error occurred in subscriptions client; retrying...");
           // eslint-disable-next-line no-console
           console.error(e);
           releaseClient(client);


### PR DESCRIPTION
## Description

The pubsub client doesn't have an `error` listener, causing the running process to crash on emitted errors.

## Performance impact

None.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.