### PR TITLE
docs: fixed indentation in README code blocks

### DIFF
--- a/packages/graphql-parse-resolve-info/README.md
+++ b/packages/graphql-parse-resolve-info/README.md
@@ -73,8 +73,8 @@ Example usage:
 
 ```js
 const {
-	parseResolveInfo,
-	simplifyParsedResolveInfoFragmentWithType
+  parseResolveInfo,
+  simplifyParsedResolveInfoFragmentWithType
 } = require('graphql-parse-resolve-info');
 // or import { parseResolveInfo, simplifyParsedResolveInfoFragmentWithType } from 'graphql-parse-resolve-info';
 
@@ -87,9 +87,9 @@ new GraphQLObjectType({
       resolve(data, args, context, resolveInfo) {
         const parsedResolveInfoFragment = parseResolveInfo(resolveInfo);
         const { fields } = simplifyParsedResolveInfoFragmentWithType(
-					parsedResolveInfoFragment,
-					ComplexType
-				);
+          parsedResolveInfoFragment,
+          ComplexType
+        );
         console.dir(fields);
         ...
       }
@@ -115,8 +115,8 @@ Example usage:
 
 ```js
 const {
-	parseResolveInfo,
-	simplifyParsedResolveInfoFragmentWithType
+  parseResolveInfo,
+  simplifyParsedResolveInfoFragmentWithType
 } = require('graphql-parse-resolve-info');
 
 new GraphQLObjectType({
@@ -129,9 +129,9 @@ new GraphQLObjectType({
         const parsedResolveInfoFragment = parseResolveInfo(resolveInfo);
 
         const { fields } = simplifyParsedResolveInfoFragmentWithType(
-					parsedResolveInfoFragment,
-					ComplexType
-				);
+          parsedResolveInfoFragment,
+          ComplexType
+        );
         ...
       }
     }


### PR DESCRIPTION
## Description

Just fixing some indentation issues.

## Performance impact

None.

## Security impact

None.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
