### PR TITLE
fix(pg-sql2): remove another spread

### DIFF
--- a/packages/pg-sql2/src/index.ts
+++ b/packages/pg-sql2/src/index.ts
@@ -313,7 +313,9 @@ export function join(items: Array<SQL>, rawSeparator = ""): SQLQuery {
       ? rawItem.map(enforceValidNode)
       : [enforceValidNode(rawItem)];
     if (i === 0 || !separator) {
-      currentItems.push(...itemsToAppend);
+      for (const itemToAppend of itemsToAppend) {
+        currentItems.push(itemToAppend);
+      }
     } else {
       currentItems.push(sepNode);
       for (const item of itemsToAppend) {


### PR DESCRIPTION
## Description

Follow up to #793; this removes another spread and uses a loop instead.

## Performance impact

Negligible.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
