### PR TITLE
Fix return type of simplifyParsedResolveInfoFragmentWithType

### DIFF
--- a/packages/graphql-parse-resolve-info/src/index.ts
+++ b/packages/graphql-parse-resolve-info/src/index.ts
@@ -352,7 +352,7 @@ export function simplifyParsedResolveInfoFragmentWithType(
   type: GraphQLType
 ) {
   const { fieldsByTypeName } = parsedResolveInfoFragment;
-  const fields = {};
+  const fields: ResolveTree = {};
   const strippedType = getNamedType(type);
   if (isCompositeType(strippedType)) {
     Object.assign(fields, fieldsByTypeName[strippedType.name]);

--- a/packages/graphql-parse-resolve-info/src/index.ts
+++ b/packages/graphql-parse-resolve-info/src/index.ts
@@ -352,7 +352,7 @@ export function simplifyParsedResolveInfoFragmentWithType(
   type: GraphQLType
 ) {
   const { fieldsByTypeName } = parsedResolveInfoFragment;
-  const fields: ResolveTree = {};
+  const fields = {} as ResolveTree;
   const strippedType = getNamedType(type);
   if (isCompositeType(strippedType)) {
     Object.assign(fields, fieldsByTypeName[strippedType.name]);


### PR DESCRIPTION
## Description

Specify type as `ResolveTree` for returned `fields` in `simplifyParsedResolveInfoFragmentWithType`. Otherwise, the return type is simply `{}` which is not indexable in TS.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
