### PR TITLE
fix(pg-sql2): use loop not spread, fixes call stack size exceeded

### DIFF
--- a/packages/pg-sql2/src/index.ts
+++ b/packages/pg-sql2/src/index.ts
@@ -231,7 +231,9 @@ export function query(
       const val = values[i];
       if (Array.isArray(val)) {
         const nodes: SQLQuery = val.map(enforceValidNode);
-        items.push(...nodes);
+        for (let item of nodes) {
+          items.push(item);
+        }
       } else {
         const node: SQLNode = enforceValidNode(val);
         items.push(node);
@@ -313,7 +315,10 @@ export function join(items: Array<SQL>, rawSeparator = ""): SQLQuery {
     if (i === 0 || !separator) {
       currentItems.push(...itemsToAppend);
     } else {
-      currentItems.push(sepNode, ...itemsToAppend);
+      currentItems.push(sepNode);
+      for (let item of itemsToAppend) {
+        currentItems.push(item);
+      }
     }
   }
   return currentItems;

--- a/packages/pg-sql2/src/index.ts
+++ b/packages/pg-sql2/src/index.ts
@@ -231,7 +231,7 @@ export function query(
       const val = values[i];
       if (Array.isArray(val)) {
         const nodes: SQLQuery = val.map(enforceValidNode);
-        for (let item of nodes) {
+        for (const item of nodes) {
           items.push(item);
         }
       } else {
@@ -316,7 +316,7 @@ export function join(items: Array<SQL>, rawSeparator = ""): SQLQuery {
       currentItems.push(...itemsToAppend);
     } else {
       currentItems.push(sepNode);
-      for (let item of itemsToAppend) {
+      for (const item of itemsToAppend) {
         currentItems.push(item);
       }
     }


### PR DESCRIPTION
## Description

<!-- If this PR fixes an issue, what is the issue? -->
when PG function arg is Array, has more then 1000 items, will fail on Maximum call stack size exceeded.

