### PR TITLE
Fix add extension types

### DIFF
--- a/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
+++ b/packages/graphile-utils/__tests__/ExtendSchemaPlugin.test.js
@@ -817,6 +817,12 @@ it("supports interfaces and unions", async () => {
           c: Int!
         }
 
+        # A child type that has no explicit references
+        type D implements Named {
+          name: String!
+          d: Int!
+        }
+
         union ABC = A | B | C
         extend type Query {
           abc: [ABC!]
@@ -832,6 +838,9 @@ it("supports interfaces and unions", async () => {
         extend type B {
           nameLanguage: String
         }
+        extend type D {
+          nameLanguage: String
+        }
       `,
       resolvers: {
         Query: {
@@ -843,6 +852,7 @@ it("supports interfaces and unions", async () => {
           named: () => [
             { name: "A-one", a: 1, nameLanguage: "en" },
             { name: "B-two", b: 2, nameLanguage: "en" },
+            { name: "D-three", d: 3, nameLanguage: "en" },
           ],
         },
         ABC: {
@@ -857,6 +867,7 @@ it("supports interfaces and unions", async () => {
           __resolveType(obj) {
             if (obj.a != null) return "A";
             if (obj.b != null) return "B";
+            if (obj.d != null) return "D";
             return null;
           },
         },
@@ -893,6 +904,9 @@ it("supports interfaces and unions", async () => {
           }
           ... on B {
             b
+          }
+          ... on D {
+            d
           }
         }
       }

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
@@ -2234,6 +2234,48 @@ input ComplexInput {
 `;
 
 exports[`allows adding a simple mutation field to PG schema 1`] = `
+input RegisterUserInput {
+  name: String!
+  email: String!
+  bio: String
+}
+
+type RegisterUserPayload {
+  user: User
+}
+
+type User implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+  email: String!
+  bio: String
+  renamedComplexColumn: [Complex]
+  createdAt: Datetime!
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+"""
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+"""
+scalar Datetime
+
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -2324,14 +2366,6 @@ type Query implements Node {
     """The globally unique \`ID\` to be used in selecting a single \`User\`."""
     nodeId: ID!
   ): User
-}
-
-"""An object with a globally unique \`ID\`."""
-interface Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
 }
 
 """A connection to a list of \`Pet\` values."""
@@ -2438,30 +2472,6 @@ type UsersConnection {
   totalCount: Int!
 }
 
-type User implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: Int!
-  name: String!
-  email: String!
-  bio: String
-  renamedComplexColumn: [Complex]
-  createdAt: Datetime!
-}
-
-type Complex {
-  numberInt: Int
-  stringText: String
-}
-
-"""
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-"""
-scalar Datetime
-
 """A \`User\` edge in the connection."""
 type UsersEdge {
   """A cursor for use in pagination."""
@@ -2529,16 +2539,6 @@ type Mutation {
     """
     input: RegisterUserInput!
   ): RegisterUserPayload
-}
-
-type RegisterUserPayload {
-  user: User
-}
-
-input RegisterUserInput {
-  name: String!
-  email: String!
-  bio: String
 }
 
 `;

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin-pg.test.js.snap
@@ -2234,48 +2234,6 @@ input ComplexInput {
 `;
 
 exports[`allows adding a simple mutation field to PG schema 1`] = `
-input RegisterUserInput {
-  name: String!
-  email: String!
-  bio: String
-}
-
-type RegisterUserPayload {
-  user: User
-}
-
-type User implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: Int!
-  name: String!
-  email: String!
-  bio: String
-  renamedComplexColumn: [Complex]
-  createdAt: Datetime!
-}
-
-"""An object with a globally unique \`ID\`."""
-interface Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-}
-
-type Complex {
-  numberInt: Int
-  stringText: String
-}
-
-"""
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-"""
-scalar Datetime
-
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -2366,6 +2324,14 @@ type Query implements Node {
     """The globally unique \`ID\` to be used in selecting a single \`User\`."""
     nodeId: ID!
   ): User
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Pet\` values."""
@@ -2472,6 +2438,30 @@ type UsersConnection {
   totalCount: Int!
 }
 
+type User implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String!
+  email: String!
+  bio: String
+  renamedComplexColumn: [Complex]
+  createdAt: Datetime!
+}
+
+type Complex {
+  numberInt: Int
+  stringText: String
+}
+
+"""
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+"""
+scalar Datetime
+
 """A \`User\` edge in the connection."""
 type UsersEdge {
   """A cursor for use in pagination."""
@@ -2539,6 +2529,16 @@ type Mutation {
     """
     input: RegisterUserInput!
   ): RegisterUserPayload
+}
+
+input RegisterUserInput {
+  name: String!
+  email: String!
+  bio: String
+}
+
+type RegisterUserPayload {
+  user: User
 }
 
 `;

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -213,20 +213,6 @@ type Query {
 `;
 
 exports[`supports defining a more complex mutation 1`] = `
-input EchoInput {
-  text: String!
-  int: Int
-  float: Float!
-  intList: [Int!]
-}
-
-type EchoOutput {
-  text: String!
-  int: Int
-  float: Float!
-  intList: [Int!]
-}
-
 """The root query type which gives access points into the data universe."""
 type Query {
   """
@@ -242,6 +228,20 @@ The root mutation type which contains root level fields which mutate data.
 type Mutation {
   """Gives you back what you put in"""
   echo(input: EchoInput): EchoOutput
+}
+
+input EchoInput {
+  text: String!
+  int: Int
+  float: Float!
+  intList: [Int!]
+}
+
+type EchoOutput {
+  text: String!
+  int: Int
+  float: Float!
+  intList: [Int!]
 }
 
 `;
@@ -321,6 +321,18 @@ type Subscription {
 `;
 
 exports[`supports defining new types 1`] = `
+"""The root query type which gives access points into the data universe."""
+type Query {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """Gives you back what you put in"""
+  echo(input: EchoInput, enum: EchoCount = FOREVER): EchoOutput
+}
+
 type EchoOutput {
   text: String!
   int: Int
@@ -341,18 +353,6 @@ input EchoInput {
   float: Float!
   count: EchoCount = FOREVER
   intList: [Int!]
-}
-
-"""The root query type which gives access points into the data universe."""
-type Query {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """Gives you back what you put in"""
-  echo(input: EchoInput, enum: EchoCount = FOREVER): EchoOutput
 }
 
 `;
@@ -395,6 +395,17 @@ Object {
 `;
 
 exports[`supports interfaces and unions 1`] = `
+"""The root query type which gives access points into the data universe."""
+type Query {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+  abc: [ABC!]
+  named: [Named!]
+}
+
 interface Named {
   name: String!
   nameLanguage: String
@@ -423,17 +434,6 @@ type D implements Named {
 }
 
 union ABC = A | B | C
-
-"""The root query type which gives access points into the data universe."""
-type Query {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-  abc: [ABC!]
-  named: [Named!]
-}
 
 `;
 

--- a/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
+++ b/packages/graphile-utils/__tests__/__snapshots__/ExtendSchemaPlugin.test.js.snap
@@ -213,6 +213,20 @@ type Query {
 `;
 
 exports[`supports defining a more complex mutation 1`] = `
+input EchoInput {
+  text: String!
+  int: Int
+  float: Float!
+  intList: [Int!]
+}
+
+type EchoOutput {
+  text: String!
+  int: Int
+  float: Float!
+  intList: [Int!]
+}
+
 """The root query type which gives access points into the data universe."""
 type Query {
   """
@@ -228,20 +242,6 @@ The root mutation type which contains root level fields which mutate data.
 type Mutation {
   """Gives you back what you put in"""
   echo(input: EchoInput): EchoOutput
-}
-
-type EchoOutput {
-  text: String!
-  int: Int
-  float: Float!
-  intList: [Int!]
-}
-
-input EchoInput {
-  text: String!
-  int: Int
-  float: Float!
-  intList: [Int!]
 }
 
 `;
@@ -321,18 +321,6 @@ type Subscription {
 `;
 
 exports[`supports defining new types 1`] = `
-"""The root query type which gives access points into the data universe."""
-type Query {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """Gives you back what you put in"""
-  echo(input: EchoInput, enum: EchoCount = FOREVER): EchoOutput
-}
-
 type EchoOutput {
   text: String!
   int: Int
@@ -353,6 +341,18 @@ input EchoInput {
   float: Float!
   count: EchoCount = FOREVER
   intList: [Int!]
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """Gives you back what you put in"""
+  echo(input: EchoInput, enum: EchoCount = FOREVER): EchoOutput
 }
 
 `;
@@ -395,27 +395,14 @@ Object {
 `;
 
 exports[`supports interfaces and unions 1`] = `
-"""The root query type which gives access points into the data universe."""
-type Query {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-  abc: [ABC!]
-  named: [Named!]
+interface Named {
+  name: String!
+  nameLanguage: String
 }
-
-union ABC = A | B | C
 
 type A implements Named {
   name: String!
   a: Int!
-  nameLanguage: String
-}
-
-interface Named {
-  name: String!
   nameLanguage: String
 }
 
@@ -427,6 +414,25 @@ type B implements Named {
 
 type C {
   c: Int!
+}
+
+type D implements Named {
+  name: String!
+  d: Int!
+  nameLanguage: String
+}
+
+union ABC = A | B | C
+
+"""The root query type which gives access points into the data universe."""
+type Query {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+  abc: [ABC!]
+  named: [Named!]
 }
 
 `;
@@ -462,6 +468,12 @@ Object {
       "__typename": "B",
       "b": 2,
       "name": "B-two",
+      "nameLanguage": "en",
+    },
+    Object {
+      "__typename": "D",
+      "d": 3,
+      "name": "D-three",
       "nameLanguage": "en",
     },
   ],

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -479,6 +479,7 @@ export default function makeExtendSchemaPlugin(
     });
 
     builder.hook("GraphQLSchema", (schema, build, _context) => {
+      const { inflection } = build;
       const {
         [`ExtendSchemaPlugin_${uniqueId}_typeExtensions`]: typeExtensions,
         [`ExtendSchemaPlugin_${uniqueId}_newTypes`]: newTypeDefinitions,
@@ -497,6 +498,11 @@ export default function makeExtendSchemaPlugin(
         types: [
           ...(schema.types || []),
           ...typeExtensions.GraphQLSchema.types,
+          ...[
+            build.getTypeByName(inflection.builtin("Query")),
+            build.getTypeByName(inflection.builtin("Mutation")),
+            build.getTypeByName(inflection.builtin("Subscription")),
+          ].filter(_ => _),
           ...newTypes,
         ],
       };

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -497,12 +497,12 @@ export default function makeExtendSchemaPlugin(
         ],
         types: [
           ...(schema.types || []),
-          ...typeExtensions.GraphQLSchema.types,
           ...[
             build.getTypeByName(inflection.builtin("Query")),
             build.getTypeByName(inflection.builtin("Mutation")),
             build.getTypeByName(inflection.builtin("Subscription")),
           ].filter(_ => _),
+          ...typeExtensions.GraphQLSchema.types,
           ...newTypes,
         ],
       };

--- a/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/packages/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -44,6 +44,7 @@ import type {
   GraphQLDirective,
   InputObjectTypeExtensionNode,
   InterfaceTypeExtensionNode,
+  TypeDefinitionNode,
 } from "graphql";
 import { GraphileEmbed } from "./gql";
 
@@ -480,14 +481,24 @@ export default function makeExtendSchemaPlugin(
     builder.hook("GraphQLSchema", (schema, build, _context) => {
       const {
         [`ExtendSchemaPlugin_${uniqueId}_typeExtensions`]: typeExtensions,
+        [`ExtendSchemaPlugin_${uniqueId}_newTypes`]: newTypeDefinitions,
       } = build;
+      const newTypes = newTypeDefinitions.map(
+        ({ definition }: { definition: TypeDefinitionNode }) =>
+          build.getTypeByName(definition.name.value)
+      );
+
       return {
         ...schema,
         directives: [
           ...(schema.directives || build.graphql.specifiedDirectives || []),
           ...typeExtensions.GraphQLSchema.directives,
         ],
-        types: [...(schema.types || []), ...typeExtensions.GraphQLSchema.types],
+        types: [
+          ...(schema.types || []),
+          ...typeExtensions.GraphQLSchema.types,
+          ...newTypes,
+        ],
       };
     });
 


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

Resolves https://github.com/graphile/graphile.github.io/issues/368

This PR updates the `makeExtendSchemaPlugin` to add all new types to the schema during the `GraphQLSchema` hook so that they are available in the final schema, regardless of explicit usage. Up to this point, types were only added to the schema if they were explicitly (direct or recursively) mapped from a Query/Mutation. 

## Performance impact

Minimum - runs during the `GraphQLSchema` hook.

## Security impact

N/A

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
