### PR TITLE
chore: add graphql 16 as peer dependency for graphql-parse-resolve-info

### DIFF
--- a/packages/graphql-parse-resolve-info/package.json
+++ b/packages/graphql-parse-resolve-info/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/graphile/graphile-engine/tree/master/packages/graphql-parse-resolve-info",
   "peerDependencies": {
-    "graphql": ">=0.9 <0.14 || ^14.0.2 || ^15.4.0"
+    "graphql": ">=0.9 <0.14 || ^14.0.2 || ^15.4.0 || ^16.3.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.4",


### PR DESCRIPTION
I propose to add graphql 16 as a supported version to the peer dependency of graphql-parse-resolve-info.
I'm currently not able to use both graphql 16 and graphql-parse-resolve-info without opting for legacy peer dependencies with npm. Once I do that, it works perfectly in runtime.
