### PR TITLE
feat(graphql-parse-resolve-info): add isResolveTree type guard

### DIFF
--- a/packages/graphql-parse-resolve-info/README.md
+++ b/packages/graphql-parse-resolve-info/README.md
@@ -372,6 +372,26 @@ single-level object containing only the fields compatible with
            ...as before...
 ```
 
+### `isResolveTree(value)`
+
+Determines whether the argument is a value of type `ResolveTree`. This is useful only to TypeScript users. It allows to differentiate between `ResolveTree` and `FieldsByTypeName` objects to pass to `simplifyParsedResolveInfoFragmentWithType `.
+
+Example:
+
+```ts
+import { isResolveTree } from "graphql-parse-resolve-info";
+
+const { parsedResolveInfoFragment, simplifiedFragment } = await graphql(
+  Schema,
+  query
+);
+
+isResolveTree(parsedResolveInfoFragment); // returns true
+isResolveTree(simplifiedFragment); // returns true
+isResolveTree(parsedResolveInfoFragment.fieldsByTypeName); // returns false
+isResolveTree(simplifiedFragment.fieldsByTypeName); // returns false
+```
+
 ## Thanks
 
 This project was originally based on https://github.com/tjmehta/graphql-parse-fields, but has evolved a lot since then.

--- a/packages/graphql-parse-resolve-info/__tests__/test.test.js
+++ b/packages/graphql-parse-resolve-info/__tests__/test.test.js
@@ -1,6 +1,7 @@
 const {
   parseResolveInfo,
   simplifyParsedResolveInfoFragmentWithType,
+  isResolveTree,
 } = require("../src");
 const {
   graphql,
@@ -275,4 +276,42 @@ test("directives", async () => {
   );
   expect(parsedResolveInfoFragment).toMatchSnapshot();
   expect(simplifiedFragment).toMatchSnapshot();
+});
+
+test("isResolveTree", async () => {
+  const variables = {
+    include: true,
+    exclude: false,
+  };
+  const { parsedResolveInfoFragment, simplifiedFragment } = await new Promise(
+    (resolve, reject) => {
+      let o;
+      graphql(
+        Schema,
+        query,
+        null,
+        {
+          test: _o => (o = _o),
+        },
+        variables
+      ).then(d => {
+        try {
+          const { errors } = d;
+          expect(errors).toBeFalsy();
+        } catch (e) {
+          return reject(e);
+        }
+        if (o) {
+          resolve(o);
+        } else {
+          reject(new Error("test not called?"));
+        }
+      }, reject);
+    }
+  );
+
+  expect(isResolveTree(parsedResolveInfoFragment)).toBe(true);
+  expect(isResolveTree(simplifiedFragment)).toBe(true);
+  expect(isResolveTree(parsedResolveInfoFragment.fieldsByTypeName)).toBe(false);
+  expect(isResolveTree(simplifiedFragment.fieldsByTypeName)).toBe(false);
 });

--- a/packages/graphql-parse-resolve-info/src/index.ts
+++ b/packages/graphql-parse-resolve-info/src/index.ts
@@ -37,6 +37,12 @@ export interface ResolveTree {
   fieldsByTypeName: FieldsByTypeName;
 }
 
+export function isResolveTree(
+  value: ResolveTree | FieldsByTypeName | null | undefined
+): value is ResolveTree {
+  return typeof value?.name === "string" && Boolean(value.fieldsByTypeName);
+}
+
 const debug = debugFactory("graphql-parse-resolve-info");
 
 const DEBUG_ENABLED = debug.enabled;


### PR DESCRIPTION
Fix #849

## Description

This PR adds a TypeScript type guard to determine whether a value is a `ResolveTree` or not.

## Performance impact

None (or minimal), it's just a two property read and boolean conditions.

## Security impact

none

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
