### PR TITLE
Remove indcheckxmin check

### DIFF
--- a/packages/graphile-build-pg/src/plugins/introspectionQuery.js
+++ b/packages/graphile-build-pg/src/plugins/introspectionQuery.js
@@ -417,7 +417,6 @@ with
     where
       idx.indislive is not false and
       idx.indisexclusion is not true and -- exclusion index
-      idx.indcheckxmin is not true and -- always valid?
       idx.indpred is null -- no partial index predicate
     order by
       idx.indrelid, idx.indexrelid


### PR DESCRIPTION
## Description

Had a client's code fail to recognize an index due to this check. Never seen it before, but the risk of ignoring it is minimal (just means the index might not be used, which is always a risk) so we should go with the intent.

## Performance impact

Negligible.

## Security impact

Negligible; fields exposed by indexes will be exposed slightly earlier than before in some rare cases.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
