### PR TITLE
chore: add node specifier to assert import

### DIFF
--- a/packages/graphql-parse-resolve-info/src/index.ts
+++ b/packages/graphql-parse-resolve-info/src/index.ts
@@ -1,4 +1,4 @@
-import * as assert from "assert";
+import * as assert from "node:assert";
 import {
   getNamedType,
   isCompositeType,


### PR DESCRIPTION
## Description

Hello there,
In order to use this library in some runtimes (ie cloudflare workers), I have to patch this library with an import specifier.  I believe this change could benefit other users.

Additionally, I haven't looked at the rest of the codebase, so maybe you would want to add node specifiers everywhere in one single PR ?

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
