### PR TITLE
feat(pg-pubsub): add option to immediately get a result on listen

### DIFF
--- a/packages/pg-pubsub/__tests__/__snapshots__/subs.test.ts.snap
+++ b/packages/pg-pubsub/__tests__/__snapshots__/subs.test.ts.snap
@@ -1366,7 +1366,11 @@ type Query implements Node {
 The root subscription type: contains realtime events you can subscribe to with the \`subscription\` operation.
 """
 type Subscription {
-  listen(topic: String!): ListenPayload!
+  listen(
+    """If true, this subscription will immediately yield data"""
+    immediate: Boolean = false
+    topic: String!
+  ): ListenPayload!
 }
 
 """All input for the \`updateBarById\` mutation."""

--- a/packages/pg-pubsub/__tests__/__snapshots__/subs.test.ts.snap
+++ b/packages/pg-pubsub/__tests__/__snapshots__/subs.test.ts.snap
@@ -1367,8 +1367,10 @@ The root subscription type: contains realtime events you can subscribe to with t
 """
 type Subscription {
   listen(
-    """If true, this subscription will immediately yield data"""
-    immediate: Boolean = false
+    """
+    If true, this subscription will trigger an event as soon as it initiates.
+    """
+    initialEvent: Boolean! = false
     topic: String!
   ): ListenPayload!
 }

--- a/packages/pg-pubsub/src/PgGenericSubscriptionPlugin.ts
+++ b/packages/pg-pubsub/src/PgGenericSubscriptionPlugin.ts
@@ -174,11 +174,11 @@ const PgGenericSubscriptionPlugin: Plugin = function (
               topic: {
                 type: new GraphQLNonNull(GraphQLString),
               },
-              immediate: {
+              initialEvent: {
                 defaultValue: false,
-                type: GraphQLBoolean,
+                type: new GraphQLNonNull(GraphQLBoolean),
                 description:
-                  "If true, this subscription will immediately yield data",
+                  "If true, this subscription will trigger an event as soon as it initiates.",
               },
             },
             subscribe: async (_parent, args, _context, _resolveInfo) => {
@@ -226,7 +226,7 @@ const PgGenericSubscriptionPlugin: Plugin = function (
                   }
                 });
               }
-              if (args.immediate) {
+              if (args.initialEvent) {
                 return withInitialValue(null, asyncIterator);
               } else {
                 return asyncIterator;

--- a/packages/pg-pubsub/src/PgGenericSubscriptionPlugin.ts
+++ b/packages/pg-pubsub/src/PgGenericSubscriptionPlugin.ts
@@ -1,6 +1,6 @@
 import debugFactory from "debug";
 import { Plugin } from "graphile-build";
-import { GraphQLFieldConfig } from "graphql";
+import { GraphQLBoolean, GraphQLFieldConfig } from "graphql";
 import { PubSub } from "graphql-subscriptions";
 
 const debug = debugFactory("pg-pubsub");
@@ -11,6 +11,38 @@ const nodeIdFromDbNode = (dbNode: any) => base64(JSON.stringify(dbNode));
 function isPubSub(pubsub: any): pubsub is PubSub {
   return !!pubsub;
 }
+
+const withInitialValue = <T>(
+  initialVal: T,
+  asyncIterator: AsyncIterator<T>
+): AsyncIterable<T> => {
+  return {
+    [Symbol.asyncIterator]: async function* (): AsyncIterator<T> {
+      yield initialVal;
+
+      /* TODO: when we can upgrade to Node 10.3+ we can replace the below with simply:
+      for await (const val of asyncIterator) {
+        yield val;
+      }
+      */
+      try {
+        while (true) {
+          const next = await asyncIterator.next();
+          if (next.done) {
+            return next.value;
+          } else {
+            yield next.value;
+          }
+        }
+      } finally {
+        // Terminate the previous iterator
+        if (typeof asyncIterator.return === "function") {
+          asyncIterator.return();
+        }
+      }
+    },
+  };
+};
 
 const PgGenericSubscriptionPlugin: Plugin = function (
   builder,
@@ -142,6 +174,12 @@ const PgGenericSubscriptionPlugin: Plugin = function (
               topic: {
                 type: new GraphQLNonNull(GraphQLString),
               },
+              immediate: {
+                defaultValue: false,
+                type: GraphQLBoolean,
+                description:
+                  "If true, this subscription will immediately yield data",
+              },
             },
             subscribe: async (_parent, args, _context, _resolveInfo) => {
               const { pgClient } = _context;
@@ -188,7 +226,11 @@ const PgGenericSubscriptionPlugin: Plugin = function (
                   }
                 });
               }
-              return asyncIterator;
+              if (args.immediate) {
+                return withInitialValue(null, asyncIterator);
+              } else {
+                return asyncIterator;
+              }
             },
             resolve: async (payload, _args, _context, _resolveInfo) => {
               const result = { ...payload };


### PR DESCRIPTION
## Description

Motivation:

Pretty much the same as https://github.com/graphile/graphile-engine/pull/612

```
subscription MySubscription {
  listen(topic: "user:2", immediate: true) {
    relatedNodeId
    query {
      user(id: "2") {
        email
      }
    }
  }
}
```

This allows to get a live view of the user email with id 2. Without the option to immediately trigger the query, this would depend on something triggering a `NOTIFY` first.

This is a non breaking change that adds a feature, it's off by default.

It seems like the tests only check the generated schema, so I only updated that test and didn't add a new one

Regarding documentation, should I open a PR on https://github.com/graphile/graphile.github.io before this is merged?

## Performance impact

This is optional and disabled by default, thus there is no performance impact

## Security impact

I can't think of a scenario where this impacts security

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
